### PR TITLE
Improve handling of timezones provided to mactime

### DIFF
--- a/tools/timeline/mactime.base
+++ b/tools/timeline/mactime.base
@@ -46,7 +46,7 @@ use strict;
 my $debug = 0;
 
 # %month_to_digit = ("Jan", 1, "Feb", 2, "Mar", 3, "Apr", 4, "May", 5, "Jun", 6,
-#       "Jul", 7, "Aug", 8, "Sep", 9, "Oct", 10, "Nov", 11, "Dec", 12);
+#                    "Jul", 7, "Aug", 8, "Sep", 9, "Oct", 10, "Nov", 11, "Dec", 12);
 my %digit_to_month = (
     "01", "Jan", "02", "Feb", "03", "Mar", "04", "Apr",
     "05", "May", "06", "Jun", "07", "Jul", "08", "Aug",
@@ -60,17 +60,17 @@ my %digit_to_day = (
 sub usage {
     print <<EOF;
 mactime [-b body_file] [-p password_file] [-g group_file] [-i day|hour idx_file] [-d] [-h] [-V] [-y] [-z TIME_ZONE] [DATE]
-        -b: Specifies the body file location, else STDIN is used
-        -d: Output timeline and index file in comma delimited format
-        -h: Display a header with session information
-        -i [day | hour] file: Specifies the index file with a summary of results
-        -g: Specifies the group file location, else GIDs are used
-        -p: Specifies the password file location, else UIDs are used
-        -V: Prints the version to STDOUT
-        -y: Dates have year first (yyyy/mm/dd) instead of (mm/dd/yyyy)
-        -m: Dates have month as number instead of word (can be used with -y)
-        -z: Specify the timezone the data came from (in the local system format)
-        [DATE]: starting date (yyyy-mm-dd) or range (yyyy-mm-dd..yyyy-mm-dd)
+		-b: Specifies the body file location, else STDIN is used
+		-d: Output timeline and index file in comma delimited format
+		-h: Display a header with session information
+		-i [day | hour] file: Specifies the index file with a summary of results
+		-g: Specifies the group file location, else GIDs are used
+		-p: Specifies the password file location, else UIDs are used
+		-V: Prints the version to STDOUT
+		-y: Dates have year first (yyyy/mm/dd) instead of (mm/dd/yyyy)
+		-m: Dates have month as number instead of word (can be used with -y)
+		-z: Specify the timezone the data came from (in the local system format)
+		[DATE]: starting date (yyyy-mm-dd) or range (yyyy-mm-dd..yyyy-mm-dd)
 EOF
     exit(1);
 }


### PR DESCRIPTION
Modified mactime so as not to silently corrupt data if a bad timezone is provided.

Added an optional dependency of DateTime::Timezone to mactime, which allows us to get a list of supported timezones.  This means we can enforce only supported timezones, and print nice lists to the user.

If DateTime::Timezone is not installed, then the behavior of timezone handling is not changed.  A future commit may use heuristics to decide whether the provided timezone looks valid.
