### PR TITLE
Only register an error if neither a volume system nor a file system can be found.

### DIFF
--- a/tsk3/auto/auto.cpp
+++ b/tsk3/auto/auto.cpp
@@ -273,14 +273,13 @@ TskAuto::findFilesInVs(TSK_OFF_T a_start, TSK_VS_TYPE_ENUM a_vtype)
     TSK_VS_INFO *vs_info;
     // USE mm_walk to get the volumes
     if ((vs_info = tsk_vs_open(m_img_info, a_start, a_vtype)) == NULL) {
-        tsk_error_set_errstr2("Unable to open volume system at offset %" PRIuOFF,
-                           a_start);
-        if (registerError())
-            return 1;
-
         /* There was no volume system, but there could be a file system */
         if (findFilesInFs(a_start)) {
-            return 1;
+            /* No file system, either */
+            tsk_error_set_errstr2("Unable to open volume system or file system"
+                " at offset %" PRIuOFF, a_start);
+            if (registerError())
+                return 1;
         }
     }
     // process the volume system


### PR DESCRIPTION
TskAuto::findFilesInImg() registers an error if a volume system can't be found but a file system can be. So, e.g., processing dftt/7-undel-ntfs.dd returns an error even though it can be processed just fine.

This patch (I think!) changes the behavior so that an error is only registered if neither a volume system nor a file system can be found.
