### PR TITLE
Fix deadlock during HFS image open

### DIFF
--- a/tsk3/img/raw.c
+++ b/tsk3/img/raw.c
@@ -228,7 +228,7 @@ raw_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf, size_t len)
                 tsk_fprintf(stderr,
                     "raw_read: found in image %d relative offset: %"
                     PRIuOFF " len: %" PRIuOFF "\n", i, rel_offset,
-                    read_len);
+                    (TSK_OFF_T) read_len);
             }
 
             cnt = raw_read_segment(raw_info, i, buf, read_len, rel_offset);


### PR DESCRIPTION
hfs_open() looks for the inum of two metadata directories needed to resolve hard links.  If the file system's root directory had hard links, the previous version would deadlock in hfs_open() while searching for these metadata directories.  Now, hard link resolution is disabled until these two metadata directories are found within hfs_open().

I also simplified the code a bit by removing a static method.
