### PR TITLE
jni content stream log TskException

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/ReadContentInputStream.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ReadContentInputStream.java
@@ -100,7 +100,7 @@ public class ReadContentInputStream extends InputStream {
 					return lenRead;
 				}
 			} catch (TskCoreException ex) {
-				logger.log(Level.WARNING, ("Error streaming content: "
+				logger.log(Level.WARNING, ("Error reading content into stream: "
 						+ content.getId()) + ": " + content.getName() 
 						+ ", at offset " + position + ", length to read: " + lenToRead, ex );
 				throw new IOException(ex);


### PR DESCRIPTION
jni content stream: log TskException so we know if IOException caused by  tsk error or by error in library using the content stream
