### PR TITLE
Allow fiwalk to output byte runs/extents to dfxml without reading file contents

### DIFF
--- a/tools/fiwalk/src/fiwalk.cpp
+++ b/tools/fiwalk/src/fiwalk.cpp
@@ -586,6 +586,9 @@ int main(int argc, char * const *argv1)
     if(!filename){
 	errx(1,"must provide filename");
     }
+    if(opt_no_data && (opt_md5 || opt_sha1 || opt_save || opt_magic)) {
+      errx(1, "-g conflicts with options requiring data access (-z may be needed)");
+    }
 
     if(opt_save){
 	if(access(save_outdir.c_str(),F_OK)){


### PR DESCRIPTION
-g now keeps data from being read. If it conflicts with other options requiring data access, it will error out with a message saying so.

Added '-b' to exclude byte runs from being printed if other options don't imply them.
