### PR TITLE
Replace obsolete autotool macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ m4_include([m4/ac_prog_javac.m4])
 
 
 AC_CONFIG_SRCDIR([tsk3/base/tsk_base.h])
-AM_CONFIG_HEADER([tsk3/tsk_config.h])
+AC_CONFIG_HEADERS([tsk3/tsk_config.h])
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([foreign])
 AM_PATH_CPPUNIT(1.12.1)


### PR DESCRIPTION
In the current up-to-date OS X 10.8 and MacPorts, autoconf v2.69
complains that "AM_CONFIG_HEADER" is obsolete, and fails.  The macro it
suggests, AC_CONFIG_HEADERS, works just fine as a drop-in replacement.

To test the macro change, I compiled TSK's 4.0.2 or current head
(depending on if Git was available), and ran the built Fiwalk without
arguments, before and after changing the macro.  I ran this test in the
following additional distros (selected for still being supported), with
their up-to-date version of autoconf:
- Fedora 17 (autoconf v2.68)
- Fedora 18 (autoconf v2.69)
- FreeBSD 9.1 (autoconf v2.69)
- Ubuntu 8.04.4 LTS (autoconf v2.61)
- Ubuntu 10.04.4 LTS (autoconf v2.65)
- Ubuntu 12.10 (autoconf v2.69)

(The thoroughness is from wariness of autotool behaviors - MacPort's is
the only v2.69 autoconf to complain so far with such vehemence, but it
won't be forever.)

Signed-off-by: Alex Nelson ajnelson@cs.ucsc.edu
