### PR TITLE
addFile() fixes

### DIFF
--- a/tsk3/auto/db_sqlite.cpp
+++ b/tsk3/auto/db_sqlite.cpp
@@ -764,20 +764,23 @@ int
     snprintf(foo, 4096,
         "INSERT INTO tsk_files (fs_obj_id, obj_id, type, attr_type, attr_id, name, meta_addr, dir_type, meta_type, dir_flags, meta_flags, size, crtime, ctime, atime, mtime, mode, gid, uid, md5, known, parent_path) "
         "VALUES ("
-        "%lld,%lld,"
+        "%" PRId64 ",%" PRId64 ","
         "%d,"
         "%d,%d,'%s',"
         "%" PRIuINUM ","
         "%d,%d,%d,%d,"
         "%" PRIuOFF ","
-        "%lld,%lld,%lld,%lld,%d,%d,%d,%s,%d,"
+        "%llu,%llu,%llu,%llu,"
+        "%d,%d,%d,%s,%d,"
         "'%s')",
         fsObjId, objId,
         TSK_DB_FILES_TYPE_FS,
         type, idx, name,
         fs_file->name->meta_addr,
         fs_file->name->type, meta_type, fs_file->name->flags, meta_flags,
-        size, crtime, ctime, atime, mtime, meta_mode, gid, uid, md5Text, known,
+        size, 
+        (unsigned long long)crtime, (unsigned long long)ctime,(unsigned long long) atime,(unsigned long long) mtime, 
+        meta_mode, gid, uid, md5Text, known,
         escaped_path);
 
     if (attempt_exec(foo, "TskDbSqlite::addFile: Error adding data to tsk_files table: %s\n")) {


### PR DESCRIPTION
- fix time to string conversion to be cross platform (possible crash fix on linux)
- terminate strings with NULL char
