### PR TITLE
Support openjdk on macos

### DIFF
--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -65,7 +65,13 @@ else
   _JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
   case "$host_os" in
         darwin*)        _JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-                        _JINC="$_JTOPDIR/Headers";;
+                        if test -d "$_JTOPDIR/Headers" 
+			then
+				_JINC="$_JTOPDIR/Headers"
+			elif test -d "$_JTOPDIR/include" 
+			then 
+			     _JINC="$_JTOPDIR/include"
+			fi;;
         *)              _JINC="$_JTOPDIR/include";;
   esac
   _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])
@@ -90,6 +96,7 @@ else
     case "$host_os" in
     bsdi*)          _JNI_INC_SUBDIRS="bsdos";;
     linux*)         _JNI_INC_SUBDIRS="linux genunix";;
+    darwin*)	    _JNI_INC_SUBDIRS="darwin";;
     osf*)           _JNI_INC_SUBDIRS="alpha";;
     solaris*)       _JNI_INC_SUBDIRS="solaris";;
     mingw*)		_JNI_INC_SUBDIRS="win32";;


### PR DESCRIPTION
Modify JNI  autoconf macros to try regular 'include' directory instead of only trying Apple specific 'Headers' dir. 

This avoids compatibility problems when using openjdk.
