### PR TITLE
vs_open: Ensure img_info is non-null

### DIFF
--- a/tsk3/vs/mm_open.c
+++ b/tsk3/vs/mm_open.c
@@ -34,6 +34,14 @@ TSK_VS_INFO *
 tsk_vs_open(TSK_IMG_INFO * img_info, TSK_DADDR_T offset,
     TSK_VS_TYPE_ENUM type)
 {
+    if (img_info == NULL) {
+        /* Opening the image file(s) failed, if attempted. */
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_IMG_NOFILE);
+        tsk_error_set_errstr("mm_open");
+        return NULL;
+    }
+
     /* Autodetect mode 
      * We need to try all of them in case there are multiple 
      * installations


### PR DESCRIPTION
The tsk_vs_open function was assuming non-null input.  This caused a
segfault in the dos opening function in a case where tsk_img_open's
results weren't checked.

I missed that check in early development on an app.  I probably won't
be the last to do that.

Signed-off-by: Alex Nelson ajnelson@cs.ucsc.edu
