### PR TITLE
Correct tsk_malloc docs

### DIFF
--- a/tsk/base/mymalloc.c
+++ b/tsk/base/mymalloc.c
@@ -34,7 +34,7 @@
 *	not return at all.
 *
 *	tsk_malloc() allocates the requested amount of memory. The memory
-*	is not set to zero.
+*	is set to zero.
 *
 *	tsk_realloc() resizes memory obtained from tsk_malloc() or tsk_realloc()
 *	to the requested size. The result pointer value may differ from


### PR DESCRIPTION
On reviewing tsk_malloc for what turned out to be my own error, I found a discrepancy between the documentation and the `memset` in the code.  This corrects the documentation to describe the function behavior.
