### PR TITLE
Move xmlns declarations to root element

### DIFF
--- a/tools/fiwalk/src/fiwalk.cpp
+++ b/tools/fiwalk/src/fiwalk.cpp
@@ -679,11 +679,12 @@ int main(int argc, char * const *argv1)
     /* output per-run metadata for XML output */
     if(x){
 	/* Output Dublin Core information */
-	x->push("dfxml","version='1.0'");
-	x->push("metadata",
+	x->push("dfxml",
 		"\n  xmlns='http://www.forensicswiki.org/wiki/Category:Digital_Forensics_XML'"
-		"\n  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
-		"\n  xmlns:dc='http://purl.org/dc/elements/1.1/'" );
+		"\n  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
+		"\n  xmlns:dc='http://purl.org/dc/elements/1.1/'"
+		"\n  version='1.0'" );
+	x->push("metadata", "");
 	x->xmlout("dc:type","Disk Image",fw_empty,false);
 	x->pop();
 	    


### PR DESCRIPTION
The XML namespace declarations in Fiwalk have been at the wrong point
in the XML tree.  Being where they were, only one or two elements would
get any namespace assigned to them.

Applying this patch, the output of Fiwalk is now valid DFXML according
to the (draft) XML Schema at:
https://github.com/dfxml-working-group/dfxml_schema/blob/v1.1.0rfc0/dfxml.xsd

After some discussion with the DFXML Working Group, it will be
appropriate to bump the /dfxml/@version attribute to "1.1.0" to indicate
support of an official DFXML Schema version; however, the current
schema version is a Request for Comments.  Input on the schema is
welcome.

Signed-off-by: Alex Nelson a.nelson@prometheuscomputing.com
