### PR TITLE
Refine checks for resource.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_HEADER_STDC
 #AC_HEADER_MAJOR
 #AC_HEADER_SYS_WAIT
 #AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h locale.h memory.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/param.h sys/time.h unistd.h utime.h wchar.h wctype.h])
-AC_CHECK_HEADERS([err.h inttypes.h unistd.h stdint.h sys/param.h])
+AC_CHECK_HEADERS([err.h inttypes.h unistd.h stdint.h sys/param.h sys/resource.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/tools/fiwalk/src/dfxml.cpp
+++ b/tools/fiwalk/src/dfxml.cpp
@@ -35,7 +35,7 @@ using namespace std;
 #include <fcntl.h>
 #include <stack>
 
-#ifdef HAVE_GETRUSAGE
+#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 
@@ -375,6 +375,7 @@ void xml::add_DFXML_execution_environment(const std::string &command_line)
 
 void xml::add_rusage()
 {
+#ifdef HAVE_SYS_RESOURCE_H
 #ifdef HAVE_GETRUSAGE
     struct rusage ru;
     memset(&ru,0,sizeof(ru));
@@ -403,6 +404,7 @@ void xml::add_rusage()
 	xmlout("clocktime",t);
 	pop();
     }
+#endif
 #endif
 }
 

--- a/tools/fiwalk/src/fiwalk.cpp
+++ b/tools/fiwalk/src/fiwalk.cpp
@@ -53,7 +53,7 @@
 #endif
 
 
-#ifdef HAVE_GETRUSAGE
+#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #endif
 
@@ -758,6 +758,7 @@ int main(int argc, char * const *argv1)
 
     comment("clock: %s",tvbuf);
 
+#ifdef HAVE_SYS_RESOURCE_H
 #ifdef HAVE_GETRUSAGE
     /* Print usage information */
     struct rusage ru;
@@ -776,6 +777,7 @@ int main(int argc, char * const *argv1)
 	comment("stop_time: %s",cstr(mytime()));
 	if(x) x->pop();
     }
+#endif
 #endif
 
     // *** Added <finished time="(time_t)" duration="<seconds>" />

--- a/tools/fiwalk/src/utils.h
+++ b/tools/fiwalk/src/utils.h
@@ -3,7 +3,7 @@
  *** 
  *** To use utils.c/utils.h, be sure this is in your configure.ac file:
  ***
-AC_CHECK_HEADERS([err.h err.h sys/mman.h sys/resource.h unistd.h])
+AC_CHECK_HEADERS([err.h err.h sys/mman.h unistd.h])
 AC_CHECK_FUNCS([ishexnumber unistd.h err errx warn warnx pread _lseeki64 ])
 
  ***

--- a/tsk/tsk_config.h.in
+++ b/tsk/tsk_config.h.in
@@ -88,6 +88,9 @@
 /* Define to 1 if you have the <sys/param.h> header file. */
 #undef HAVE_SYS_PARAM_H
 
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#undef HAVE_SYS_RESOURCE_H
+
 /* Define to 1 if you have the <sys/select.h> header file. */
 #undef HAVE_SYS_SELECT_H
 


### PR DESCRIPTION
The addition of getrusage in 369a530 had a dependency not evident when
testing in OS X.

This change wraps getrusage with a test for the header that @ant1
caught.  @bcarrier suggested using that symbol, and with the way it
pops up in Hashdeep, it looks worth using.

This builds in:
- CentOS 6.4
- Debian 7.0.0
- Fedora 19
- Ubuntu 13.04
- OS X 10.8.5
