### PR TITLE
Limit yaffs2 initial scan for blank images

### DIFF
--- a/tsk/fs/tsk_yaffs.h
+++ b/tsk/fs/tsk_yaffs.h
@@ -32,8 +32,8 @@ extern "C" {
 #define YAFFS_DEFAULT_PAGE_SIZE     2048
 #define YAFFS_DEFAULT_SPARE_SIZE    64
 
-/* Don't scan more than YAFFS_MAX_SIZE data when trying to detect a yaffs2 filesystem */
-#define YAFFS_MAX_SIZE (64 * 1024 * 1024 * 1024)
+/* Don't scan more than YAFFS_MAX_SCAN_SIZE data when trying to detect a yaffs2 filesystem */
+#define YAFFS_MAX_SCAN_SIZE (64 * 1024 * 1024 * 1024)
 
 /*
 ** Yaffs Object Flags

--- a/tsk/fs/yaffs.cpp
+++ b/tsk/fs/yaffs.cpp
@@ -725,7 +725,7 @@ uint8_t yaffs_initialize_spare_format(YAFFSFS_INFO * yfs){
         while(badBlock && (! outOfData)){
             // Read the last one of the set first. It makes dealing with the unallocated stuff easier
             offset = blockIndex * yfs->chunks_per_block * (yfs->page_size + yfs->spare_size) + (chunksToTest - 1) * (yfs->page_size + yfs->spare_size) + yfs->page_size;
-            if (offset > YAFFS_MAX_SIZE) {
+            if (offset > YAFFS_MAX_SCAN_SIZE) {
                 outOfData = 1;
             }
             cnt = tsk_img_read(fs->img_info, offset, (char *) spareBuffer,


### PR DESCRIPTION
Don't scan huge blank images in their entirety when trying to detect a yaffs2 image. Scan the first 64GB, and if a yaffs2 layout still hasn't been detected, assume it's not yaffs2.
