### PR TITLE
Reset database schema version number

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -163,7 +163,7 @@ public class SleuthkitCase {
 			resultSet.close();
 						
 			// ***CALL SCHEMA UPDATE METHODS HERE***
-			schemaVersionNumber = updateFromSchema3toSchema4(schemaVersionNumber);		
+			schemaVersionNumber = updateFromSchema2toSchema3(schemaVersionNumber);		
 			
 			// Update the schema version number.
 			statement.executeUpdate("UPDATE tsk_db_info SET schema_ver = " + schemaVersionNumber);
@@ -184,8 +184,8 @@ public class SleuthkitCase {
 		}
 	}
 		
-	private int updateFromSchema3toSchema4(int schemaVersionNumber) throws SQLException, TskCoreException {
-		if (schemaVersionNumber != 3) {
+	private int updateFromSchema2toSchema3(int schemaVersionNumber) throws SQLException, TskCoreException {
+		if (schemaVersionNumber != 2) {
 			return schemaVersionNumber;
 		}
 
@@ -260,7 +260,7 @@ public class SleuthkitCase {
 				
 		closeStatements();
 		
-		return 4;	
+		return 3;	
 	}			
 				
 	/**

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -25,7 +25,7 @@ using std::stringstream;
 using std::sort;
 using std::for_each;
 
-#define TSK_SCHEMA_VER 4
+#define TSK_SCHEMA_VER 3
 
 /**
  * Set the locations and logging object.  Must call


### PR DESCRIPTION
Work on the hash database feature used a case database schema version number for a schema change that was rolled back, so it was off by one. This commit increments the schema version number from 2 to 3 instead of from 3 to 4. 
