### PR TITLE
memory leak & fix

### DIFF
--- a/tsk/fs/tsk_fs.h
+++ b/tsk/fs/tsk_fs.h
@@ -2655,6 +2655,7 @@ class TskFsMeta {
 * undefined. See TSK_FS_FILE for more details. 
 */
 class TskFsFile {
+  friend class TskFsDir;
   private:
     TSK_FS_FILE * m_fsFile;
     bool m_opened;
@@ -2972,9 +2973,11 @@ class TskFsDir {
      */
     TskFsFile *getFile(size_t a_idx) const {
         TSK_FS_FILE *fs_file = tsk_fs_dir_get(m_fsDir, a_idx);
-        if (fs_file != NULL)
-             return new TskFsFile(fs_file);
-        else
+        if (fs_file != NULL) {
+             TskFsFile *f = new TskFsFile(fs_file);
+             f->m_opened = true;
+             return f;
+        } else
              return NULL;
     };
 


### PR DESCRIPTION
I found a memory leak in TskFsDir::getFile
I've also sent an e-mail to the dev mailing list sleuthkit-developers@lists.sourceforge.net describing
the leak and also attached a patch(the same patch that's provided by this pull-request).
On the mailing list [this email](http://sourceforge.net/p/sleuthkit/mailman/message/32305174/)  contains an attachment with a testcase and Valgrind output, as well as scripts to automate GDB in order to construct the callgraphs.

When TskFsDir::getFile is called, it wasn't setting TskFsFile::m_opened to true, which in turn would mean that TskFsDir's destructor, and in turn, TskFsDir::close() wouldn't call tsk_fs_file_close. This was causing the leak.

I wrote a testcase to isolate the problem and used Valgrind and GDB to debug it.

This diagram shows all the callpaths to tsk_fs_file_alloc and tsk_fs_file_close on the testcase(also, the number of times that area of the code was reached appears in square brackets near every node):

![gdb-all-paths](https://cloud.githubusercontent.com/assets/180373/2885015/8f8e8568-d4b7-11e3-9432-33b430f6be67.png)

This diagram shows the callpath that causes the memory leak:

![gdb-paths-that-caused-leak](https://cloud.githubusercontent.com/assets/180373/2885016/8f9369de-d4b7-11e3-972e-2d8787e0709d.png)
