### PR TITLE
mactime: ignore invalid timestamps ($time == 0) in index files

### DIFF
--- a/tools/timeline/mactime.base
+++ b/tools/timeline/mactime.base
@@ -514,6 +514,7 @@ sub print_tl {
 
     my $prev_day        = "";   # has the format of 'day day_week mon year'
     my $prev_hour       = "";   # has just the hour and is used for hourly index
+    my $prev_time       = 0;
     my $prev_cnt        = 0;
     my $old_date_string = "";
 
@@ -618,6 +619,7 @@ sub print_tl {
                 if ($prev_day eq "") {
                     $prev_day  = "$mday $wday $mon $yeart";
                     $prev_hour = $hour;
+                    $prev_time = $time;
                     $prev_cnt  = 0;
                 }
 
@@ -642,12 +644,13 @@ sub print_tl {
                     $date_str .= " $prev_hour:00:00"
                       if ($INDEX_TYPE == $INDEX_HOUR);
 
-                    print INDEX "${date_str}${delim} $prev_cnt\n";
+                    print INDEX "${date_str}${delim} $prev_cnt\n" if ($prev_time > 0);
 
                     # Reset
                     $prev_cnt  = 0;
                     $prev_day  = "$mday $wday $mon $yeart";
                     $prev_hour = $hour;
+                    $prev_time = $time;
 
                 }
 
@@ -659,18 +662,21 @@ sub print_tl {
                         print INDEX "$digit_to_day{$prev_vals[1]} "
                           . "$prev_vals[2] "
                           . "$prev_vals[0] ${prev_vals[3]} "
-                          . "$prev_hour:00:00${delim} $prev_cnt\n";
+                          . "$prev_hour:00:00${delim} $prev_cnt\n"
+                          if ($prev_time > 0);
                     }
                     else {
                         print INDEX "$digit_to_day{$prev_vals[1]} "
                           . "$digit_to_month{$prev_vals[2]} "
                           . "$prev_vals[0] ${prev_vals[3]} "
-                          . "$prev_hour:00:00${delim} $prev_cnt\n";
+                          . "$prev_hour:00:00${delim} $prev_cnt\n"
+                          if ($prev_time > 0);
                     }
 
                     # Reset
                     $prev_cnt  = 0;
                     $prev_hour = $hour;
+                    $prev_time = $time;
                 }
                 $prev_cnt++;
             }
@@ -750,7 +756,7 @@ sub print_tl {
         $date_str .= " $prev_hour:00:00"
           if ($INDEX_TYPE == $INDEX_HOUR);
 
-        print INDEX "${date_str}${delim} $prev_cnt\n";
+        print INDEX "${date_str}${delim} $prev_cnt\n" if ($prev_time > 0);
         close INDEX;
     }
 }


### PR DESCRIPTION
Ignore invalid timestamps while creating index files (instead of printing them as 01/01/1970). See https://github.com/sleuthkit/sleuthkit/issues/330. 
