### PR TITLE
Fix for issue #345: relinking sqlite-jdbc to latest release

### DIFF
--- a/bindings/java/ivy.xml
+++ b/bindings/java/ivy.xml
@@ -3,7 +3,7 @@
     <dependencies>
 		<dependency org="junit" name="junit" rev="4.8.2"/>
 		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.2.1"/>
-		<dependency org="org.xerial" name="sqlite-jdbc" rev="3.8.0-SNAPSHOT" >
+		<dependency org="org.xerial" name="sqlite-jdbc" rev="latest.integration" >
 			<artifact name="sqlite-jdbc" type="jar" />
 		</dependency>
     </dependencies>

--- a/bindings/java/ivysettings.xml
+++ b/bindings/java/ivysettings.xml
@@ -4,8 +4,6 @@
     <chain name="default">
     <ibiblio name="central" m2compatible="true"/>
     <ibiblio name="ibiblio" m2compatible="true"/>
-    <ibiblio name="xerial" m2compatible="true"
-root="http://oss.sonatype.org/content/repositories/snapshots" />
     </chain>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
This pull request is to address issue #[345](https://github.com/sleuthkit/sleuthkit/issues/345) that prevents sleuthkit from building because ivy cannot find sqlite-jdbc-3.8.0-SNAPSHOT on xerial's Maven server. It uses the central repositories most current release version, currently sqlite-jdbc-3.7.15-M1 instead.
