### PR TITLE
Change mmls to 3 digit precision so that it aligns nicely when there are >= 100 slots.

### DIFF
--- a/tools/vstools/mmls.cpp
+++ b/tools/vstools/mmls.cpp
@@ -134,7 +134,7 @@ print_header(const TSK_VS_INFO * vs)
     tsk_printf("Units are in %d-byte sectors\n\n", vs->block_size);
     if (print_bytes)
         tsk_printf
-            ("      Slot      Start        End          Length       Size     Description\n");
+            ("      Slot      Start        End          Length       Size    Description\n");
     else
         tsk_printf
             ("      Slot      Start        End          Length       Description\n");


### PR DESCRIPTION
Proposed patch to make mmls use 3 digit precision on its tsk_printf() output.  The reason for this is that mmls currently doesn't align nicely when there are >= 100 slots which causes the output to skew on images with numerous partitions (ie. a Android device in the below case).  This change increases the outputted max line length by 3 characters vs. the previous mmls output.

**Current mmls output:**

``` shell
$ mmls DumpData.bin
DOS Partition Table
Offset Sector: 0
Units are in 512-byte sectors

     Slot    Start        End          Length       Description
00:  Meta    0000000000   0000000000   0000000001   Primary Table (#0)
01:  -----   0000000000   0000000000   0000000001   Unallocated
02:  00:00   0000000001   0000204800   0000204800   Free FDISK Hidden Primary DOS Large FAT16 (0x92)
03:  00:01   0000204801   0000205800   0000001000   QNX 4.x (0x4d)
04:  00:02   0000205801   0000208800   0000003000   OnTrack Disk Manager (0x51)
05:  Meta    0000208801   0030777343   0030568543   DOS Extended (0x05)
<snip>
<snip>
<snip>
<snip>
96:  22:00   0006275072   0006893567   0000618496   Mac OS X (0xa8)
97:  -----   0006893568   0006897663   0000004096   Unallocated
98:  23:00   0006897664   0007161855   0000264192   NetBSD (0xa9)
99:  -----   0007161856   0007167999   0000006144   Unallocated
100:  24:00   0007168000   0030777343   0023609344   Free FDISK Hidden Primary DOS FAT16 (0x90)
```

**Proposed mmls output:**

``` shell
$ mmls DumpData.bin
DOS Partition Table
Offset Sector: 0
Units are in 512-byte sectors

      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Primary Table (#0)
001:  -------   0000000000   0000000000   0000000001   Unallocated
002:  000:000   0000000001   0000204800   0000204800   Free FDISK Hidden Primary DOS Large FAT16 (0x92)
003:  000:001   0000204801   0000205800   0000001000   QNX 4.x (0x4d)
004:  000:002   0000205801   0000208800   0000003000   OnTrack Disk Manager (0x51)
005:  Meta      0000208801   0030777343   0030568543   DOS Extended (0x05)
<snip>
<snip>
<snip>
096:  022:000   0006275072   0006893567   0000618496   Mac OS X (0xa8)
097:  -------   0006893568   0006897663   0000004096   Unallocated
098:  023:000   0006897664   0007161855   0000264192   NetBSD (0xa9)
099:  -------   0007161856   0007167999   0000006144   Unallocated
100:  024:000   0007168000   0030777343   0023609344   Free FDISK Hidden Primary DOS FAT16 (0x90)
```
