### PR TITLE
Default build target now builds for PostgreSQL + SQLite

### DIFF
--- a/bindings/java/build-windows.xml
+++ b/bindings/java/build-windows.xml
@@ -47,35 +47,34 @@
 		targetfile="${amd64}/win/libtsk_jni.dll"/>
 	</target>
 
-	<target name="copyLibs" description="Copy native libs to the correct folder">
+	<target name="copyLibsSQLite" description="Copy native libs to the correct folder">
 		<property name="tsk.config" value="Release"/>
+		<antcall target="copyWinTskLibsToBuildSQLite" />
+	</target>
+	
+	<target name="copyLibsSQLiteDebug" description="Copy native libs to the correct folder">
+		<property name="tsk.config" value="Debug"/>
+		<antcall target="copyWinTskLibsToBuildSQLite" />
+	</target>
+
+	<target name="copyLibs" description="Copy native libs to the correct folder">
+		<property name="tsk.config" value="Release_PostgreSQL"/>
 		<antcall target="copyWinTskLibsToBuild" />
 	</target>
 	
 	<target name="copyLibsDebug" description="Copy native libs to the correct folder">
-		<property name="tsk.config" value="Debug"/>
-		<antcall target="copyWinTskLibsToBuild" />
-	</target>
-
-	<target name="copyLibsPostgreSQL" description="Copy native libs to the correct folder">
-		<property name="tsk.config" value="Release_PostgreSQL"/>
-		<antcall target="copyWinTskLibsToBuildPostgres" />
-	</target>
-	
-	<target name="copyLibsPostgreSQLDebug" description="Copy native libs to the correct folder">
 		<property name="tsk.config" value="Debug_PostgreSQL"/>
 		<antcall target="copyWinTskLibsToBuild" />
 	</target>
-	
 
-	<target name="copyWinTskLibsToBuild" depends="copyWinTskLibs64ToBuild, copyWinTskLibs32ToBuild" description="Copy windows dlls to the correct location." />
+	<target name="copyWinTskLibsToBuildSQLite" depends="copyWinTskLibs64ToBuildSQLite, copyWinTskLibs32ToBuild" description="Copy windows dlls to the correct location." />
 	
-	<target name="checkTskLibDirs">
+	<target name="checkTskLibDirsSQLite">
 		<available property="win64.TskLib.exists" type="file" file="${basedir}/../../win32/x64/${tsk.config}/libtsk_jni.dll" />
 		<available property="win32.TskLib.exists" type="file" file="${basedir}/../../win32/${tsk.config}/libtsk_jni.dll" />
 	</target>
 	
-	<target name="copyWinTskLibs64ToBuild" depends="checkTskLibDirs" if="win64.TskLib.exists">
+	<target name="copyWinTskLibs64ToBuildSQLite" depends="checkTskLibDirsSQLite" if="win64.TskLib.exists">
 		<property name="tsk.jni.64" location="${basedir}/../../win32/x64/${tsk.config}/libtsk_jni.dll" />
 		
 		<copy file="${tsk.jni.64}" todir="${amd64}/win" overwrite="true"/>
@@ -84,22 +83,34 @@
 	
 	<target name="copyWinTskLibs32ToBuild" depends="checkTskLibDirs" if="win32.TskLib.exists">
 		<property name="tsk.jni.32" location="${basedir}/../../win32/${tsk.config}/libtsk_jni.dll" />
-				
+		<property name="libewf.32" location="${basedir}/../../win32/${tsk.config}/libewf.dll" />
+		<property name="zlib.32" location="${basedir}/../../win32/${tsk.config}/zlib.dll" />
+
+		<copy file="${libewf.32}" todir="${i386}/win" overwrite="true"/>
+		<copy file="${libewf.32}" todir="${x86}/win" overwrite="true"/>
+		<copy file="${libewf.32}" todir="${i586}/win" overwrite="true"/>
+		<copy file="${libewf.32}" todir="${i686}/win" overwrite="true"/>
+		<copy file="${zlib.32}" todir="${i386}/win" overwrite="true"/>
+		<copy file="${zlib.32}" todir="${x86}/win" overwrite="true"/>
+		<copy file="${zlib.32}" todir="${i586}/win" overwrite="true"/>
+		<copy file="${zlib.32}" todir="${i686}/win" overwrite="true"/>
 		<copy file="${tsk.jni.32}" todir="${i386}/win" overwrite="true"/>
 		<copy file="${tsk.jni.32}" todir="${x86}/win" overwrite="true"/>
 		<copy file="${tsk.jni.32}" todir="${i586}/win" overwrite="true"/>	
 		<copy file="${tsk.jni.32}" todir="${i686}/win" overwrite="true"/>
 	</target>
 		
-	<target name="copyWinTskLibsToBuildPostgres" depends="copyWinTskLibs64ToBuildPostgres" description="Copy windows dlls to the correct location." />
+	<target name="copyWinTskLibsToBuild" depends="copyWinTskLibs64ToBuild" description="Copy windows dlls to the correct location." />
 	
-	<target name="checkTskLibDirsPostgres">
+	<target name="checkTskLibDirs">
 		<available property="win64.TskLib.exists" type="file" file="${basedir}/../../win32/x64/${tsk.config}/libtsk_jni.dll" />
 		<available property="win32.TskLib.exists" type="file" file="${basedir}/../../win32/${tsk.config}/libtsk_jni.dll" />
 	</target>
 	
-	<target name="copyWinTskLibs64ToBuildPostgres" depends="checkTskLibDirsPostgres" if="win64.TskLib.exists">
+	<target name="copyWinTskLibs64ToBuild" depends="checkTskLibDirs" if="win64.TskLib.exists">
 		<property name="tsk.jni.64" location="${basedir}/../../win32/x64/${tsk.config}/libtsk_jni.dll" />
+		<property name="libewf.64" location="${basedir}/../../win32/x64/${tsk.config}/libewf.dll" />
+		<property name="zlib.64" location="${basedir}/../../win32/x64/${tsk.config}/zlib.dll" />
 		<property name="libintl-8.64" location="${basedir}/../../win32/x64/${tsk.config}/libintl-8.dll" />
 		<property name="libeay32.64" location="${basedir}/../../win32/x64/${tsk.config}/libeay32.dll" />
 		<property name="ssleay32.64" location="${basedir}/../../win32/x64/${tsk.config}/ssleay32.dll" />
@@ -107,6 +118,10 @@
 		
 		<copy file="${tsk.jni.64}" todir="${amd64}/win" overwrite="true"/>
 		<copy file="${tsk.jni.64}" todir="${x86_64}/win" overwrite="true"/>
+		<copy file="${libewf.64}" todir="${amd64}/win" overwrite="true"/>
+		<copy file="${libewf.64}" todir="${x86_64}/win" overwrite="true"/>
+		<copy file="${zlib.64}" todir="${amd64}/win" overwrite="true"/>
+		<copy file="${zlib.64}" todir="${x86_64}/win" overwrite="true"/>
 		<copy file="${libintl-8.64}" todir="${amd64}/win" overwrite="true"/>
 		<copy file="${libintl-8.64}" todir="${x86_64}/win" overwrite="true"/>
 		<copy file="${libeay32.64}" todir="${amd64}/win" overwrite="true"/>
@@ -116,15 +131,5 @@
 		<copy file="${libpq.64}" todir="${amd64}/win" overwrite="true"/>
 		<copy file="${libpq.64}" todir="${x86_64}/win" overwrite="true"/>
 	</target>
-	
-	<target name="copyWinTskLibs32ToBuildPostgres" depends="checkTskLibDirsPostgres" if="win32.TskLib.exists">
-		<property name="tsk.jni.32" location="${basedir}/../../win32/${tsk.config}/libtsk_jni.dll" />
-			
-		<copy file="${tsk.jni.32}" todir="${i386}/win" overwrite="true"/>
-		<copy file="${tsk.jni.32}" todir="${x86}/win" overwrite="true"/>
-		<copy file="${tsk.jni.32}" todir="${i586}/win" overwrite="true"/>	
-		<copy file="${tsk.jni.32}" todir="${i686}/win" overwrite="true"/>
-	</target>
-	
 	
 </project>

--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -126,11 +126,11 @@
 		</javac>
 	</target>
 
-	<target name="dist" depends="check-build" unless="up-to-date">
-		<antcall target="dist-do"/>
+	<target name="dist-SQLite" depends="check-build" unless="up-to-date">
+		<antcall target="dist-SQLite-do"/>
 	</target>
 
-	<target name="dist-PostgreSQL" depends="check-build, init-ivy, compile, copyLibsPostgreSQL" unless="up-to-date"	description="generate the distribution" >
+	<target name="dist" depends="check-build, init-ivy, compile, copyLibs" unless="up-to-date"	description="generate the distribution" >
 		<!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
 		<jar jarfile="${dist}/Tsk_DataModel.jar" basedir="${build}"/>
 	</target>
@@ -148,19 +148,19 @@
 		</condition>
 	</target>
 	
-	<target name="dist-do" depends="init-ivy, compile, copyLibs"
+	<target name="dist-SQLite-do" depends="init-ivy, compile, copyLibsSQLite"
 			description="generate the distribution" >
 		<!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
 		<jar jarfile="${dist}/Tsk_DataModel.jar" basedir="${build}"/>
 	</target>
 	
-	<target name="dist-debug" depends="init-ivy, compile, copyLibsDebug"
+	<target name="dist-SQLite-debug" depends="init-ivy, compile, copyLibsSQLiteDebug"
 			description="generate the distribution" >
 		<!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
 		<jar jarfile="${dist}/Tsk_DataModel.jar" basedir="${build}"/>
 	</target>
   
-	<target name="dist-debug-PostgreSQL" depends="init-ivy, compile, copyLibsPostgreSQLDebug"
+	<target name="dist-debug" depends="init-ivy, compile, copyLibsDebug"
 			description="generate the distribution" >
 		<!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
 		<jar jarfile="${dist}/Tsk_DataModel.jar" basedir="${build}"/>

--- a/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
@@ -122,9 +122,23 @@ class ResultSetHelper {
 	 * @throws SQLException thrown if SQL error occurred
 	 */
 	Volume volume(ResultSet rs, VolumeSystem parent) throws SQLException {
+		/**
+		 * TODO!! 
+		 * LANDMINE!! This allows the two types of databases to have slightly
+		 * different schemas. SQLite uses desc as the column name in tsk_vs_parts
+		 * and Postgres uses descr, as desc is a reserved keyword in Postgres.
+		 * When we have to make a schema change, be sure to change this over to 
+		 * just one name. 
+		 */
+		String description;
+		try {
+			description = rs.getString("desc");
+		} catch (Exception ex) {
+			description = rs.getString("descr");
+		}
 		Volume vol = new Volume(db, rs.getLong("obj_id"), rs.getLong("addr"), //NON-NLS
 				rs.getLong("start"), rs.getLong("length"), rs.getLong("flags"), //NON-NLS
-				rs.getString("desc")); //NON-NLS
+				description);
 		vol.setParent(parent);
 		return vol;
 	}

--- a/win32/libtsk/libtsk.vcxproj
+++ b/win32/libtsk/libtsk.vcxproj
@@ -237,7 +237,8 @@ copy "$(LIBEWF_HOME)\msvscpp\x64\release\zlib.dll" "$(OutDir)"
 copy "$(LIBEWF_HOME)\msvscpp\x64\release\zlib.dll" "$(OutDir)"
 copy "$(POSTGRESQL_HOME_64)\bin\libpq.dll" "$(OutDir)"
 copy "$(POSTGRESQL_HOME_64)\bin\libintl-8.dll" "$(OutDir)"
-</Command>
+copy "$(POSTGRESQL_HOME_64)\bin\libeay32.dll" "$(OutDir)"
+copy "$(POSTGRESQL_HOME_64)\bin\ssleay32.dll" "$(OutDir)"</Command>
     </PostBuildEvent>
     <Lib>
       <AdditionalDependencies>libpq.lib</AdditionalDependencies>
@@ -306,7 +307,10 @@ copy "$(LIBEWF_HOME)\msvscpp\release\zlib.dll" "$(OutDir)"
     <PostBuildEvent>
       <Command>copy "$(LIBEWF_HOME)\msvscpp\x64\release\libewf.dll" "$(OutDir)"
 copy "$(LIBEWF_HOME)\msvscpp\x64\release\zlib.dll" "$(OutDir)"
-</Command>
+copy "$(POSTGRESQL_HOME_64)\bin\libpq.dll" "$(OutDir)"
+copy "$(POSTGRESQL_HOME_64)\bin\libintl-8.dll" "$(OutDir)"
+copy "$(POSTGRESQL_HOME_64)\bin\libeay32.dll" "$(OutDir)"
+copy "$(POSTGRESQL_HOME_64)\bin\ssleay32.dll" "$(OutDir)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_PostgreSQL|x64'">


### PR DESCRIPTION
To build Autopsy, you must have a 64-bit version of PostgreSQL installed. It is available at http://www.postgresql.org/download/
You need to define an environment variable called POSTGRESQL_HOME_64 and point it to the PostgreSQL folder containing but not including the bin folder.
Here is an example: 
POSTGRESQL_HOME_64=C:\Program Files\PostgreSQL\9.4

In Visual Studio, build The SleuthKit (TSK) selecting one of following targets:
Debug_PostgreSQL x64
Release_PostgreSQL x64

Then, in NetBeans, build the DataModel with "Clean and Build"
Then, also in NetBeans, build Autopsy with "Clean and Build"


For those interested in just using TSK and the DataModel:
Build TSK with non-PostgreSQL targets in Visual Studio.
Then, build the DataModel with two steps:
    1) clean 
    2) select one of the two following targets and build that:
        a) dist-SQLite
        b) dist-SQLite-debug 
Then you can use the DataModel and JNI to access TSK.
