### PR TITLE
add local and logical files, clip large mode values

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
@@ -34,7 +34,9 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
  */
 class ResultSetHelper {
 	SleuthkitCase db;
-
+	
+	private final static int TWELVE_BITS_MASK = 0xFFF; // Only keep 12 bits
+	
 	ResultSetHelper(SleuthkitCase db) {
 		this.db = db;
 	}
@@ -172,6 +174,7 @@ class ResultSetHelper {
 	 * @throws SQLException
 	 */
 	File file(ResultSet rs, FileSystem fs) throws SQLException {
+	
 		File f = new File(db, rs.getLong("obj_id"), rs.getLong("fs_obj_id"), //NON-NLS
 				TSK_FS_ATTR_TYPE_ENUM.valueOf(rs.getShort("attr_type")), //NON-NLS
 				rs.getShort("attr_id"), rs.getString("name"), rs.getLong("meta_addr"), rs.getInt("meta_seq"), //NON-NLS
@@ -180,7 +183,7 @@ class ResultSetHelper {
 				TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), //NON-NLS
 				rs.getShort("meta_flags"), rs.getLong("size"), //NON-NLS
 				rs.getLong("ctime"), rs.getLong("crtime"), rs.getLong("atime"), rs.getLong("mtime"), //NON-NLS
-				(short)rs.getInt("mode"), rs.getInt("uid"), rs.getInt("gid"), //NON-NLS /// KDM rs.getShort("mode"),
+				(short)(rs.getInt("mode") & TWELVE_BITS_MASK), rs.getInt("uid"), rs.getInt("gid"), //NON-NLS
 				rs.getString("md5"), //NON-NLS
 				FileKnown.valueOf(rs.getByte("known")), rs.getString("parent_path")); //NON-NLS
 		f.setFileSystem(fs);

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -2693,7 +2693,10 @@ public class SleuthkitCase {
 			statement.clearParameters();
 			if (parentId != 0) {
 				statement.setLong(1, parentId);
+			} else {
+				statement.setNull(1, java.sql.Types.BIGINT);
 			}
+		
 			statement.setLong(2, TskData.ObjectType.ABSTRACTFILE.getObjectType());
 			connection.executeUpdate(statement);
 			resultSet = statement.getGeneratedKeys();
@@ -3245,6 +3248,7 @@ public class SleuthkitCase {
 			statement.setLong(1, newObjId);
 
 			// nothing to set for parameter 2, fs_obj_id since local files aren't part of file systems
+			statement.setNull(2, java.sql.Types.BIGINT);
 			statement.setString(3, fileName);
 
 			//type, has_path


### PR DESCRIPTION
Note that the YAFFS2 larger mode data is still stored in the database, as it is an integer column, but we don't use it in the Java side.