### PR TITLE
fix bad SQL statement formation

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -1413,7 +1413,7 @@ public class SleuthkitCase {
 			rs = connection.executeQuery(s, "SELECT attribute_type_id FROM blackboard_attribute_types WHERE type_name = '" + attrTypeString + "'"); //NON-NLS
 			if (!rs.next()) {
 				rs.close();
-				connection.executeUpdate(s, "INSERT INTO blackboard_artifact_types (type_name, display_name) VALUES (" + attrTypeString + "', '" + displayName + "')"); //NON-NLS
+				connection.executeUpdate(s, "INSERT INTO blackboard_artifact_types (type_name, display_name) VALUES ('" + attrTypeString + "', '" + displayName + "')"); //NON-NLS
 				rs = s.getGeneratedKeys();
 			}
 			int type = rs.getInt(1);


### PR DESCRIPTION
sql statement missing leading quote. tracing execution into Stmt.java :: executeUpdate().... int statusCode = db._exec(sql);
sql is malformed.
Repro data:

use the SampleIngestModule example....  the line:
attrId = sleuthkitCase.addAttrType("ATTR_SAMPLE", "Sample Attribute");

...traced to Stmt.java :: executeUpdate() (see above), yields
INSERT INTO blackboard_artifact_types (type_name, display_name) VALUES (ATTR_SAMPLE', 'Sample Attribute')
(note mismatched single-quote on ATTR_SAMPLE)

execution freezes here with infinite (re)calls to executeUpdate().

This fix should band-aid the problem. However, two more meaningful fixes could be:

1. fix "wrapper" callee executeUpdate() to not stick in infinite loop on this kind of error; propagate error upward so that the framework can see it.
while (locked) {   <----- always true in this type of error case!!!!
				try {
					statement.executeUpdate(update);    

2. use Sql quote() functions or similar rather than manually quoting (with e.g. quote + append identifier string + quote....)