### PR TITLE
Patches for cross-compilation using MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,11 +84,18 @@ AX_PTHREAD([
     LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
     CC="$PTHREAD_CC"],[])
 
-dnl Not all compilers include /usr/local in the include and link path
-if test -d /usr/local/include; then
+case "$host" in
+*-*-mingw*)
+  dnl Adding the native /usr/local is wrong for cross-compiling
+  ;;
+*)
+  dnl Not all compilers include /usr/local in the include and link path
+  if test -d /usr/local/include; then
     CPPFLAGS="$CPPFLAGS -I/usr/local/include"
     LDFLAGS="$LDFLAGS -L/usr/local/lib"
-fi
+  fi
+  ;;
+esac
 
 dnl Add enable/disable option
 AC_ARG_ENABLE([java],

--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,8 @@ AC_CONFIG_COMMANDS([tsk/tsk_incs.h],
     ac_cv_header_sys_param_h=$ac_cv_header_sys_param_h
     ax_pthread_ok=$ax_pthread_ok])
 
+AC_CHECK_FUNCS([getline], [], [AC_MSG_WARN([no getline, so fiwalk will not be built])])
+AM_CONDITIONAL([BUILD_FIWALK], [test "x$ac_cv_func_getline" = "xyes"])
 
 AC_CONFIG_FILES([
     Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,20 @@ AC_CONFIG_COMMANDS([tsk/tsk_incs.h],
     ac_cv_header_sys_param_h=$ac_cv_header_sys_param_h
     ax_pthread_ok=$ax_pthread_ok])
 
+AC_MSG_CHECKING([if libtool needs -no-undefined flag to build shared libraries])
+case "$host" in
+*-*-mingw*)
+  dnl Add -no-undefined flag to LDFLAGS to let libtool build DLLs.
+  AC_MSG_RESULT([yes])
+  LIBTSK_LDFLAGS="-no-undefined"
+  AC_SUBST([LIBTSK_LDFLAGS])
+  ;;
+  *)
+  dnl No additional flags needed.
+  AC_MSG_RESULT([no])
+  ;;
+esac
+
 AC_CHECK_FUNCS([getline], [], [AC_MSG_WARN([no getline, so fiwalk will not be built])])
 AM_CONDITIONAL([BUILD_FIWALK], [test "x$ac_cv_func_getline" = "xyes"])
 

--- a/tests/fs_attrlist_apis.cpp
+++ b/tests/fs_attrlist_apis.cpp
@@ -119,7 +119,7 @@ test_get_apis(TSK_FS_INFO * a_fs, TSK_INUM_T a_addr, int a_len)
         if (fs_attr != fs_attr2) {
             fprintf(stderr,
                 "Attribute from get_type not same addr as original %lu vs %lu from %"
-                PRIuINUM "\n", (long) fs_attr, (long) fs_attr2, a_addr);
+                PRIuINUM "\n", fs_attr, fs_attr2, a_addr);
             tsk_error_print(stderr);
             return 1;
         }

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,1 +1,5 @@
-SUBDIRS = imgtools vstools fstools hashtools srchtools sorter timeline autotools fiwalk
+SUBDIRS = imgtools vstools fstools hashtools srchtools sorter timeline autotools
+
+if BUILD_FIWALK
+SUBDIRS += fiwalk
+endif

--- a/tsk/Makefile.am
+++ b/tsk/Makefile.am
@@ -8,6 +8,6 @@ libtsk_la_LIBADD = base/libtskbase.la img/libtskimg.la \
     vs/libtskvs.la fs/libtskfs.la hashdb/libtskhashdb.la \
     auto/libtskauto.la
 # current:revision:age
-libtsk_la_LDFLAGS = -version-info 12:0:2
+libtsk_la_LDFLAGS = -version-info 12:0:2 $(LIBTSK_LDFLAGS)
 
 EXTRA_DIST = tsk_tools_i.h docs/Doxyfile docs/*.dox docs/*.html


### PR DESCRIPTION
This PR contains four patches for compiling Windows builds of libtsk using the MinGW compiler. The issues fixed are:

* I removed narrowing casts in tests/fs_attrlist_apis.cpp which cause compilation to fail without `-fpermissive`.
* fiwalk won't build for Windows due to the absence of `getline` from <stdio.h>. I modified configure.ac to check for `getline` and decline to build fiwalk if `getline` is absent.
* I added `-no-undefined` as a flag for libtool when building using MinGW. Libtool will not produce DLLs without this flag.
* Adding the native /usr/local/include and /usr/local/lib to CPPFLAGS and LDFLAGS when cross-compiling is wrong.