### PR TITLE
Patch fiwalk so it builds under MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,6 @@ AC_FUNC_VPRINTF
 dnl AC_CHECK_FUNCS([dup2 gethostname isascii iswprint memset munmap regcomp select setlocale strcasecmp strchr strdup strerror strndup strrchr strtol strtoul strtoull utime wcwidth])
 AC_CHECK_FUNCS([ishexnumber err errx warn warnx vasprintf getrusage])
 AC_CHECK_FUNCS([strlcpy strlcat])
-AC_CHECK_FUNCS([getline])
 
 AX_PTHREAD([
     AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.])
@@ -301,6 +300,10 @@ case "$host" in
   AC_MSG_RESULT([no])
   ;;
 esac
+
+dnl Dependencies for fiwalk
+AC_CHECK_FUNCS([getline])
+AC_SEARCH_LIBS(regexec, [regex], , AC_MSG_ERROR([missing regex]))
 
 AC_CONFIG_FILES([
     Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_FUNC_VPRINTF
 dnl AC_CHECK_FUNCS([dup2 gethostname isascii iswprint memset munmap regcomp select setlocale strcasecmp strchr strdup strerror strndup strrchr strtol strtoul strtoull utime wcwidth])
 AC_CHECK_FUNCS([ishexnumber err errx warn warnx vasprintf getrusage])
 AC_CHECK_FUNCS([strlcpy strlcat])
+AC_CHECK_FUNCS([getline])
 
 AX_PTHREAD([
     AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.])
@@ -300,9 +301,6 @@ case "$host" in
   AC_MSG_RESULT([no])
   ;;
 esac
-
-AC_CHECK_FUNCS([getline], [], [AC_MSG_WARN([no getline, so fiwalk will not be built])])
-AM_CONDITIONAL([BUILD_FIWALK], [test "x$ac_cv_func_getline" = "xyes"])
 
 AC_CONFIG_FILES([
     Makefile

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,5 +1,1 @@
-SUBDIRS = imgtools vstools fstools hashtools srchtools sorter timeline autotools
-
-if BUILD_FIWALK
-SUBDIRS += fiwalk
-endif
+SUBDIRS = imgtools vstools fstools hashtools srchtools sorter timeline autotools fiwalk


### PR DESCRIPTION
This patch:

* provides an implementation of getline(), a POSIX function used by fiwalk which doesn't exist in MinGW, so that fiwalk can be successfully cross-compiled,
* adds `-lregex` to LIBS in the case where the POSIX regex functions aren't found without it, and
* reenables building of fiwalk unconditionally, instead of skipping it when building with MinGW.