### PR TITLE
Fix memory leak caused by allocated corrupt dir structures

### DIFF
--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -247,8 +247,10 @@ tsk_fs_dir_open_meta(TSK_FS_INFO * a_fs, TSK_INUM_T a_addr)
     }
 
     retval = a_fs->dir_open_meta(a_fs, &fs_dir, a_addr);
-    if (retval != TSK_OK)
+    if (retval != TSK_OK) {
+        tsk_fs_dir_close(fs_dir);
         return NULL;
+    }
 
     return fs_dir;
 }


### PR DESCRIPTION
If a directory cannot be opened, it must still be deallocated.