### PR TITLE
Some extra sanity checking to avoid SIGSEGV on corrupt input.

### DIFF
--- a/tsk/fs/ext2fs.c
+++ b/tsk/fs/ext2fs.c
@@ -449,7 +449,8 @@ ext2fs_imap_load(EXT2FS_INFO * ext2fs, EXT2_GRPNUM_T grp_num)
      * Look up the inode allocation bitmap.
      */
     if (EXT2FS_HAS_INCOMPAT_FEATURE(fs, ext2fs->fs,
-            EXT2FS_FEATURE_INCOMPAT_64BIT)) {
+            EXT2FS_FEATURE_INCOMPAT_64BIT)
+	&& (ext2fs->ext4_grp_buf != NULL)) {
         if (ext4_getu64(fs->endian,
                 ext2fs->ext4_grp_buf->bg_block_bitmap_hi,
                 ext2fs->ext4_grp_buf->bg_block_bitmap_lo)
@@ -574,7 +575,8 @@ ext2fs_dinode_load(EXT2FS_INFO * ext2fs, TSK_INUM_T dino_inum,
         ext2fs->fs->s_inodes_per_group) * grp_num;
     if (EXT2FS_HAS_INCOMPAT_FEATURE(fs, ext2fs->fs,
             EXT2FS_FEATURE_INCOMPAT_64BIT)
-        && (tsk_getu16(fs->endian, ext2fs->fs->s_desc_size) >= 64)) {
+        && (tsk_getu16(fs->endian, ext2fs->fs->s_desc_size) >= 64)
+	&& (ext2fs->ext4_grp_buf != NULL)) {
 #ifdef Ext4_DBG
         printf("DEBUG: d_inode_load 64bit gd_size=%d\n",
             tsk_getu16(fs->endian, ext2fs->fs->s_desc_size));


### PR DESCRIPTION
`tsk/fs/ext2fs.c` can get a SIGSEGV on malformed or unexpected input. With a single bit flipped in the input data, the ext2 parser may think there are some file system features are enabled, and wrongly assumes some structures are populated. These snippets cause SIGSEGV, depending on the input:

From line 453:

        if (ext4_getu64(fs->endian,
                ext2fs->ext4_grp_buf->bg_block_bitmap_hi,
                ext2fs->ext4_grp_buf->bg_block_bitmap_lo)
            > fs->last_block) {

From line 582:

        addr =
            (TSK_OFF_T) ext4_getu64(fs->endian,
            ext2fs->ext4_grp_buf->bg_inode_table_hi,
            ext2fs->ext4_grp_buf->bg_inode_table_lo)
            * (TSK_OFF_T) fs->block_size +
            rel_inum * (TSK_OFF_T) ext2fs->inode_size;

In both cases, `ex2fs->ext4_grp_buf` is NULL, but this isn't checked before using it. A sample image causing this behaviour when parsed with `fls -r`:

https://www.dropbox.com/s/yh6cxqvvnw6be6n/ext2-segfault.dd?dl=0

The proposed patch appears to solve the issue.