### PR TITLE
Close input image and file system handles

### DIFF
--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -109,7 +109,7 @@ static TSK_IMG_INFO *
 castImgInfo(JNIEnv * env, jlong ptr)
 {
     TSK_IMG_INFO *lcl = (TSK_IMG_INFO *) ptr;
-    if (lcl->tag != TSK_IMG_INFO_TAG) {
+    if (!lcl || lcl->tag != TSK_IMG_INFO_TAG) {
         setThrowTskCoreError(env, "Invalid IMG_INFO object");
         return 0;
     }
@@ -121,11 +121,14 @@ static TSK_VS_INFO *
 castVsInfo(JNIEnv * env, jlong ptr)
 {
     TSK_VS_INFO *lcl = (TSK_VS_INFO *) ptr;
-    if (lcl->tag != TSK_VS_INFO_TAG) {
+    if (!lcl || lcl->tag != TSK_VS_INFO_TAG) {
         setThrowTskCoreError(env, "Invalid VS_INFO object");
         return 0;
     }
-
+    // verify that image handle is still open
+    if (!castImgInfo(env, (jlong) lcl->img_info)) {
+        return 0;
+    }
     return lcl;
 }
 
@@ -133,11 +136,14 @@ static TSK_VS_PART_INFO *
 castVsPartInfo(JNIEnv * env, jlong ptr)
 {
     TSK_VS_PART_INFO *lcl = (TSK_VS_PART_INFO *) ptr;
-    if (lcl->tag != TSK_VS_PART_INFO_TAG) {
+    if (!lcl || lcl->tag != TSK_VS_PART_INFO_TAG) {
         setThrowTskCoreError(env, "Invalid VS_PART_INFO object");
         return 0;
     }
-
+    // verify that all handles are still open
+    if (!castVsInfo(env, (jlong) lcl->vs)) {
+        return 0;
+    }
     return lcl;
 }
 
@@ -145,8 +151,12 @@ static TSK_FS_INFO *
 castFsInfo(JNIEnv * env, jlong ptr)
 {
     TSK_FS_INFO *lcl = (TSK_FS_INFO *) ptr;
-    if (lcl->tag != TSK_FS_INFO_TAG) {
+    if (!lcl || lcl->tag != TSK_FS_INFO_TAG) {
         setThrowTskCoreError(env, "Invalid FS_INFO object");
+        return 0;
+    }
+    // verify that image handle is still open
+    if (!castImgInfo(env, (jlong) lcl->img_info)) {
         return 0;
     }
     return lcl;
@@ -157,8 +167,12 @@ static TSK_JNI_FILEHANDLE *
 castFsFile(JNIEnv * env, jlong ptr)
 {
     TSK_JNI_FILEHANDLE *lcl = (TSK_JNI_FILEHANDLE *) ptr;
-    if (lcl->tag != TSK_JNI_FILEHANDLE_TAG) {
+    if (!lcl || lcl->tag != TSK_JNI_FILEHANDLE_TAG) {
         setThrowTskCoreError(env, "Invalid TSK_JNI_FILEHANDLE object");
+        return 0;
+    }
+    // verify that all handles are still open
+    if (!lcl->fs_file || !castFsInfo(env, (jlong) lcl->fs_file->fs_info)) {
         return 0;
     }
     return lcl;
@@ -168,7 +182,7 @@ static TskCaseDb *
 castCaseDb(JNIEnv * env, jlong ptr)
 {
     TskCaseDb *lcl = ((TskCaseDb *) ptr);
-    if (lcl->m_tag != TSK_CASE_DB_TAG) {
+    if (!lcl || lcl->m_tag != TSK_CASE_DB_TAG) {
         setThrowTskCoreError(env,
             "Invalid TskCaseDb object");
         return 0;

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -197,8 +197,12 @@ public class SleuthkitJNI {
 				for (Map.Entry<String, Long> imageHandleMap : imageHandleCache.entrySet()){
 					closeImgNat(imageHandleMap.getValue()); 
 				}
-				
+
 				// clear both maps
+				/* NOTE: it is possible to close a case while ingest is going in the background.
+				 In this scenario it is possible for an igest module to try to read from source image.
+				 If this happens, image will be re-opened in a normal manner.
+				 */
 				fsHandleCache.clear();
 				imageHandleCache.clear();
 			}

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -173,7 +173,8 @@ public class SleuthkitJNI {
 		}
 
 		/**
-		 * Close the case database as well as close all open image and file system handles.
+		 * Close the case database as well as close all open image and file
+		 * system handles.
 		 *
 		 * @throws TskCoreException exception thrown if critical error occurs
 		 * within TSK
@@ -182,19 +183,17 @@ public class SleuthkitJNI {
 			synchronized (cacheLock) {
 				// close all file system handles 
 				// loop over all images for which we have opened a file system
-				for (Map<Long, Long> imageToFsMap : fsHandleCache.values())
-				{
+				for (Map<Long, Long> imageToFsMap : fsHandleCache.values()) {
 					// for each image loop over all file systems open as part of that image
-					for (Long fsHandle : imageToFsMap.values())
-					{
+					for (Long fsHandle : imageToFsMap.values()) {
 						// close the file system handle
 						closeFsNat(fsHandle);
 					}
 				}
 
 				// close all open image handles
-				for (Long imageHandle : imageHandleCache.values()){
-					closeImgNat(imageHandle); 
+				for (Long imageHandle : imageHandleCache.values()) {
+					closeImgNat(imageHandle);
 				}
 
 				// clear both maps
@@ -205,7 +204,7 @@ public class SleuthkitJNI {
 				fsHandleCache.clear();
 				imageHandleCache.clear();
 			}
-			
+
 			SleuthkitJNI.closeCaseDbNat(caseDbPointer);
 		}
 
@@ -437,9 +436,7 @@ public class SleuthkitJNI {
 				CaseDbHandle.imageHandleCache.put(imageKey, imageHandle);
 			}
 		}
-
 		return imageHandle;
-
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -181,19 +181,26 @@ public class SleuthkitJNI {
 		void free() throws TskCoreException {
 			synchronized (cacheLock) {
 				// close all file system handles 
+				// loop over all images for which we have opened a file system
 				for (Map.Entry<Long, Map<Long, Long>> imageToFsMap : fsHandleCache.entrySet())
 				{
 					Map<Long, Long> imgOffSetToFsHandle = imageToFsMap.getValue();
+					// for each image loop over all file systems open as part of that image
 					for (Map.Entry<Long, Long> fsHandleMap : imgOffSetToFsHandle.entrySet())
 					{
+						// close the file system
 						closeFsNat(fsHandleMap.getValue());
 					}
-					//System.out.println(entry.getKey() + "/" + entry.getValue());
 				}
 
 				// close all open image handles
+				for (Map.Entry<String, Long> imageHandleMap : imageHandleCache.entrySet()){
+					closeImgNat(imageHandleMap.getValue()); 
+				}
 				
 				// clear both maps
+				fsHandleCache.clear();
+				imageHandleCache.clear();
 			}
 			
 			SleuthkitJNI.closeCaseDbNat(caseDbPointer);

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -182,20 +182,19 @@ public class SleuthkitJNI {
 			synchronized (cacheLock) {
 				// close all file system handles 
 				// loop over all images for which we have opened a file system
-				for (Map.Entry<Long, Map<Long, Long>> imageToFsMap : fsHandleCache.entrySet())
+				for (Map<Long, Long> imageToFsMap : fsHandleCache.values())
 				{
-					Map<Long, Long> imgOffSetToFsHandle = imageToFsMap.getValue();
 					// for each image loop over all file systems open as part of that image
-					for (Map.Entry<Long, Long> fsHandleMap : imgOffSetToFsHandle.entrySet())
+					for (Long fsHandle : imageToFsMap.values())
 					{
-						// close the file system
-						closeFsNat(fsHandleMap.getValue());
+						// close the file system handle
+						closeFsNat(fsHandle);
 					}
 				}
 
 				// close all open image handles
-				for (Map.Entry<String, Long> imageHandleMap : imageHandleCache.entrySet()){
-					closeImgNat(imageHandleMap.getValue()); 
+				for (Long imageHandle : imageHandleCache.values()){
+					closeImgNat(imageHandle); 
 				}
 
 				// clear both maps


### PR DESCRIPTION
* Whenever case is closed close all cached images and file systems. This will free open image file handles as well as free memory allocated to TSK_IMG_INFO and TSK_FS_INFO structures themselves.
* When a call to TSK is made, walk the entire chain of TSK structures (from TSK_FS_FILE to TSK_IMG_INFO) each time to verify that everything down to TSK_IMG_INFO is still open.
