### PR TITLE
Added --disable-multithreading option to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,13 @@ AX_PTHREAD([
     LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
     CC="$PTHREAD_CC"],[])
 
+dnl Permit single-threaded builds
+AC_ARG_ENABLE([multithreading],
+    [AS_HELP_STRING([--disable-multithreading], [Build without multithreading support])])
+
+dnl Enable multithreading by default in the presence of pthread
+AS_IF([test "x$ax_pthread_ok" = "xyes" && test "x$enable_multithreading" != "xno"], [ax_multithread=yes], [ax_multithread=no])
+
 case "$host" in
 *-*-mingw*)
   dnl Adding the native /usr/local is wrong for cross-compiling
@@ -275,8 +282,8 @@ AC_CONFIG_COMMANDS([tsk/tsk_incs.h],
         echo "#include <sys/param.h>" >> tsk/tsk_incs.h
     fi
 
-    if test x$ax_pthread_ok = xyes; then
-        echo "#define TSK_MULTITHREAD_LIB // set because we have pthreads" >> tsk/tsk_incs.h
+    if test x$ax_multithread = xyes; then
+        echo "#define TSK_MULTITHREAD_LIB // enable multithreading" >> tsk/tsk_incs.h
     fi
 
     echo "" >> tsk/tsk_incs.h
@@ -345,5 +352,6 @@ Building:
 
 Features:
    Java/JNI support:                      $ax_java_support
+   Multithreading:                        $ax_multithread
 ]);
 


### PR DESCRIPTION
Added --disable-multithreading option to configure.ac to permit the disabling of multithreading. This prevents TSK_MULTITHREAD_LIB from being defined when pthread is available.