### PR TITLE
Avoid splitting up parts of statements with conditional directives.

### DIFF
--- a/tsk/img/ewf.c
+++ b/tsk/img/ewf.c
@@ -196,6 +196,7 @@ TSK_IMG_INFO *
 ewf_open(int a_num_img,
     const TSK_TCHAR * const a_images[], unsigned int a_ssize)
 {
+    int is_error;
 #if defined( HAVE_LIBEWF_V2_API )
     char error_string[TSK_EWF_ERROR_STRING_SIZE];
 
@@ -225,14 +226,15 @@ ewf_open(int a_num_img,
     if (a_num_img == 1) {
 #if defined( HAVE_LIBEWF_V2_API)
 #ifdef TSK_WIN32
-        if (libewf_glob_wide(a_images[0], TSTRLEN(a_images[0]),
+        is_error = (libewf_glob_wide(a_images[0], TSTRLEN(a_images[0]),
                 LIBEWF_FORMAT_UNKNOWN, &ewf_info->images,
-                &ewf_info->num_imgs, &ewf_error) == -1) {
+                &ewf_info->num_imgs, &ewf_error) == -1);
 #else
-        if (libewf_glob(a_images[0], TSTRLEN(a_images[0]),
+        is_error = (libewf_glob(a_images[0], TSTRLEN(a_images[0]),
                 LIBEWF_FORMAT_UNKNOWN, &ewf_info->images,
-                &ewf_info->num_imgs, &ewf_error) == -1) {
+                &ewf_info->num_imgs, &ewf_error) == -1);
 #endif
+        if (is_error){
             tsk_error_reset();
             tsk_error_set_errno(TSK_ERR_IMG_MAGIC);
 
@@ -297,10 +299,11 @@ ewf_open(int a_num_img,
 
     // Check the file signature before we call the library open
 #if defined( TSK_WIN32 )
-    if (libewf_check_file_signature_wide(a_images[0], &ewf_error) != 1)
+    is_error = (libewf_check_file_signature_wide(a_images[0], &ewf_error) != 1);
 #else
-    if (libewf_check_file_signature(a_images[0], &ewf_error) != 1)
+    is_error = (libewf_check_file_signature(a_images[0], &ewf_error) != 1);
 #endif
+    if (is_error)
     {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_MAGIC);
@@ -335,14 +338,15 @@ ewf_open(int a_num_img,
         return (NULL);
     }
 #if defined( TSK_WIN32 )
-    if (libewf_handle_open_wide(ewf_info->handle,
+    is_error = (libewf_handle_open_wide(ewf_info->handle,
             (wchar_t * const *) ewf_info->images,
-            ewf_info->num_imgs, LIBEWF_OPEN_READ, &ewf_error) != 1)
+            ewf_info->num_imgs, LIBEWF_OPEN_READ, &ewf_error) != 1);
 #else
-    if (libewf_handle_open(ewf_info->handle,
+    is_error = (libewf_handle_open(ewf_info->handle,
             (char *const *) ewf_info->images,
-            ewf_info->num_imgs, LIBEWF_OPEN_READ, &ewf_error) != 1)
+            ewf_info->num_imgs, LIBEWF_OPEN_READ, &ewf_error) != 1);
 #endif
+    if (is_error)
     {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_OPEN);
@@ -403,10 +407,11 @@ ewf_open(int a_num_img,
 
     // Check the file signature before we call the library open
 #if defined( TSK_WIN32 )
-    if (libewf_check_file_signature_wide(a_images[0]) != 1)
+    is_error = (libewf_check_file_signature_wide(a_images[0]) != 1);
 #else
-    if (libewf_check_file_signature(a_images[0]) != 1)
+    is_error = (libewf_check_file_signature(a_images[0]) != 1);
 #endif
+    if (is_error)
     {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_MAGIC);


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.