### PR TITLE
Added tsk_img_open_external for setting up handles for external image types

### DIFF
--- a/tests/fs_attrlist_apis.cpp
+++ b/tests/fs_attrlist_apis.cpp
@@ -118,8 +118,8 @@ test_get_apis(TSK_FS_INFO * a_fs, TSK_INUM_T a_addr, int a_len)
 
         if (fs_attr != fs_attr2) {
             fprintf(stderr,
-                "Attribute from get_type not same addr as original %lu vs %lu from %"
-                PRIuINUM "\n", (unsigned long)fs_attr, (unsigned long)fs_attr2, a_addr);
+                "Attribute from get_type not same addr as original %p vs %p from %"
+                PRIuINUM "\n", fs_attr, fs_attr2, a_addr);
             tsk_error_print(stderr);
             return 1;
         }

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -216,7 +216,8 @@ aff_close(TSK_IMG_INFO * img_info)
 {
     IMG_AFF_INFO *aff_info = (IMG_AFF_INFO *) img_info;
     af_close(aff_info->af_file);
-    tsk_img_free(aff_info);
+    img_info->tag = 0;
+    free(aff_info);
 }
 
 

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -216,8 +216,7 @@ aff_close(TSK_IMG_INFO * img_info)
 {
     IMG_AFF_INFO *aff_info = (IMG_AFF_INFO *) img_info;
     af_close(aff_info->af_file);
-    img_info->tag = 0;
-    free(aff_info);
+    tsk_img_free(aff_info);
 }
 
 

--- a/tsk/img/ewf.c
+++ b/tsk/img/ewf.c
@@ -144,8 +144,7 @@ ewf_image_close(TSK_IMG_INFO * img_info)
     }
 
     tsk_deinit_lock(&(ewf_info->read_lock));
-    img_info->tag = 0;
-    free(ewf_info);
+    tsk_img_free(ewf_info);
 }
 
 /* Tests if the image file header against the

--- a/tsk/img/ewf.c
+++ b/tsk/img/ewf.c
@@ -144,7 +144,8 @@ ewf_image_close(TSK_IMG_INFO * img_info)
     }
 
     tsk_deinit_lock(&(ewf_info->read_lock));
-    tsk_img_free(img_info);
+    img_info->tag = 0;
+    free(ewf_info);
 }
 
 /* Tests if the image file header against the

--- a/tsk/img/img_open.c
+++ b/tsk/img/img_open.c
@@ -317,7 +317,7 @@ tsk_img_open_utf8(int num_img,
         free(images16);
 
         if (retval) {
-            tsk_init_lock(&(img_info->cache_lock));
+            tsk_init_lock(&(retval->cache_lock));
         }
         return retval;
     }

--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -370,8 +370,7 @@ raw_close(TSK_IMG_INFO * img_info)
     if (raw_info->cptr)
         free(raw_info->cptr);
 
-    img_info->tag = 0;
-    free(raw_info);
+    tsk_img_free(raw_info);
 }
 
 
@@ -728,7 +727,7 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
 }
 
 
-/* tsk_img_malloc - init lock after tsk_malloc 
+/* tsk_img_malloc - tsk_malloc, then set image tag
  * This is for img module and all its inheritances
  */
 void *
@@ -737,25 +736,18 @@ tsk_img_malloc(size_t a_len)
     TSK_IMG_INFO *imgInfo;
     if ((imgInfo = (TSK_IMG_INFO *) tsk_malloc(a_len)) == NULL)
         return NULL;
-    //init lock
-    tsk_init_lock(&(imgInfo->cache_lock));
     imgInfo->tag = TSK_IMG_INFO_TAG;
-
     return (void *) imgInfo;
 }
 
 
-/* tsk_img_free - deinit lock  before free memory 
+/* tsk_img_free - unset image tag, then free memory
  * This is for img module and all its inheritances
  */
 void
 tsk_img_free(void *a_ptr)
 {
     TSK_IMG_INFO *imgInfo = (TSK_IMG_INFO *) a_ptr;
-
-    //deinit lock
-    tsk_deinit_lock(&(imgInfo->cache_lock));
     imgInfo->tag = 0;
-
     free(imgInfo);
 }

--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -370,7 +370,8 @@ raw_close(TSK_IMG_INFO * img_info)
     if (raw_info->cptr)
         free(raw_info->cptr);
 
-    tsk_img_free(raw_info);
+    img_info->tag = 0;
+    free(raw_info);
 }
 
 

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -93,7 +93,7 @@ extern "C" {
         int cache_age[TSK_IMG_INFO_CACHE_NUM];  ///< "Age" of corresponding cache entry, higher means more recently used (r/w shared - lock) 
         size_t cache_len[TSK_IMG_INFO_CACHE_NUM];       ///< Length of cache entry used (0 if never used) (r/w shared - lock) 
 
-         ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len);     ///< \internal External progs should call tsk_img_read()
+        ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len);     ///< \internal External progs should call tsk_img_read()
         void (*close) (TSK_IMG_INFO *); ///< \internal Progs should call tsk_img_close()
         void (*imgstat) (TSK_IMG_INFO *, FILE *);       ///< Pointer to file type specific function
     };
@@ -109,6 +109,11 @@ extern "C" {
     extern TSK_IMG_INFO *tsk_img_open_utf8(int num_img,
         const char *const images[], TSK_IMG_TYPE_ENUM type,
         unsigned int a_ssize);
+    extern TSK_IMG_INFO *tsk_img_open_external(void* ext_img_info,
+        TSK_OFF_T size, unsigned int sector_size,
+        ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len),
+        void (*close) (TSK_IMG_INFO *),
+        void (*imgstat) (TSK_IMG_INFO *, FILE *));
     extern void tsk_img_close(TSK_IMG_INFO *);
 
     // read functions


### PR DESCRIPTION
This patch adds tsk_img_open_external, which eases the setup of `TSK_IMG_INFO`s of type `TSK_IMG_TYPE_EXTERNAL` and---most importantly---ensures that the cache lock is initialized and deinitialized as appropriate. (It wasn't possible to handle the cache lock properly for external types before, due to the locking functions being internal to libtsk.)

There's also a one-line fix for two bad casts in tests/fs_attrlist_apis.cpp, which prevented compilation under MinGW.