### PR TITLE
Two small bug fixes

### DIFF
--- a/tsk/auto/auto_db.cpp
+++ b/tsk/auto/auto_db.cpp
@@ -139,7 +139,7 @@ uint8_t
  * @param a_images Array of paths to the image parts
  * @param a_type Image type
  * @param a_ssize Size of device sector in bytes (or 0 for default)
- * @param dataSourceId An ASCII-printable identifier for the data source that is intended to be unique across multiple cases (e.g., a UUID)
+ * @param a_dataSourceId An ASCII-printable identifier for the data source that is intended to be unique across multiple cases (e.g., a UUID)
  * @return 0 for success, 1 for failure
  */
 uint8_t
@@ -200,7 +200,7 @@ uint8_t
 
     return 0;
 #else
-    return openImageUtf8(a_num, a_images, a_type, a_ssize, dataSourceId);
+    return openImageUtf8(a_num, a_images, a_type, a_ssize, a_dataSourceId);
 #endif
 }
 

--- a/tsk/img/ewf.c
+++ b/tsk/img/ewf.c
@@ -34,9 +34,7 @@ getError(libewf_error_t * ewf_error,
     error_string[0] = '\0';
     retval = libewf_error_backtrace_sprint(ewf_error,
         error_string, TSK_EWF_ERROR_STRING_SIZE);
-    if (retval)
-        return 1;
-    return 0;
+    return retval <= 0;
 }
 #endif
 


### PR DESCRIPTION
Two bug fixes:

1. `getError` is intended to return 1 if there is no error message from libewf. That can happen when `libewf_error_backtrace_sprint` sets an empty message and returns 0 OR has an error and returns -1. Thus the correct return condition for getError is `retval <= 0`, not `retval`.

2. `dataSourceId` should be `a_dataSourceId` otherwise auto_db.cpp doesn't compile.