### PR TITLE
Java bindings update for tsk_files.data_source_obj_id

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -556,7 +556,7 @@ public abstract class AbstractFile extends AbstractContent {
 	}
 
 	/**
-	 * Gets the data source (image, virtual directory, etc.) for this file.
+	 * Gets the data source for this file.
 	 *
 	 * @return The data source.
 	 * @throws TskCoreException if there was an error querying the case
@@ -577,8 +577,7 @@ public abstract class AbstractFile extends AbstractContent {
 	}
 
 	/**
-	 * Gets the object id of the data source (image, virtual directory, etc.)
-	 * for this file.
+	 * Gets the object id of the data source for this file.
 	 *
 	 * @return The object id of the data source.
 	 */

--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -107,7 +107,7 @@ public abstract class AbstractFile extends AbstractContent {
 	 * @param knownState knownState status of the file, or null if unknown
 	 * (default)
 	 * @param parentPath
-	 * @deprecated Do not make public subclasses of AbstractFile outside of this
+	 * @deprecated Do not make subclasses of AbstractFile outside of this
 	 * package.
 	 */
 	@Deprecated
@@ -556,8 +556,7 @@ public abstract class AbstractFile extends AbstractContent {
 	}
 
 	/**
-	 * Gets the root data source (image, virtual directory, etc.) of this
-	 * content.
+	 * Gets the root data source (image, virtual directory, etc.) of this file.
 	 *
 	 * @return Content associated with data source.
 	 * @throws TskCoreException if there was an error querying the case
@@ -566,12 +565,26 @@ public abstract class AbstractFile extends AbstractContent {
 	@Override
 	public Content getDataSource() throws TskCoreException {
 		if (0 == this.dataSourceObjectId) {
+			// This lazy initialization is used to support the deprecated 
+			// protected constructor of this class and its known subclasses and 
+			// should be removed when that constructor is removed and 
+			// subclassing outside of this package is prohibited. 
 			Content dataSource = super.getDataSource();
 			this.dataSourceObjectId = dataSource.getId();
 			return dataSource;
 		} else {
 			return getSleuthkitCase().getContentById(this.dataSourceObjectId);
 		}
+	}
+
+	/**
+	 * Gets the root data source (image, virtual directory, etc.) object id of
+	 * this file.
+	 *
+	 * @return The root data source object id.
+	 */
+	long getDataSourceObjectId() {
+		return dataSourceObjectId;
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -556,9 +556,9 @@ public abstract class AbstractFile extends AbstractContent {
 	}
 
 	/**
-	 * Gets the root data source (image, virtual directory, etc.) of this file.
+	 * Gets the data source (image, virtual directory, etc.) for this file.
 	 *
-	 * @return Content associated with data source.
+	 * @return The data source.
 	 * @throws TskCoreException if there was an error querying the case
 	 * database.
 	 */
@@ -567,8 +567,7 @@ public abstract class AbstractFile extends AbstractContent {
 		if (0 == this.dataSourceObjectId) {
 			// This lazy initialization is used to support the deprecated 
 			// protected constructor of this class and its known subclasses and 
-			// should be removed when that constructor is removed and 
-			// subclassing outside of this package is prohibited. 
+			// should be removed when that constructor is removed. 
 			Content dataSource = super.getDataSource();
 			this.dataSourceObjectId = dataSource.getId();
 			return dataSource;
@@ -578,10 +577,10 @@ public abstract class AbstractFile extends AbstractContent {
 	}
 
 	/**
-	 * Gets the root data source (image, virtual directory, etc.) object id of
-	 * this file.
+	 * Gets the object id of the data source (image, virtual directory, etc.)
+	 * for this file.
 	 *
-	 * @return The root data source object id.
+	 * @return The object id of the data source.
 	 */
 	long getDataSourceObjectId() {
 		return dataSourceObjectId;

--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -566,8 +566,8 @@ public abstract class AbstractFile extends AbstractContent {
 	public Content getDataSource() throws TskCoreException {
 		if (0 == this.dataSourceObjectId) {
 			// This lazy initialization is used to support the deprecated 
-			// protected constructor of this class and its known subclasses and 
-			// should be removed when that constructor is removed. 
+			// protected constructor of this class and any unknown subclasses
+			// and should be removed when that constructor is removed. 
 			Content dataSource = super.getDataSource();
 			this.dataSourceObjectId = dataSource.getId();
 			return dataSource;

--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  * 
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,6 +77,7 @@ public abstract class AbstractFile extends AbstractContent {
 	private String mimeType;
 	private static final Logger logger = Logger.getLogger(AbstractFile.class.getName());
 	private static final ResourceBundle bundle = ResourceBundle.getBundle("org.sleuthkit.datamodel.Bundle");
+	private long dataSourceObjectId;
 
 	/**
 	 * Initializes common fields used by AbstactFile implementations (objects in
@@ -106,13 +107,16 @@ public abstract class AbstractFile extends AbstractContent {
 	 * @param knownState knownState status of the file, or null if unknown
 	 * (default)
 	 * @param parentPath
+	 * @deprecated Do not make public subclasses of AbstractFile outside of this
+	 * package.
 	 */
+	@Deprecated
 	protected AbstractFile(SleuthkitCase db, long objId, TskData.TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
 			String name, TskData.TSK_DB_FILES_TYPE_ENUM fileType, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
 			String parentPath) {
-		this(db, objId, attrType, attrId, name, fileType, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime,mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+		this(db, objId, 0, attrType, attrId, name, fileType, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
 
 	/**
@@ -121,6 +125,8 @@ public abstract class AbstractFile extends AbstractContent {
 	 *
 	 * @param db case / db handle where this file belongs to
 	 * @param objId object id in tsk_objects table
+	 * @param dataSourceObjectId The object id of the root data source of this
+	 * file.
 	 * @param attrType
 	 * @param attrId
 	 * @param name name field of the file
@@ -145,12 +151,13 @@ public abstract class AbstractFile extends AbstractContent {
 	 * @param parentPath
 	 * @param mimeType The MIME type of the file, can be null
 	 */
-	protected AbstractFile(SleuthkitCase db, long objId, TskData.TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+	AbstractFile(SleuthkitCase db, long objId, long dataSourceObjectId, TskData.TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
 			String name, TskData.TSK_DB_FILES_TYPE_ENUM fileType, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
 			String parentPath, String mimeType) {
 		super(db, objId, name);
+		this.dataSourceObjectId = dataSourceObjectId;
 		this.attrType = attrType;
 		this.attrId = attrId;
 		this.fileType = fileType;
@@ -546,6 +553,25 @@ public abstract class AbstractFile extends AbstractContent {
 	 */
 	public String getParentPath() {
 		return parentPath;
+	}
+
+	/**
+	 * Gets the root data source (image, virtual directory, etc.) of this
+	 * content.
+	 *
+	 * @return Content associated with data source.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
+	@Override
+	public Content getDataSource() throws TskCoreException {
+		if (0 == this.dataSourceObjectId) {
+			Content dataSource = super.getDataSource();
+			this.dataSourceObjectId = dataSource.getId();
+			return dataSource;
+		} else {
+			return getSleuthkitCase().getContentById(this.dataSourceObjectId);
+		}
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/Content.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Content.java
@@ -91,7 +91,8 @@ public interface Content extends SleuthkitVisitableItem {
 	public long getId();
 
 	/**
-	 * Get the root data source of this content (image, virtual directory, etc.)
+	 * Gets the root data source (image, virtual directory, etc.) of this
+	 * content.
 	 *
 	 * @return Content associated with data source or null if one can't be found
 	 * @throws TskCoreException if critical error occurred within tsk core

--- a/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
@@ -74,13 +74,10 @@ public class DerivedFile extends AbstractFile {
 	protected DerivedFile(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId) {
-
-		super(db, objId, 0, TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
-				name, TSK_DB_FILES_TYPE_ENUM.LOCAL, 0L, 0, dirType, metaType, dirFlag,
-				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
-
-		//use the local path read infrastructure
-		setLocalPath(localPath, false); //local paths for derived files are relative to case db
+		this(db, objId, 0, name, dirType, metaType, dirFlag, metaFlags, size,
+				ctime, crtime, atime, mtime,
+				md5Hash, knownState,
+				parentPath, localPath, parentId, null);
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  * 
- * Copyright 2013 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,23 +67,29 @@ public class DerivedFile extends AbstractFile {
 	 * file, or another derived file path)
 	 * @param localPath local path of this derived file, relative to the db path
 	 * @param parentId parent id of this derived file to set if available
+	 * @deprecated Do not make public subclasses of DerivedFile outside of this
+	 * package.
 	 */
+	@Deprecated
 	protected DerivedFile(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId) {
 
-		super(db, objId, TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
+		super(db, objId, 0, TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, TSK_DB_FILES_TYPE_ENUM.LOCAL, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
 
 		//use the local path read infrastructure
 		setLocalPath(localPath, false); //local paths for derived files are relative to case db
 	}
+	
 	/**
 	 * Create a db representation of a derived file
 	 *
 	 * @param db
 	 * @param objId object if of this file already in database
+	 * @param dataSourceObjectId The object id of the root data source of this
+	 * file.
 	 * @param name name of this derived file
 	 * @param dirType
 	 * @param metaType
@@ -101,11 +107,11 @@ public class DerivedFile extends AbstractFile {
 	 * @param localPath local path of this derived file, relative to the db path
 	 * @param parentId parent id of this derived file to set if available
 	 */
-	protected DerivedFile(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
+	DerivedFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId, String mimeType) {
 
-		super(db, objId, TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
+		super(db, objId, dataSourceObjectId, TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, TSK_DB_FILES_TYPE_ENUM.LOCAL, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);
 

--- a/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
@@ -67,7 +67,7 @@ public class DerivedFile extends AbstractFile {
 	 * file, or another derived file path)
 	 * @param localPath local path of this derived file, relative to the db path
 	 * @param parentId parent id of this derived file to set if available
-	 * @deprecated Do not make public subclasses of DerivedFile outside of this
+	 * @deprecated Do not make subclasses of DerivedFile outside of this
 	 * package.
 	 */
 	@Deprecated
@@ -82,7 +82,7 @@ public class DerivedFile extends AbstractFile {
 		//use the local path read infrastructure
 		setLocalPath(localPath, false); //local paths for derived files are relative to case db
 	}
-	
+
 	/**
 	 * Create a db representation of a derived file
 	 *

--- a/bindings/java/src/org/sleuthkit/datamodel/Directory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Directory.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  * 
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,10 @@ public class Directory extends FsContent {
 	 * @param md5Hash
 	 * @param knownState
 	 * @param parentPath
+	 * @deprecated Do not make public subclasses of Directory outside of this
+	 * package.
 	 */
+	@Deprecated
 	protected Directory(SleuthkitCase db, long objId, long fsObjId,
 			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
 			String name, long metaAddr, int metaSeq,
@@ -66,7 +69,17 @@ public class Directory extends FsContent {
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes,
 			int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath);
+		super(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+	}
+
+	Directory(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId,
+			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+			String name, long metaAddr, int metaSeq,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size, long ctime, long crtime, long atime, long mtime, short modes,
+			int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
+		super(db, objId, dataSourceObjectId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
 
 	@Override

--- a/bindings/java/src/org/sleuthkit/datamodel/Directory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Directory.java
@@ -58,8 +58,7 @@ public class Directory extends FsContent {
 	 * @param md5Hash
 	 * @param knownState
 	 * @param parentPath
-	 * @deprecated Do not make public subclasses of Directory outside of this
-	 * package.
+	 * @deprecated Do not make subclasses of Directory outside of this package.
 	 */
 	@Deprecated
 	protected Directory(SleuthkitCase db, long objId, long fsObjId,

--- a/bindings/java/src/org/sleuthkit/datamodel/Directory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Directory.java
@@ -68,7 +68,7 @@ public class Directory extends FsContent {
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes,
 			int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+		this(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath);
 	}
 
 	Directory(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId,

--- a/bindings/java/src/org/sleuthkit/datamodel/File.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/File.java
@@ -67,7 +67,7 @@ public class File extends FsContent {
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime,
 			short modes, int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+		this(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
 
 	File(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId,

--- a/bindings/java/src/org/sleuthkit/datamodel/File.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/File.java
@@ -18,7 +18,6 @@
  */
 package org.sleuthkit.datamodel;
 
-import java.util.Collections;
 import java.util.List;
 import org.sleuthkit.datamodel.TskData.FileKnown;
 import org.sleuthkit.datamodel.TskData.TSK_FS_ATTR_TYPE_ENUM;
@@ -59,8 +58,7 @@ public class File extends FsContent {
 	 * @param md5Hash
 	 * @param knownState
 	 * @param parentPath
-	 * @deprecated Do not make public subclasses of File outside of this
-	 * package.
+	 * @deprecated Do not make subclasses of File outside of this package.
 	 */
 	@Deprecated
 	protected File(SleuthkitCase db, long objId, long fsObjId,

--- a/bindings/java/src/org/sleuthkit/datamodel/File.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/File.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  * 
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,22 +59,26 @@ public class File extends FsContent {
 	 * @param md5Hash
 	 * @param knownState
 	 * @param parentPath
+	 * @deprecated Do not make public subclasses of File outside of this
+	 * package.
 	 */
+	@Deprecated
 	protected File(SleuthkitCase db, long objId, long fsObjId,
 			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId, String name, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime,
 			short modes, int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath);
+		super(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
-	protected File(SleuthkitCase db, long objId, long fsObjId,
+
+	File(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId,
 			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId, String name, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime,
 			short modes, int uid, int gid, String md5Hash, FileKnown knownState, String parentPath, String mimeType) {
-		super(db, objId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, mimeType);
+		super(db, objId, dataSourceObjectId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, mimeType);
 	}
 
 	@Override

--- a/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
@@ -83,8 +83,7 @@ public abstract class FsContent extends AbstractFile {
 	 * @param md5Hash String of MD5 hash of content or null if not known
 	 * @param knownState
 	 * @param parentPath
-	 * @deprecated Do not make public subclasses of FsContent outside of this
-	 * package.
+	 * @deprecated Do not make subclasses of FsContent outside of this package.
 	 */
 	@Deprecated
 	FsContent(SleuthkitCase db, long objId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,

--- a/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  * 
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,22 +83,26 @@ public abstract class FsContent extends AbstractFile {
 	 * @param md5Hash String of MD5 hash of content or null if not known
 	 * @param knownState
 	 * @param parentPath
+	 * @deprecated Do not make public subclasses of FsContent outside of this
+	 * package.
 	 */
+	@Deprecated
 	FsContent(SleuthkitCase db, long objId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
 			String name, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
 			String parentPath) {
-		super(db, objId, attrType, attrId, name, TskData.TSK_DB_FILES_TYPE_ENUM.FS, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+		super(db, objId, 0, attrType, attrId, name, TskData.TSK_DB_FILES_TYPE_ENUM.FS, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 		this.tskCase = db;
 		this.fsObjId = fsObjId;
 	}
-	FsContent(SleuthkitCase db, long objId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+
+	FsContent(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
 			String name, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
 			String parentPath, String mimeType) {
-		super(db, objId, attrType, attrId, name, TskData.TSK_DB_FILES_TYPE_ENUM.FS, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, mimeType);
+		super(db, objId, dataSourceObjectId, attrType, attrId, name, TskData.TSK_DB_FILES_TYPE_ENUM.FS, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, mimeType);
 		this.tskCase = db;
 		this.fsObjId = fsObjId;
 	}

--- a/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
@@ -91,9 +91,7 @@ public abstract class FsContent extends AbstractFile {
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
 			String parentPath) {
-		super(db, objId, 0, attrType, attrId, name, TskData.TSK_DB_FILES_TYPE_ENUM.FS, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
-		this.tskCase = db;
-		this.fsObjId = fsObjId;
+		this(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
 
 	FsContent(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,

--- a/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  * 
- * Copyright 2011 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,12 +46,41 @@ public class LayoutFile extends AbstractFile {
 
 	private long imageHandle = -1;
 
+	/**
+	 * Constructs a layout file.
+	 * 
+	 * @param db
+	 * @param objId
+	 * @param name
+	 * @param fileType
+	 * @param dirType
+	 * @param metaType
+	 * @param dirFlag
+	 * @param metaFlags
+	 * @param size
+	 * @param md5Hash
+	 * @param knownState
+	 * @param parentPath
+	 * @deprecated
+	 * @deprecated Do not make public subclasses of LayoutFile outside of this
+	 * package.
+	 */
+	@Deprecated
 	protected LayoutFile(SleuthkitCase db, long objId, String name,
 			TSK_DB_FILES_TYPE_ENUM fileType,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name, fileType, 0L, 0, dirType, metaType, dirFlag, metaFlags, size, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
+		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name, fileType, 0L, 0, dirType, metaType, dirFlag, metaFlags, size, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
+		//this.size = calcSize(); //update calculated size
+	}
+
+	LayoutFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name,
+			TSK_DB_FILES_TYPE_ENUM fileType,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size, String md5Hash, FileKnown knownState, String parentPath) {
+		super(db, objId, dataSourceObjectId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name, fileType, 0L, 0, dirType, metaType, dirFlag, metaFlags, size, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
 		//this.size = calcSize(); //update calculated size
 	}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
@@ -48,7 +48,7 @@ public class LayoutFile extends AbstractFile {
 
 	/**
 	 * Constructs a layout file.
-	 * 
+	 *
 	 * @param db
 	 * @param objId
 	 * @param name
@@ -62,8 +62,7 @@ public class LayoutFile extends AbstractFile {
 	 * @param knownState
 	 * @param parentPath
 	 * @deprecated
-	 * @deprecated Do not make public subclasses of LayoutFile outside of this
-	 * package.
+	 * @deprecated Do not make subclasses of LayoutFile outside of this package.
 	 */
 	@Deprecated
 	protected LayoutFile(SleuthkitCase db, long objId, String name,

--- a/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
@@ -70,8 +70,7 @@ public class LayoutFile extends AbstractFile {
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name, fileType, 0L, 0, dirType, metaType, dirFlag, metaFlags, size, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
-		//this.size = calcSize(); //update calculated size
+		this(db, objId, 0, name, fileType, dirType, metaType, dirFlag, metaFlags, size, md5Hash, knownState, parentPath);
 	}
 
 	LayoutFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name,
@@ -80,7 +79,6 @@ public class LayoutFile extends AbstractFile {
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, String md5Hash, FileKnown knownState, String parentPath) {
 		super(db, objId, dataSourceObjectId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name, fileType, 0L, 0, dirType, metaType, dirFlag, metaFlags, size, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
-		//this.size = calcSize(); //update calculated size
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
@@ -20,7 +20,6 @@ package org.sleuthkit.datamodel;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 import org.sleuthkit.datamodel.TskData.FileKnown;
 import org.sleuthkit.datamodel.TskData.TSK_DB_FILES_TYPE_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_ATTR_TYPE_ENUM;
@@ -32,8 +31,6 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
  * Represents a local file (on user's machine) that has been added to the case
  */
 public class LocalFile extends AbstractFile {
-
-	private static final Logger logger = Logger.getLogger(LocalFile.class.getName());
 
 	/**
 	 * Create a db representation of a local file, passing a more specific file

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  * 
- * Copyright 2013 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,14 +58,17 @@ public class LocalFile extends AbstractFile {
 	 * @param parentPath path of the parent of this local file (e.g. fs zip
 	 * file, or another local file path)
 	 * @param localPath local absolute path of this local file
+	 * @deprecated Do not make public subclasses of LocalFile outside of this
+	 * package.
 	 */
+	@Deprecated
 	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_DB_FILES_TYPE_ENUM fileType,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag,
 			short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash,
 			FileKnown knownState, String parentPath, String localPath) {
-		super(db, objId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
+		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, fileType, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
 
@@ -79,6 +82,8 @@ public class LocalFile extends AbstractFile {
 	 *
 	 * @param db
 	 * @param objId object if of this file already in database
+	 * @param dataSourceObjectId The object id of the root data source of this
+	 * file.
 	 * @param name name of this local file
 	 * @param fileType TSK_DB_FILES_TYPE_ENUM type of the file (local of more
 	 * specific)
@@ -97,13 +102,13 @@ public class LocalFile extends AbstractFile {
 	 * file, or another local file path)
 	 * @param localPath local absolute path of this local file
 	 */
-	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_DB_FILES_TYPE_ENUM fileType,
+	LocalFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_DB_FILES_TYPE_ENUM fileType,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag,
 			short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash,
 			FileKnown knownState, String parentPath, String localPath, String mimeType) {
-		super(db, objId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
+		super(db, dataSourceObjectId, objId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, fileType, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);
 
@@ -152,6 +157,8 @@ public class LocalFile extends AbstractFile {
 	 *
 	 * @param db
 	 * @param objId object if of this file already in database
+	 * @param dataSourceObjectId The object id of the root data source of this
+	 * file.
 	 * @param name name of this local file
 	 * @param fileType TSK_DB_FILES_TYPE_ENUM type of the file (LOCAL or more
 	 * specific)
@@ -171,10 +178,10 @@ public class LocalFile extends AbstractFile {
 	 * @param localPath local path of this local file, relative to the db path
 	 * @param parentId parent id of this local file to set if available
 	 */
-	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_DB_FILES_TYPE_ENUM fileType, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
+	protected LocalFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_DB_FILES_TYPE_ENUM fileType, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId, String mimeType) {
-		this(db, objId, name, fileType, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath, mimeType);
+		this(db, objId, dataSourceObjectId, name, fileType, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath, mimeType);
 
 		if (parentId > 0) {
 			setParentId(parentId);
@@ -215,6 +222,8 @@ public class LocalFile extends AbstractFile {
 	 *
 	 * @param db
 	 * @param objId object if of this file already in database
+	 * @param dataSourceObjectId The object id of the root data source of this
+	 * file.
 	 * @param name name of this local file
 	 * @param dirType
 	 * @param metaType
@@ -232,10 +241,10 @@ public class LocalFile extends AbstractFile {
 	 * @param localPath local path of this local file, relative to the db path
 	 * @param parentId parent id of this local file to set if available
 	 */
-	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
+	protected LocalFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId, String mimeType) {
-		this(db, objId, name, TSK_DB_FILES_TYPE_ENUM.LOCAL, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath, mimeType);
+		this(db, dataSourceObjectId, objId, name, TSK_DB_FILES_TYPE_ENUM.LOCAL, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath, mimeType);
 	}
 
 	@Override

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
@@ -58,8 +58,7 @@ public class LocalFile extends AbstractFile {
 	 * @param parentPath path of the parent of this local file (e.g. fs zip
 	 * file, or another local file path)
 	 * @param localPath local absolute path of this local file
-	 * @deprecated Do not make public subclasses of LocalFile outside of this
-	 * package.
+	 * @deprecated Do not make subclasses of LocalFile outside of this package.
 	 */
 	@Deprecated
 	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_DB_FILES_TYPE_ENUM fileType,
@@ -71,11 +70,8 @@ public class LocalFile extends AbstractFile {
 		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, fileType, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
-
-		//use the local path functionality of AbstractFile, this sets up the infrastructure for it
-		super.setLocalPath(localPath, true); //local paths for local files are absolute paths
 	}
-	
+
 	/**
 	 * Create a db representation of a local file, passing a more specific file
 	 * type
@@ -98,6 +94,7 @@ public class LocalFile extends AbstractFile {
 	 * @param mtime
 	 * @param md5Hash
 	 * @param knownState
+	 * @param parentId
 	 * @param parentPath path of the parent of this local file (e.g. fs zip
 	 * file, or another local file path)
 	 * @param localPath local absolute path of this local file
@@ -107,11 +104,16 @@ public class LocalFile extends AbstractFile {
 			short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash,
-			FileKnown knownState, String parentPath, String localPath, String mimeType) {
+			FileKnown knownState, long parentId, String parentPath, String localPath, String mimeType) {
 		super(db, dataSourceObjectId, objId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, fileType, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);
 
+		// TODO (AUT-1904): The parent id should be passed through contructors.
+		if (parentId > 0) {
+			setParentId(parentId);
+		}
+				
 		//use the local path functionality of AbstractFile, this sets up the infrastructure for it
 		super.setLocalPath(localPath, true); //local paths for local files are absolute paths
 	}
@@ -140,53 +142,13 @@ public class LocalFile extends AbstractFile {
 	 * or another local file path)
 	 * @param localPath local path of this local file, relative to the db path
 	 * @param parentId parent id of this local file to set if available
+	 * @deprecated Do not make subclasses of LocalFile outside of this package.
 	 */
+	@Deprecated
 	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_DB_FILES_TYPE_ENUM fileType, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId) {
-		this(db, objId, name, fileType, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath);
-
-		if (parentId > 0) {
-			setParentId(parentId);
-		}
-
-	}
-	/**
-	 * Create a db representation of a local file, passing a more specific file
-	 * type
-	 *
-	 * @param db
-	 * @param objId object if of this file already in database
-	 * @param dataSourceObjectId The object id of the root data source of this
-	 * file.
-	 * @param name name of this local file
-	 * @param fileType TSK_DB_FILES_TYPE_ENUM type of the file (LOCAL or more
-	 * specific)
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size size of the file
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath path of the parent of this local file (e.g. virtual dir
-	 * or another local file path)
-	 * @param localPath local path of this local file, relative to the db path
-	 * @param parentId parent id of this local file to set if available
-	 */
-	protected LocalFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_DB_FILES_TYPE_ENUM fileType, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
-			long ctime, long crtime, long atime, long mtime,
-			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId, String mimeType) {
-		this(db, objId, dataSourceObjectId, name, fileType, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath, mimeType);
-
-		if (parentId > 0) {
-			setParentId(parentId);
-		}
-
+		this(db, objId, 0, name, fileType, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentId, parentPath, localPath, null);
 	}
 
 	/**
@@ -210,43 +172,15 @@ public class LocalFile extends AbstractFile {
 	 * or another local file path)
 	 * @param localPath local path of this local file, relative to the db path
 	 * @param parentId parent id of this local file to set if available
+	 * @deprecated Do not make subclasses of LocalFile outside of this package.
 	 */
+	@Deprecated
 	protected LocalFile(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
 			long ctime, long crtime, long atime, long mtime,
 			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId) {
-		this(db, objId, name, TSK_DB_FILES_TYPE_ENUM.LOCAL, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath);
+		this(db, objId, 0, name, TSK_DB_FILES_TYPE_ENUM.LOCAL, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentId, parentPath, localPath, null);
 	}
 	
-	/**
-	 * Create a db representation of a local file
-	 *
-	 * @param db
-	 * @param objId object if of this file already in database
-	 * @param dataSourceObjectId The object id of the root data source of this
-	 * file.
-	 * @param name name of this local file
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size size of the file
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath path of the parent of this local file (e.g. virtual dir
-	 * or another local file path)
-	 * @param localPath local path of this local file, relative to the db path
-	 * @param parentId parent id of this local file to set if available
-	 */
-	protected LocalFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
-			long ctime, long crtime, long atime, long mtime,
-			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId, String mimeType) {
-		this(db, dataSourceObjectId, objId, name, TSK_DB_FILES_TYPE_ENUM.LOCAL, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, md5Hash, knownState, parentPath, localPath, mimeType);
-	}
-
 	@Override
 	public List<TskFileRange> getRanges() throws TskCoreException {
 		return Collections.<TskFileRange>emptyList();

--- a/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
@@ -172,7 +172,7 @@ class ResultSetHelper {
 	 */
 	File file(ResultSet rs, FileSystem fs) throws SQLException {
 
-		File f = new File(db, rs.getLong("obj_id"), rs.getLong("fs_obj_id"), //NON-NLS
+		File f = new File(db, rs.getLong("obj_id"), rs.getLong("data_source_obj_id"), rs.getLong("fs_obj_id"), //NON-NLS
 				TSK_FS_ATTR_TYPE_ENUM.valueOf(rs.getShort("attr_type")), //NON-NLS
 				rs.getShort("attr_id"), rs.getString("name"), rs.getLong("meta_addr"), rs.getInt("meta_seq"), //NON-NLS
 				TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")), //NON-NLS
@@ -198,7 +198,7 @@ class ResultSetHelper {
 	 * @throws SQLException thrown if SQL error occurred
 	 */
 	Directory directory(ResultSet rs, FileSystem fs, String name) throws SQLException {
-		Directory dir = new Directory(db, rs.getLong("obj_id"), rs.getLong("fs_obj_id"), //NON-NLS
+		Directory dir = new Directory(db, rs.getLong("obj_id"), rs.getLong("data_source_obj_id"), rs.getLong("fs_obj_id"), //NON-NLS
 				TSK_FS_ATTR_TYPE_ENUM.valueOf(rs.getShort("attr_type")), //NON-NLS
 				rs.getShort("attr_id"), name, rs.getLong("meta_addr"), rs.getInt("meta_seq"), //NON-NLS
 				TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")), //NON-NLS
@@ -226,13 +226,18 @@ class ResultSetHelper {
 			parentPath = "";
 		}
 
-		final VirtualDirectory vd = new VirtualDirectory(db, rs.getLong("obj_id"), //NON-NLS
+		final VirtualDirectory vd = new VirtualDirectory(db,
+				rs.getLong("obj_id"), //NON-NLS
+				rs.getLong("data_source_obj_id"), //NON-NLS
 				rs.getString("name"), //NON-NLS
 				TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")), //NON-NLS
 				TSK_FS_META_TYPE_ENUM.valueOf(rs.getShort("meta_type")), //NON-NLS
-				TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), rs.getShort("meta_flags"), //NON-NLS
-				rs.getLong("size"), rs.getString("md5"), //NON-NLS
-				FileKnown.valueOf(rs.getByte("known")), parentPath); //NON-NLS
+				TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), //NON-NLS
+				rs.getShort("meta_flags"), //NON-NLS
+				rs.getLong("size"), //NON-NLS
+				rs.getString("md5"), //NON-NLS
+				FileKnown.valueOf(rs.getByte("known")), //NON-NLS
+				parentPath);
 		return vd;
 	}
 
@@ -284,7 +289,7 @@ class ResultSetHelper {
 		}
 
 		final DerivedFile df
-				= new DerivedFile(db, objId, rs.getString("name"), //NON-NLS
+				= new DerivedFile(db, objId, rs.getLong("data_source_obj_id"), rs.getString("name"), //NON-NLS
 						TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")), //NON-NLS
 						TSK_FS_META_TYPE_ENUM.valueOf(rs.getShort("meta_type")), //NON-NLS
 						TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), rs.getShort("meta_flags"), //NON-NLS
@@ -319,7 +324,7 @@ class ResultSetHelper {
 		}
 
 		final LocalFile lf
-				= new LocalFile(db, objId, rs.getString("name"), //NON-NLS
+				= new LocalFile(db, objId, rs.getLong("data_source_obj_id"), rs.getString("name"), //NON-NLS
 						TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")), //NON-NLS
 						TSK_FS_META_TYPE_ENUM.valueOf(rs.getShort("meta_type")), //NON-NLS
 						TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), rs.getShort("meta_flags"), //NON-NLS
@@ -366,7 +371,10 @@ class ResultSetHelper {
 					parentPath = "";
 				}
 				final LayoutFile lf
-						= new LayoutFile(db, rs.getLong("obj_id"), rs.getString("name"),
+						= new LayoutFile(db,
+								rs.getLong("obj_id"),
+								rs.getLong("data_source_obj_id"),
+								rs.getString("name"),
 								type,
 								TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")),
 								TSK_FS_META_TYPE_ENUM.valueOf(rs.getShort("meta_type")),

--- a/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
@@ -235,7 +235,6 @@ class ResultSetHelper {
 				TSK_FS_META_TYPE_ENUM.valueOf(rs.getShort("meta_type")), //NON-NLS
 				TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), //NON-NLS
 				rs.getShort("meta_flags"), //NON-NLS
-				rs.getLong("size"), //NON-NLS
 				rs.getString("md5"), //NON-NLS
 				FileKnown.valueOf(rs.getByte("known")), //NON-NLS
 				parentPath);

--- a/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ResultSetHelper.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  * 
- * Copyright 2014 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import org.sleuthkit.datamodel.TskData.FileKnown;
+import org.sleuthkit.datamodel.TskData.TSK_DB_FILES_TYPE_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_ATTR_TYPE_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_META_TYPE_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
@@ -325,15 +326,16 @@ class ResultSetHelper {
 
 		final LocalFile lf
 				= new LocalFile(db, objId, rs.getLong("data_source_obj_id"), rs.getString("name"), //NON-NLS
+						TSK_DB_FILES_TYPE_ENUM.valueOf(rs.getShort("type")), //NON-NLS
 						TSK_FS_NAME_TYPE_ENUM.valueOf(rs.getShort("dir_type")), //NON-NLS
 						TSK_FS_META_TYPE_ENUM.valueOf(rs.getShort("meta_type")), //NON-NLS
 						TSK_FS_NAME_FLAG_ENUM.valueOf(rs.getShort("dir_flags")), rs.getShort("meta_flags"), //NON-NLS
 						rs.getLong("size"), //NON-NLS
 						rs.getLong("ctime"), rs.getLong("crtime"), rs.getLong("atime"), rs.getLong("mtime"), //NON-NLS
 						rs.getString("md5"), FileKnown.valueOf(rs.getByte("known")), //NON-NLS
-						parentPath, localPath,
-						parentId, rs.getString("mime_type"));
-
+						parentId, parentPath, 
+						localPath,
+						rs.getString("mime_type"));						
 		return lf;
 	}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
@@ -27,35 +27,47 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * Layout directory object representation of a virtual layout directory stored
- * in tsk_files table.
- *
- * Layout directories are not fs directories, but "virtual" directories used to
- * organize LayoutFiles. Since they are not real fs dirs, they have similar
- * attributes to LayoutFiles and they also have children like real Directories.
- *
+ * A virtual directory that can be used as a parent for unallocated space files,
+ * carved files, or derived files. A virtual directory can also be a data
+ * source, with local/logical files as its children. Not a file system
+ * directory.
  */
 public class VirtualDirectory extends AbstractFile {
 
-	//some built-in virtual directory names
+	/**
+	 * The name given to a virtual directory that contains unallocated space
+	 * files.
+	 */
 	public static final String NAME_UNALLOC = "$Unalloc"; //NON-NLS
+
+	/**
+	 * The name given to a virtual directory that contains carved files.
+	 */
 	public static final String NAME_CARVED = "$CarvedFiles"; //NON-NLS
 
 	/**
+	 * Constructs a virtual directory that can be used as a parent for
+	 * unallocated space files, carved files, or derived files. A virtual
+	 * directory can also be a data source, with local/logical files as its
+	 * children. Not a file system directory.
 	 *
-	 * @param db
-	 * @param objId
-	 * @param name
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath
-	 * @deprecated Do not make public subclasses of VirtualDirectory outside of
-	 * this package.
+	 * @param db The case database.
+	 * @param objId The object id of the virtual directory.
+	 * @param dataSourceObjectId The object id of the data source for the
+	 * virtual directory; same as objId if the virtual directory is a data
+	 * source.
+	 * @param name The name of the virtual directory.
+	 * @param dirType The TSK_FS_NAME_TYPE_ENUM for the virtual directory.
+	 * @param metaType The TSK_FS_META_TYPE_ENUM for the virtual directory.
+	 * @param dirFlag The TSK_FS_META_TYPE_ENUM for the virtual directory.
+	 * @param metaFlags The meta flags for the virtual directory.
+	 * @param size The size value for the virtual directory
+	 * @param md5Hash The MD5 hash for the virtual directory.
+	 * @param knownState The known state for the virtual directory
+	 * @param parentPath The parent path for the virtual directory, should be
+	 * "/" if the virtual directory is a data source.
+	 * @deprecated Do not make subclasses of VirtualDirectory outside of this
+	 * package.
 	 */
 	@Deprecated
 	VirtualDirectory(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
@@ -64,8 +76,30 @@ public class VirtualDirectory extends AbstractFile {
 		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name,
 				TskData.TSK_DB_FILES_TYPE_ENUM.VIRTUAL_DIR, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, 0L, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
-	}
-
+	}	
+	
+	/**
+	 * Constructs a virtual directory that can be used as a parent for
+	 * unallocated space files, carved files, or derived files. A virtual
+	 * directory can also be a data source, with local/logical files as its
+	 * children. Not a file system directory.
+	 *
+	 * @param db The case database.
+	 * @param objId The object id of the virtual directory.
+	 * @param dataSourceObjectId The object id of the data source for the
+	 * virtual directory; same as objId if the virtual directory is a data
+	 * source.
+	 * @param name The name of the virtual directory.
+	 * @param dirType The TSK_FS_NAME_TYPE_ENUM for the virtual directory.
+	 * @param metaType The TSK_FS_META_TYPE_ENUM for the virtual directory.
+	 * @param dirFlag The TSK_FS_META_TYPE_ENUM for the virtual directory.
+	 * @param metaFlags The meta flags for the virtual directory.
+	 * @param size The size of the virtual directory, should be zero.
+	 * @param md5Hash The MD5 hash for the virtual directory.
+	 * @param knownState The known state for the virtual directory
+	 * @param parentPath The parent path for the virtual directory, should be
+	 * "/" if the virtual directory is a data source.
+	 */
 	VirtualDirectory(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
 			TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, String md5Hash, FileKnown knownState, String parentPath) {
@@ -74,52 +108,120 @@ public class VirtualDirectory extends AbstractFile {
 				metaFlags, 0L, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
 	}
 
+	/**
+	 * Gets the children of this virtual directory.
+	 *
+	 * @return List of children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Content> getChildren() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildren(this);
 	}
 
+	/**
+	 * Gets the object ids of the children of this virtual directory.
+	 *
+	 * @return List of child object ids.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Long> getChildrenIds() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildrenIds(this);
 	}
 
+	/**
+	 * Gets the extents in terms of byte addresses of this virtual directory
+	 * within its data source, an empty list.
+	 *
+	 * @return An empty list of extents (TskFileRange objects)
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<TskFileRange> getRanges() throws TskCoreException {
 		return Collections.<TskFileRange>emptyList();
 	}
 
+	/**
+	 * Does nothing, a virtual directory cannot be opened, read, and closed.
+	 */
 	@Override
 	public void close() {
-		//nothing to be closed
 	}
 
+	/**
+	 * Whether or not this virtual directory is the root of a file system,
+	 * always returns false.
+	 *
+	 * @return False.
+	 */
 	@Override
 	public boolean isRoot() {
 		return false;
 	}
 
+	/**
+	 * Accepts a content visitor (Visitor design pattern).
+	 *
+	 * @param visitor A ContentVisitor supplying an algorithm to run using this
+	 * virtual directory as input.
+	 * @return The output of the algorithm
+	 */
 	@Override
-	public <T> T accept(ContentVisitor<T> v) {
-		return v.visit(this);
+	public <T> T accept(ContentVisitor<T> visitor) {
+		return visitor.visit(this);
 	}
 
+	/**
+	 * Accepts a Sleuthkit item visitor (Visitor design pattern).
+	 *
+	 * @param visitor A SleuthkitItemVisitor supplying an algorithm to run using
+	 * this virtual directory as input.
+	 * @return The output of the algorithm
+	 */
 	@Override
-	public <T> T accept(SleuthkitItemVisitor<T> v) {
-		return v.visit(this);
+	public <T> T accept(SleuthkitItemVisitor<T> visitor) {
+		return visitor.visit(this);
 	}
 
+	/**
+	 * Gets the root data source (image, virtual directory, etc.) of this
+	 * content.
+	 *
+	 * @return Content associated with data source or null if one can't be found
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public Content getDataSource() throws TskCoreException {
-		Content parent = getParent();
-		if (parent != null) {
-			return parent.getDataSource();
-		} else {
-			//root-level VirtualDirectory, such as local files container
+		if (this.getDataSourceObjectId() == this.getId()) {
+			// This virtual directory is a data source.
 			return this;
+		} else {
+			return super.getDataSource();
 		}
 	}
 
+	/**
+	 * Indicates whether or not this virtual directory is a data source.
+	 *
+	 * @return True or false.
+	 */
+	public boolean isDataSource() {
+		return (this.getDataSourceObjectId() == this.getId());
+	}
+
+	/**
+	 * Provides a string representation of this virtual directory.
+	 *
+	 * @param preserveState True if state should be included in the string
+	 * representation of this object.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public String toString(boolean preserveState) {
 		return super.toString(preserveState) + "VirtualDirectory [\t" + "]\t"; //NON-NLS

--- a/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
@@ -73,11 +73,9 @@ public class VirtualDirectory extends AbstractFile {
 	VirtualDirectory(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
 			TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name,
-				TskData.TSK_DB_FILES_TYPE_ENUM.VIRTUAL_DIR, 0L, 0, dirType, metaType, dirFlag,
-				metaFlags, 0L, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
-	}	
-	
+		this(db, objId, 0, name, dirType, metaType, dirFlag, metaFlags, md5Hash, knownState, parentPath);
+	}
+
 	/**
 	 * Constructs a virtual directory that can be used as a parent for
 	 * unallocated space files, carved files, or derived files. A virtual
@@ -102,7 +100,7 @@ public class VirtualDirectory extends AbstractFile {
 	 */
 	VirtualDirectory(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
 			TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, String md5Hash, FileKnown knownState, String parentPath) {
+			String md5Hash, FileKnown knownState, String parentPath) {
 		super(db, objId, dataSourceObjectId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name,
 				TskData.TSK_DB_FILES_TYPE_ENUM.VIRTUAL_DIR, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, 0L, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);

--- a/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
@@ -1,7 +1,7 @@
 /*
  * Autopsy Forensic Browser
  * 
- * Copyright 2012 Basis Technology Corp.
+ * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,10 +41,35 @@ public class VirtualDirectory extends AbstractFile {
 	public static final String NAME_UNALLOC = "$Unalloc"; //NON-NLS
 	public static final String NAME_CARVED = "$CarvedFiles"; //NON-NLS
 
-	protected VirtualDirectory(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
+	/**
+	 *
+	 * @param db
+	 * @param objId
+	 * @param name
+	 * @param dirType
+	 * @param metaType
+	 * @param dirFlag
+	 * @param metaFlags
+	 * @param size
+	 * @param md5Hash
+	 * @param knownState
+	 * @param parentPath
+	 * @deprecated Do not make public subclasses of VirtualDirectory outside of
+	 * this package.
+	 */
+	@Deprecated
+	VirtualDirectory(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
 			TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, String md5Hash, FileKnown knownState, String parentPath) {
-		super(db, objId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name,
+		super(db, objId, 0, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name,
+				TskData.TSK_DB_FILES_TYPE_ENUM.VIRTUAL_DIR, 0L, 0, dirType, metaType, dirFlag,
+				metaFlags, 0L, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
+	}
+
+	VirtualDirectory(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
+			TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size, String md5Hash, FileKnown knownState, String parentPath) {
+		super(db, objId, dataSourceObjectId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name,
 				TskData.TSK_DB_FILES_TYPE_ENUM.VIRTUAL_DIR, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, 0L, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, null);
 	}


### PR DESCRIPTION
 TSK OBJECT CLASS CHANGES

- AbstractFile
-- Added dataSourceObjectId field with package level accessor for derived classes.
-- Modified the new package access constructor with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Modfied the old protected (public API) constructor to pass 0 (dinstingushed value!) for the dataSourceObjectId to the newer constructor. 
-- Deprecated the old protected (public API) constructor.
-- Added an override of Content.getDataSource that supports lazy init of dataSourceObjectId to support deprecated ctor of this and derivd classes.
- DerivedFile (subclass of AbstractFile)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
- LocalFile (subclass of AbstractFile)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
- LayoutFile (subclass of AbstractFile)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
- FsContent (subclass of AbstractFile)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
- Directory (subclass of FsContent)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
- VirtualDirectory (subclass of AbstractFile)
-- Modified the new package access constructors with a MIME type parameter to also have a dataSourceObjectId parameter.
-- Deprecated the old protected constructor (public API)
-- Modified override of Content.getDataSource to make use of dataSourceObjectId to save DB round trips.

SLEUTHKIT CASE/RESULTS SET HELPER CHANGES

Changes:
- updateFromSchema3toSchema4
-- Adds and populates new column using new getDataSourceObjectId method
- addVirtualDirectory
-- Uses new getDataSourceObjectId method to parameterize modified INSERT_FILE prepared statement
-- Uses new LayoutFile ctor
- addCarvedFiles
-- Uses new getDataSourceObjectId method to parameterize modified INSERT_FILE prepared statement
-- Uses new LayoutFile ctor
- addDerivedFile
-- Uses new getDataSourceObjectId method to parameterize modified INSERT_FILE prepared statement
-- Uses new DerivedFile ctor
- addLocalFile
-- Uses new getDataSourceObjectId method to parameterize modified INSERT_FILE prepared statement
-- Uses new LocalFile ctor
- getFileSystemId
-- Removed private, now unused method
- isFileFromSource
-- Updated to use tsk_files.data_source_obj_id
- findFiles(Content dataSource, String fileName)
-- Updated prepared statement SQL to use tsk_files.data_source_obj_id
- findFiles(Content dataSource, String fileName, String dirName)
-- Updated prepared statement SQL to use tsk_files.data_source_obj_id
- getVirtualDirectoryRoots()
-- Updated SQL query to use tsk_files.data_source_obj_id
- getLastObjectId()
-- Deprecated, does not work reliably for multi-user cases
- resultSetToAbstractFiles
-- Uses new LayoutFile ctor (other objects are constructed by delegating to ResultsSetHelper)
- ResultsSetHelper
-- All methods updated to get the data source object id from the result set and use the new package access TSK object ctors
- resultSetToFsContents
-- Used only by deprecated method, inlined and deleted
