### PR TITLE
Use GUID partition type as gpt partition description

### DIFF
--- a/tsk/vs/gpt.c
+++ b/tsk/vs/gpt.c
@@ -16,11 +16,19 @@
 #include "tsk_dos.h"
 
 
-/*
- *Check if GUID matches a given value.
+/**
+ * Check if GUID matches a given value.
+ *
+ * @param g The GUID to match.
+ * @param d1 First 4 bytes of the given value. 
+ * @param d2 Next 2 bytes of the given value following d1.
+ * @param d3 Next 2 bytes of the given value following d2.
+ * @param d4 Next 8 bytes of the given value following d3.
+ * @returns 1 if they match, 0 if they do not.
+ *
  */
 static int
-gpt_guid_match(GUID * g, uint32_t d1, uint16_t d2, uint16_t d3, uint64_t d4)
+gpt_guid_match(gpt_guid * g, uint32_t d1, uint16_t d2, uint16_t d3, uint64_t d4)
 {
     if(g->data_1 != d1 || g->data_2 != d2 || g->data_3 != d3)
         return 0;
@@ -40,15 +48,18 @@ gpt_guid_match(GUID * g, uint32_t d1, uint16_t d2, uint16_t d3, uint64_t d4)
 
 
 
-/*
- *get_guid_type
+/**
  *
- *Get partition type by reading GUID value.
+ * Get partition type by reading GUID value.
+ * Source: https://en.wikipedia.org/wiki/GUID_Partition_Table
  *
- *Source: https://en.wikipedia.org/wiki/GUID_Partition_Table
+ * @param desc C-string to store the description.
+ * @param g Type GUID to compare.
+ * @returns 1 if matched type found, 0 if not.
+ *
  */
-static void
-gpt_guid_type(char * desc, GUID * g)
+static int
+gpt_guid_type(char * desc, gpt_guid * g)
 {
     if(gpt_guid_match(g, 0, 0, 0, 0))
         snprintf(desc, GUID_DESC_LEN, "Unused entry");
@@ -64,6 +75,7 @@ gpt_guid_type(char * desc, GUID * g)
         snprintf(desc, GUID_DESC_LEN, "Sony boot partition");
     else if(gpt_guid_match(g, 0xBFBFAFE7, 0xA34F, 0x448A, 0x9A5B6213EB736C22))
         snprintf(desc, GUID_DESC_LEN, "Lenovo boot partition");
+
     else if(gpt_guid_match(g, 0xE3C9E316, 0x0B5C, 0x4DB8, 0x817DF92DF00215AE))
         snprintf(desc, GUID_DESC_LEN, "Microsoft Reserved Partition");
     else if(gpt_guid_match(g, 0xDE94BBA4, 0x06D1, 0x4D40, 0xA16ABFD50179D6AC))
@@ -78,8 +90,202 @@ gpt_guid_type(char * desc, GUID * g)
         snprintf(desc, GUID_DESC_LEN, "GPFS partition");
     else if(gpt_guid_match(g, 0xE75CAF8F, 0xF680, 0x4CEE, 0xAFA3B001E56EFC2D))
         snprintf(desc, GUID_DESC_LEN, "Storage Spaces partition");
-    else
+    
+    else if(gpt_guid_match(g, 0x75894C1E, 0x3AEB, 0x11D3, 0xB7C17B03A0000000))
+        snprintf(desc, GUID_DESC_LEN, "HP-UX Data partition");
+    else if(gpt_guid_match(g, 0xE2A1E728, 0x32E3, 0x11D6, 0xA6827B03A0000000))
+        snprintf(desc, GUID_DESC_LEN, "HP-UX Data partition");
+
+    else if(gpt_guid_match(g, 0x0FC63DAF, 0x8483, 0x4772, 0x8E793D69D8477DE4))
+        snprintf(desc, GUID_DESC_LEN, "Linux filesystem data");
+    else if(gpt_guid_match(g, 0xA19D880F, 0x05FC, 0x4D3B, 0xA006743F0F84911E))
+        snprintf(desc, GUID_DESC_LEN, "Linux RAID partition");
+    else if(gpt_guid_match(g, 0x44479540, 0xF297, 0x41B2, 0x9AF7D131D5F0458A))
+        snprintf(desc, GUID_DESC_LEN, "Linux Root partition (x86)");
+    else if(gpt_guid_match(g, 0x4F68BCE3, 0xE8CD, 0x4DB1, 0x96E7FBCAF984B709))
+        snprintf(desc, GUID_DESC_LEN, "Linux Root partition (x86-64)");
+    else if(gpt_guid_match(g, 0x69DAD710, 0x2CE4, 0x4E3C, 0xB16C21A1D49ABED3))
+        snprintf(desc, GUID_DESC_LEN, "Linux Root partition (32-bit ARM)");
+    else if(gpt_guid_match(g, 0x0657FD6D, 0xA4AB, 0x43C4, 0x84E50933C84B4F4F))
+        snprintf(desc, GUID_DESC_LEN, "Linux swap partition");
+    else if(gpt_guid_match(g, 0x933AC7E1, 0x2EB4, 0x4F13, 0xB8440E14E2AEF915))
+        snprintf(desc, GUID_DESC_LEN, "Linux /home partition");
+    else if(gpt_guid_match(g, 0x3B8F8425, 0x20E0, 0x4F3B, 0x907F1A25A76F98E8))
+        snprintf(desc, GUID_DESC_LEN, "/srv (server data) partition");
+    else if(gpt_guid_match(g, 0x7FFEC5C9, 0x2D00, 0x49B7, 0x89413EA10A5586B7))
+        snprintf(desc, GUID_DESC_LEN, "Plain dm-crypt partition");
+    else if(gpt_guid_match(g, 0xCA7D7CCB, 0x63ED, 0x4C53, 0x861C1742536059CC))
+        snprintf(desc, GUID_DESC_LEN, "LUKS partition");
+    else if(gpt_guid_match(g, 0x8DA63339, 0x0007, 0x60C0, 0xC436083AC8230908))
+        snprintf(desc, GUID_DESC_LEN, "Reserved");
+
+    else if(gpt_guid_match(g, 0x83BD6B9D, 0x7F41, 0x11DC, 0xBE0B001560B84F0F))
+        snprintf(desc, GUID_DESC_LEN, "FreeBSD Boot partition");
+    else if(gpt_guid_match(g, 0x516E7CB4, 0x6ECF, 0x11D6, 0x8FF800022D09712B))
+        snprintf(desc, GUID_DESC_LEN, "FreeBSD Data partition");
+    else if(gpt_guid_match(g, 0x516E7CB5, 0x6ECF, 0x11D6, 0x8FF800022D09712B))
+        snprintf(desc, GUID_DESC_LEN, "FreeBSD Swap partition");
+    else if(gpt_guid_match(g, 0x516E7CB6, 0x6ECF, 0x11D6, 0x8FF800022D09712B))
+        snprintf(desc, GUID_DESC_LEN, "FreeBSD Unix File System (UFS) partition");
+    else if(gpt_guid_match(g, 0x516E7CB8, 0x6ECF, 0x11D6, 0x8FF800022D09712B))
+        snprintf(desc, GUID_DESC_LEN, "FreeBSD Vinum volume manager partition");
+    else if(gpt_guid_match(g, 0x516E7CBA, 0x6ECF, 0x11D6, 0x8FF800022D09712B))
+        snprintf(desc, GUID_DESC_LEN, "FreeBSD ZFS partition");
+
+    else if(gpt_guid_match(g, 0x48465300, 0x0000, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Hierarchical File System Plus (HFS+) partition");
+    else if(gpt_guid_match(g, 0x55465300, 0x0000, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple UFS");
+    else if(gpt_guid_match(g, 0x6A898CC3, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "OS X ZFS");
+    else if(gpt_guid_match(g, 0x52414944, 0x0000, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple RAID partition");
+    else if(gpt_guid_match(g, 0x52414944, 0x5F4F, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple RAID partition, offline");
+    else if(gpt_guid_match(g, 0x426F6F74, 0x0000, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple Boot partition (Recovery HD)");
+    else if(gpt_guid_match(g, 0x4C616265, 0x6C00, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple Label");
+    else if(gpt_guid_match(g, 0x5265636F, 0x7665, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple TV Recovery partition");
+    else if(gpt_guid_match(g, 0x53746F72, 0x6167, 0x11AA, 0xAA1100306543ECAC))
+        snprintf(desc, GUID_DESC_LEN, "OS X Apple Core Storage (i.e. Lion FileVault) partition");
+    else if(gpt_guid_match(g, 0x6A82CB45, 0x1DD2, 0x11B2, 0x99A6080020736631))
+
+        snprintf(desc, GUID_DESC_LEN, "Solaris Boot partition");
+    else if(gpt_guid_match(g, 0x6A85CF4D, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Root partition");
+    else if(gpt_guid_match(g, 0x6A87C46F, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Swap partition");
+    else if(gpt_guid_match(g, 0x6A8B642B, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Backup partition");
+    else if(gpt_guid_match(g, 0x6A898CC3, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris /usr partition");
+    else if(gpt_guid_match(g, 0x6A8EF2E9, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris /var partition");
+    else if(gpt_guid_match(g, 0x6A90BA39, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris /home partition");
+    else if(gpt_guid_match(g, 0x6A9283A5, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Alternate sector");
+    else if(gpt_guid_match(g, 0x6A945A3B, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Reserved partition");
+    else if(gpt_guid_match(g, 0x6A9630D1, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Reserved partition");
+    else if(gpt_guid_match(g, 0x6A980767, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Reserved partition");
+    else if(gpt_guid_match(g, 0x6A96237F, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Reserved partition");
+    else if(gpt_guid_match(g, 0x6A8D2AC7, 0x1DD2, 0x11B2, 0x99A6080020736631))
+        snprintf(desc, GUID_DESC_LEN, "Solaris Reserved partition");
+
+    else if(gpt_guid_match(g, 0x49F48D32, 0xB10E, 0x11DC, 0xB99B0019D1879648))
+        snprintf(desc, GUID_DESC_LEN, "NetBSD Swap partition");
+    else if(gpt_guid_match(g, 0x49F48D5A, 0xB10E, 0x11DC, 0xB99B0019D1879648))
+        snprintf(desc, GUID_DESC_LEN, "NetBSD FFS partition");
+    else if(gpt_guid_match(g, 0x49F48D82, 0xB10E, 0x11DC, 0xB99B0019D1879648))
+        snprintf(desc, GUID_DESC_LEN, "NetBSD LFS partition");
+    else if(gpt_guid_match(g, 0x49F48DAA, 0xB10E, 0x11DC, 0xB99B0019D1879648))
+        snprintf(desc, GUID_DESC_LEN, "NetBSD RAID partition");
+    else if(gpt_guid_match(g, 0x2DB519C4, 0xB10F, 0x11DC, 0xB99B0019D1879648))
+        snprintf(desc, GUID_DESC_LEN, "NetBSD Concatenated partition");
+    else if(gpt_guid_match(g, 0x2DB519EC, 0xB10F, 0x11DC, 0xB99B0019D1879648))
+        snprintf(desc, GUID_DESC_LEN, "NetBSD Encrypted partition");
+
+    else if(gpt_guid_match(g, 0xFE3A2A5D, 0x4F32, 0x41A7, 0xB725ACCC3285A309))
+        snprintf(desc, GUID_DESC_LEN, "ChromeOS kernel");
+    else if(gpt_guid_match(g, 0x3CB8E202, 0x3B7E, 0x47DD, 0x8A3C7FF2A13CFCEC))
+        snprintf(desc, GUID_DESC_LEN, "ChromeOS rootfs");
+    else if(gpt_guid_match(g, 0x2E0A753D, 0x9E48, 0x43B0, 0x8337B15192CB1B5E))
+        snprintf(desc, GUID_DESC_LEN, "ChromeOS future use");
+
+    else if(gpt_guid_match(g, 0x42465331, 0x3BA3, 0x10F1, 0x802A4861696B7521))
+        snprintf(desc, GUID_DESC_LEN, "Haiku BFS");
+
+    else if(gpt_guid_match(g, 0x85D5E45E, 0x237C, 0x11E1, 0xB4B3E89A8F7FC3A7))
+        snprintf(desc, GUID_DESC_LEN, "MidnightBSD Boot partition");
+    else if(gpt_guid_match(g, 0x85D5E45A, 0x237C, 0x11E1, 0xB4B3E89A8F7FC3A7))
+        snprintf(desc, GUID_DESC_LEN, "MidnightBSD Data partition");
+    else if(gpt_guid_match(g, 0x85D5E45B, 0x237C, 0x11E1, 0xB4B3E89A8F7FC3A7))
+        snprintf(desc, GUID_DESC_LEN, "MidnightBSD Swap partition");
+    else if(gpt_guid_match(g, 0x0394EF8B, 0x237E, 0x11E1, 0xB4B3E89A8F7FC3A7))
+        snprintf(desc, GUID_DESC_LEN, "MidnightBSD Unix File System (UFS) partition");
+    else if(gpt_guid_match(g, 0x85D5E45C, 0x237C, 0x11E1, 0xB4B3E89A8F7FC3A7))
+        snprintf(desc, GUID_DESC_LEN, "MidnightBSD Vinum volume manager partition");
+    else if(gpt_guid_match(g, 0x85D5E45D, 0x237C, 0x11E1, 0xB4B3E89A8F7FC3A7))
+        snprintf(desc, GUID_DESC_LEN, "MidnightBSD ZFS partition");
+
+    else if(gpt_guid_match(g, 0x45B0969E, 0x9B03, 0x4F30, 0xB4C6B4B80CEFF106))
+        snprintf(desc, GUID_DESC_LEN, "Ceph Journal");
+    else if(gpt_guid_match(g, 0x45B0969E, 0x9B03, 0x4F30, 0xB4C65EC00CEFF106))
+        snprintf(desc, GUID_DESC_LEN, "Ceph dm-crypt Encrypted Journal");
+    else if(gpt_guid_match(g, 0x4FBD7E29, 0x9D25, 0x41B8, 0xAFD0062C0CEFF05D))
+        snprintf(desc, GUID_DESC_LEN, "Ceph OSD");
+    else if(gpt_guid_match(g, 0x4FBD7E29, 0x9D25, 0x41B8, 0xAFD05EC00CEFF05D))
+        snprintf(desc, GUID_DESC_LEN, "Ceph dm-crypt OSD");
+    else if(gpt_guid_match(g, 0x89C57F98, 0x2FE5, 0x4DC0, 0x89C1F3AD0CEFF2BE))
+        snprintf(desc, GUID_DESC_LEN, "Ceph disk in creation");
+    else if(gpt_guid_match(g, 0x89C57F98, 0x2FE5, 0x4DC0, 0x89C15EC00CEFF2BE))
+        snprintf(desc, GUID_DESC_LEN, "Ceph dm-crypt disk in creation");
+
+    else if(gpt_guid_match(g, 0x824CC7A0, 0x36A8, 0x11E3, 0x890A952519AD3F61))
+        snprintf(desc, GUID_DESC_LEN, "OpenBSD Data partition");
+
+    else if(gpt_guid_match(g, 0xCEF5A9AD, 0x73BC, 0x4601, 0x89F3CDEEEEE321A1))
+        snprintf(desc, GUID_DESC_LEN, "QNX Power-safe (QNX6) file system");
+
+    else if(gpt_guid_match(g, 0xC91818F9, 0x8025, 0x47AF, 0x89D2F030D7000C2C))
+        snprintf(desc, GUID_DESC_LEN, "Plan 9 partition");
+    else if(gpt_guid_match(g, 0x9D275380, 0x40AD, 0x11DB, 0xBF97000C2911D1B8))
+        snprintf(desc, GUID_DESC_LEN, "vmkcore (coredump partition)");
+    else if(gpt_guid_match(g, 0xAA31E02A, 0x400F, 0x11DB, 0x9590000C2911D1B8))
+        snprintf(desc, GUID_DESC_LEN, "VMFS filesystem partition");
+    else if(gpt_guid_match(g, 0x9198EFFC, 0x31C0, 0x11DB, 0x8F78000C2911D1B8))
+        snprintf(desc, GUID_DESC_LEN, "VMware Reserved");
+
+    else if(gpt_guid_match(g, 0x2568845D, 0x2332, 0x4675, 0xBC398FA5A4748D15))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Bootloader");
+    else if(gpt_guid_match(g, 0x114EAFFE, 0x1552, 0x4022, 0xB26E9B053604CF84))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Bootloader2");
+    else if(gpt_guid_match(g, 0x49A4D17F, 0x93A3, 0x45C1, 0xA0DEF50B2EBE2599))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Boot");
+    else if(gpt_guid_match(g, 0x4177C722, 0x9E92, 0x4AAB, 0x864443502BFD5506))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Recovery");
+    else if(gpt_guid_match(g, 0xEF32A33B, 0xA409, 0x486C, 0x91419FFB711F6266))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Misc");
+    else if(gpt_guid_match(g, 0x20AC26BE, 0x20B7, 0x11E3, 0x84C56CFDB94711E9))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Metadata");
+    else if(gpt_guid_match(g, 0x38F428E6, 0xD326, 0x425D, 0x91406E0EA133647C))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA System");
+    else if(gpt_guid_match(g, 0xA893EF21, 0xE428, 0x470A, 0x9E550668FD91A2D9))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Cache");
+    else if(gpt_guid_match(g, 0xDC76DDA9, 0x5AC1, 0x491C, 0xAF42A82591580C0D))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Data");
+    else if(gpt_guid_match(g, 0xEBC597D0, 0x2053, 0x4B15, 0x8B64E0AAC75F4DB1))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Persistent");
+    else if(gpt_guid_match(g, 0x8F68CC74, 0xC5E5, 0x48DA, 0xBE91A0C8C15E9C80))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Factory");
+    else if(gpt_guid_match(g, 0x767941D0, 0x2085, 0x11E3, 0xAD3B6CFDB94711E9))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA Fastboot / Tertiary");
+    else if(gpt_guid_match(g, 0xAC6D7924, 0xEB71, 0x4DF8, 0xB48DE267B27148FF))
+        snprintf(desc, GUID_DESC_LEN, "Android-IA OEM");
+
+    else if(gpt_guid_match(g, 0x7412F7D5, 0xA156, 0x4B13, 0x81DC867174929325))
+        snprintf(desc, GUID_DESC_LEN, "ONIE Boot");
+    else if(gpt_guid_match(g, 0xD4E6E2CD, 0x4469, 0x46F3, 0xB5CB1BFF57AFC149))
+        snprintf(desc, GUID_DESC_LEN, "ONIE Config");
+
+    else if(gpt_guid_match(g, 0x9E1A2D38, 0xC612, 0x4316, 0xAA268B49521E5A8B))
+        snprintf(desc, GUID_DESC_LEN, "PowerPC PReP boot");
+
+    else if(gpt_guid_match(g, 0xBC13C2FF, 0x59E6, 0x4262, 0xA352B275FD6F7172))
+        snprintf(desc, GUID_DESC_LEN, "Freedesktop Extended Boot Partition ($BOOT)");
+        
+    else {
         snprintf(desc, GUID_DESC_LEN, "[Unkown type]");
+        return 0;
+    }
+
+    return 1;
 }
 
 
@@ -259,9 +465,9 @@ gpt_load_table(TSK_VS_INFO * vs)
         for (; (uintptr_t) ent < (uintptr_t) ent_buf + vs->block_size &&
             i < tsk_getu32(vs->endian, &head->tab_num_ent); i++) {
 
-            /*UTF16 *name16;
+            UTF16 *name16;
             UTF8 *name8;
-            int retVal;*/
+            int retVal;
 
             if (tsk_verbose)
                 tsk_fprintf(stderr,
@@ -297,8 +503,26 @@ gpt_load_table(TSK_VS_INFO * vs)
             }
 
             
-            /*Find GUID partition type and use as description*/
-            gpt_guid_type(name, &(ent->type_guid));
+            /*Find GUID partition type and use as description.*/
+            /*If GUID type is unknown, use description stored in gpt entry.*/
+            if( ! gpt_guid_type(name, &(ent->type_guid))) {
+                name16 = (UTF16 *) ((uintptr_t) ent->name);
+                name8 = (UTF8 *) name;
+
+                retVal =
+                    tsk_UTF16toUTF8(vs->endian, (const UTF16 **) &name16,
+                    (UTF16 *) ((uintptr_t) name16 + sizeof(ent->name)),
+                    &name8,
+                    (UTF8 *) ((uintptr_t) name8 + 256), TSKlenientConversion);
+
+                if (retVal != TSKconversionOK) {
+                    if (tsk_verbose)
+                        tsk_fprintf(stderr,
+                            "gpt_load_table: Error converting name to UTF8: %d\n",
+                            retVal);
+                    *name = '\0';
+                }
+            }
 
 
             if (NULL == tsk_vs_part_add(vs,

--- a/tsk/vs/tsk_gpt.h
+++ b/tsk/vs/tsk_gpt.h
@@ -29,7 +29,7 @@ extern "C" {
 #define GPT_HEAD_SIG	0x5452415020494645ULL
 
 /*Length of a GUID partition type description*/
-#define GUID_DESC_LEN 64
+#define GUID_DESC_LEN 256
 
 /*Definiation of GUID struct.*/
     typedef struct{
@@ -37,7 +37,7 @@ extern "C" {
         uint16_t data_2;
         uint16_t data_3;
         uint8_t data_4[8];
-    } GUID;
+    } gpt_guid;
 
 
     typedef struct {
@@ -61,8 +61,8 @@ extern "C" {
 
 /* The location of this is specified in the header - tab_start */
     typedef struct {
-        GUID type_guid;         /* partition type GUID */
-        GUID id_guid;           /* unique partition GUID */
+        gpt_guid type_guid;         /* partition type GUID */
+        gpt_guid id_guid;           /* unique partition GUID */
         uint8_t start_lba[8];   /* Starting lba of part */
         uint8_t end_lba[8];     /* end lba of part */
         uint8_t flags[8];       /* flags */

--- a/tsk/vs/tsk_gpt.h
+++ b/tsk/vs/tsk_gpt.h
@@ -28,6 +28,18 @@ extern "C" {
 #define GPT_HEAD_OFFSET	1
 #define GPT_HEAD_SIG	0x5452415020494645ULL
 
+/*Length of a GUID partition type description*/
+#define GUID_DESC_LEN 64
+
+/*Definiation of GUID struct.*/
+    typedef struct{
+        uint32_t data_1;
+        uint16_t data_2;
+        uint16_t data_3;
+        uint8_t data_4[8];
+    } GUID;
+
+
     typedef struct {
         uint8_t signature[8];   /* EFI PART */
         uint8_t version[4];
@@ -49,8 +61,8 @@ extern "C" {
 
 /* The location of this is specified in the header - tab_start */
     typedef struct {
-        uint8_t type_guid[16];  /* partition type guid */
-        uint8_t id_guid[16];    /* unique partition GUID */
+        GUID type_guid;         /* partition type GUID */
+        GUID id_guid;           /* unique partition GUID */
         uint8_t start_lba[8];   /* Starting lba of part */
         uint8_t end_lba[8];     /* end lba of part */
         uint8_t flags[8];       /* flags */


### PR DESCRIPTION
The mmls tool displayed partition information in an image. In previous edition, while processing GPT partitioned image, the "Description" column used the **name** field of a partition entry. But usually it did not provide very useful information.

Unlike GPT, while processing DOS partition, the mmls uses the flag in an entry to indicate the type of the partition and displays it in the "Description" column. This provides more accurate and useful information.

Thus, using similar method in GPT system may be a better idea. The program now reads partition type GUID, namely the first 16 bytes of each GPT partition entry, then finds out the corresponding partition type and displays it in mmls output.
