### PR TITLE
TSK objects use SleuthkitCase.getDataSourceObjectId in ctors

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -110,21 +110,21 @@ public abstract class AbstractFile extends AbstractContent {
 	 * @param parentPath
 	 * @param mimeType The MIME type of the file, can be null
 	 */
-	AbstractFile(SleuthkitCase db, 
-			long objId, 
-			long dataSourceObjectId, 
+	AbstractFile(SleuthkitCase db,
+			long objId,
+			long dataSourceObjectId,
 			TskData.TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
-			String name, 
-			TskData.TSK_DB_FILES_TYPE_ENUM fileType, 
+			String name,
+			TskData.TSK_DB_FILES_TYPE_ENUM fileType,
 			long metaAddr, int metaSeq,
-			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, 
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, 
-			long ctime, long crtime, long atime, long mtime, 
-			short modes, 
-			int uid, int gid, 
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes,
+			int uid, int gid,
 			String md5Hash, FileKnown knownState,
-			String parentPath, 
+			String parentPath,
 			String mimeType) {
 		super(db, objId, name);
 		this.dataSourceObjectId = dataSourceObjectId;
@@ -525,16 +525,7 @@ public abstract class AbstractFile extends AbstractContent {
 	 */
 	@Override
 	public Content getDataSource() throws TskCoreException {
-		if (0 == this.dataSourceObjectId) {
-			// This lazy initialization is used to support the deprecated 
-			// protected constructor of this class and any unknown subclasses
-			// and should be removed when that constructor is removed. 
-			Content dataSource = super.getDataSource();
-			this.dataSourceObjectId = dataSource.getId();
-			return dataSource;
-		} else {
-			return getSleuthkitCase().getContentById(this.dataSourceObjectId);
-		}
+		return getSleuthkitCase().getContentById(this.dataSourceObjectId);
 	}
 
 	/**
@@ -1081,12 +1072,13 @@ public abstract class AbstractFile extends AbstractContent {
 	 * @deprecated Do not make subclasses outside of this package.
 	 */
 	@Deprecated
+	@SuppressWarnings("deprecation")
 	protected AbstractFile(SleuthkitCase db, long objId, TskData.TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
 			String name, TskData.TSK_DB_FILES_TYPE_ENUM fileType, long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
 			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
 			String parentPath) {
-		this(db, objId, 0, attrType, attrId, name, fileType, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+		this(db, objId, db.getDataSourceObjectId(objId), attrType, attrId, name, fileType, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
 
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
@@ -1,5 +1,5 @@
 /*
- * Sleuth Kit Data Model
+ * SleuthKit Java Bindings
  * 
  * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
@@ -23,7 +23,6 @@ import java.util.ResourceBundle;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.sleuthkit.datamodel.TskData.FileKnown;
 import org.sleuthkit.datamodel.TskData.TSK_DB_FILES_TYPE_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_META_TYPE_ENUM;
@@ -31,142 +30,113 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * Represents a file or directory that has been derived from another file and
- * contents of which are stored locally on user's machine.
- *
- * The file extends AbstractFile by adding derived method used and information
- * needed to rederive it.
- *
- * Use case example is an extracted file from an archive.
+ * A representation of a file or directory that has been derived from another
+ * file and is stored outside of the data source (e.g., on a user's machine). A
+ * typical example of a derived file is a file extracted from an archive file.
  */
 public class DerivedFile extends AbstractFile {
 
 	private volatile DerivedMethod derivedMethod;
 	private static final Logger logger = Logger.getLogger(DerivedFile.class.getName());
 	private static ResourceBundle bundle = ResourceBundle.getBundle("org.sleuthkit.datamodel.Bundle");
-	private boolean hasDerivedMethod = true; ///< whether it has the derived method to lazy load or not
+	private boolean hasDerivedMethod = true;
 
 	/**
-	 * Create a db representation of a derived file
+	 * Constructs a representation of a file or directory that has been derived
+	 * from another file and is stored outside of the data source (e.g., on a
+	 * user's machine). A typical example of a derived file is a file extracted
+	 * from an archive file.
 	 *
-	 * @param db
-	 * @param objId object if of this file already in database
-	 * @param name name of this derived file
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size size of the file
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath path of the parent of this derived file (e.g. fs zip
-	 * file, or another derived file path)
-	 * @param localPath local path of this derived file, relative to the db path
-	 * @param parentId parent id of this derived file to set if available
-	 * @deprecated Do not make subclasses of DerivedFile outside of this
-	 * package.
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param dataSourceObjectId The object id of the data source for the file.
+	 * @param name The name of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @param localPath The absolute path of the file in secondary storage.
+	 * @param parentId The object id of parent of the file.
+	 * @param mimeType The MIME type of the file, null if it has not yet been
+	 * determined.
 	 */
-	@Deprecated
-	protected DerivedFile(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
+	DerivedFile(SleuthkitCase db,
+			long objId,
+			long dataSourceObjectId,
+			String name,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size,
 			long ctime, long crtime, long atime, long mtime,
-			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId) {
-		this(db, objId, 0, name, dirType, metaType, dirFlag, metaFlags, size,
-				ctime, crtime, atime, mtime,
-				md5Hash, knownState,
-				parentPath, localPath, parentId, null);
-	}
-
-	/**
-	 * Create a db representation of a derived file
-	 *
-	 * @param db
-	 * @param objId object if of this file already in database
-	 * @param dataSourceObjectId The object id of the root data source of this
-	 * file.
-	 * @param name name of this derived file
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size size of the file
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath path of the parent of this derived file (e.g. fs zip
-	 * file, or another derived file path)
-	 * @param localPath local path of this derived file, relative to the db path
-	 * @param parentId parent id of this derived file to set if available
-	 */
-	DerivedFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name, TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags, long size,
-			long ctime, long crtime, long atime, long mtime,
-			String md5Hash, FileKnown knownState, String parentPath, String localPath, long parentId, String mimeType) {
-
+			String md5Hash, FileKnown knownState,
+			String parentPath,
+			String localPath,
+			long parentId,
+			String mimeType) {
+		// TODO (AUT-1904): The parent id should be passed to AbstractContent 
+		// through the class hierarchy contructors.
 		super(db, objId, dataSourceObjectId, TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, TSK_DB_FILES_TYPE_ENUM.LOCAL, 0L, 0, dirType, metaType, dirFlag,
 				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);
-
-		//use the local path read infrastructure
-		setLocalPath(localPath, false); //local paths for derived files are relative to case db
-	}
-
-	@Override
-	public boolean isRoot() {
-		//not a root of a fs, since it always has a parent
-		return false;
-	}
-
-	@Override
-	public Content getDataSource() throws TskCoreException {
-		//TODO need schema support to implement this more efficiently
-		Content parent = getParent();
-		Content dataSource = parent.getDataSource();
-		while (dataSource == null) {
-			parent = parent.getParent();
-			if (parent == null) {
-				//should never happen
-				break;
-			}
-			dataSource = parent.getDataSource();
-		}
-		return dataSource;
-	}
-
-	@Override
-	public List<Content> getChildren() throws TskCoreException {
-		//derived file/dir children, can only be other derived files
-		return getSleuthkitCase().getAbstractFileChildren(this, TSK_DB_FILES_TYPE_ENUM.DERIVED);
-
-	}
-
-	@Override
-	public List<Long> getChildrenIds() throws TskCoreException {
-		//derived file/dir children, can only be other derived files
-		return getSleuthkitCase().getAbstractFileChildrenIds(this, TSK_DB_FILES_TYPE_ENUM.DERIVED);
-	}
-
-	@Override
-	public <T> T accept(SleuthkitItemVisitor<T> v) {
-		return v.visit(this);
-	}
-
-	@Override
-	public <T> T accept(ContentVisitor<T> v) {
-		return v.visit(this);
+		setLocalPath(localPath, false);
 	}
 
 	/**
-	 * Get derived method for this derived file if it exists, or null
+	 * Indicates whether or not this derived file is the root of a file system,
+	 * always returns false.
 	 *
-	 * @return derived method if exists, or null
-	 * @throws TskCoreException exception thrown when critical error occurred
-	 * and derived method could not be queried
+	 * @return False.
+	 */
+	@Override
+	public boolean isRoot() {
+		return false;
+	}
+
+	/**
+	 * Gets the derived files, if any, that are children of this derived file.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
+	@Override
+	public List<Content> getChildren() throws TskCoreException {
+		return getSleuthkitCase().getAbstractFileChildren(this, TSK_DB_FILES_TYPE_ENUM.DERIVED);
+	}
+
+	/**
+	 * Gets the object ids of the derived files, if any, that are children of
+	 * this derived file.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
+	@Override
+	public List<Long> getChildrenIds() throws TskCoreException {
+		return getSleuthkitCase().getAbstractFileChildrenIds(this, TSK_DB_FILES_TYPE_ENUM.DERIVED);
+	}
+
+	/**
+	 * Gets the method used to derive this file, if it has been recorded.
+	 *
+	 * @return Derived method or null.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
 	 */
 	public synchronized DerivedMethod getDerivedMethod() throws TskCoreException {
 		if (derivedMethod == null && hasDerivedMethod == true) {
@@ -181,19 +151,55 @@ public class DerivedFile extends AbstractFile {
 				throw new TskCoreException(msg, e);
 			}
 		}
-
 		return derivedMethod;
 	}
 
+	/**
+	 * Accepts a content visitor (Visitor design pattern).
+	 *
+	 * @param visitor A ContentVisitor supplying an algorithm to run using this
+	 * derived file as input.
+	 * @return The output of the algorithm.
+	 */
+	@Override
+	public <T> T accept(SleuthkitItemVisitor<T> v) {
+		return v.visit(this);
+	}
+
+	/**
+	 * Accepts a Sleuthkit item visitor (Visitor design pattern).
+	 *
+	 * @param visitor A SleuthkitItemVisitor supplying an algorithm to run using
+	 * this derived file as input.
+	 * @return The output of the algorithm.
+	 */
+	@Override
+	public <T> T accept(ContentVisitor<T> v) {
+		return v.visit(this);
+	}
+
+	/**
+	 * Closes this derived file, if it was open.
+	 *
+	 * @throws Throwable
+	 */
 	@Override
 	protected void finalize() throws Throwable {
 		try {
 			close();
 		} finally {
-			super.finalize(); //To change body of generated methods, choose Tools | Templates.
+			super.finalize();
 		}
 	}
 
+	/**
+	 * Provides a string representation of this derived file.
+	 *
+	 * @param preserveState True if state should be included in the string
+	 * representation of this object.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public String toString(boolean preserveState) {
 		return super.toString(preserveState) + "DerivedFile{" //NON-NLS
@@ -203,16 +209,15 @@ public class DerivedFile extends AbstractFile {
 	}
 
 	/**
-	 * Method used to derive the file super-set of tsk_files_derived and
-	 * tsk_files_derived_method tables
+	 * A description of the method used to derive a file.
 	 */
 	public static class DerivedMethod {
 
-		private int derivedId; ///< Unique id for this derivation method.
-		private String toolName; ///< Name of derivation method/tool
-		private String toolVersion; ///< Version of tool used in derivation method
-		private String other; ///< Other details 
-		private String rederiveDetails; ///< details to rederive specific to this method
+		private final int derivedId; 
+		private String toolName; 
+		private String toolVersion; 
+		private String other; 
+		private String rederiveDetails;
 
 		public DerivedMethod(int derivedId, String rederiveDetails) {
 			this.derivedId = derivedId;
@@ -262,4 +267,56 @@ public class DerivedFile extends AbstractFile {
 			return "DerivedMethod{" + "derived_id=" + derivedId + ", toolName=" + toolName + ", toolVersion=" + toolVersion + ", other=" + other + ", rederiveDetails=" + rederiveDetails + '}'; //NON-NLS
 		}
 	}
+
+	/**
+	/**
+	 * Constructs a representation of a file or directory that has been derived
+	 * from another file and is stored outside of the data source (e.g., on a
+	 * user's machine). A typical example of a derived file is a file extracted
+	 * from an archive file.
+	 *
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param name The name of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @param localPath The absolute path of the file in secondary storage.
+	 * @param parentId The object id of parent of the file.
+	 * @deprecated Do not make subclasses outside of this package.
+	 */
+	@Deprecated
+	@SuppressWarnings("deprecation")
+	protected DerivedFile(SleuthkitCase db,
+			long objId,
+			String name,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			String md5Hash, FileKnown knownState,
+			String parentPath,
+			String localPath,
+			long parentId) {
+		this(db, objId, db.getDataSourceObjectId(objId), name, dirType, metaType, dirFlag, metaFlags, size,
+				ctime, crtime, atime, mtime,
+				md5Hash, knownState,
+				parentPath, localPath, parentId, null);
+	}
+
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/Directory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Directory.java
@@ -1,5 +1,5 @@
 /*
- * Sleuth Kit Data Model
+ * SleuthKit Java Bindings
  * 
  * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
@@ -26,83 +26,175 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * Representation of Directory object, stored in tsk_files table. Directory can
- * have other content children associated with it. There are many similarities
- * to a File otherwise, which are defined in the parent FsContent class.
+ * A representation of a file system directory that has been added to a case.
  */
 public class Directory extends FsContent {
 
 	/**
-	 * Create directory from db
+	 * Constructs a representation of a file system directory that has been
+	 * added to a case.
 	 *
-	 * @param db
-	 * @param objId
-	 * @param fsObjId
-	 * @param attrType
-	 * @param attrId
-	 * @param name
-	 * @param metaAddr
-	 * @param metaSeq
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param modes
-	 * @param uid
-	 * @param gid
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath
-	 * @deprecated Do not make subclasses of Directory outside of this package.
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param dataSourceObjectId The object id of the data source for the file.
+	 * @param fsObjId The object id of the file system to which this file
+	 * belongs.
+	 * @param attrType The type attribute given to the file by the file system.
+	 * @param attrId The type id given to the file by the file system.
+	 * @param name The name of the file.
+	 * @param metaAddr The meta address of the file.
+	 * @param metaSeq The meta sequence number of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param modes The modes for the file.
+	 * @param uid The UID for the file.
+	 * @param gid The GID for the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
 	 */
-	@Deprecated
-	protected Directory(SleuthkitCase db, long objId, long fsObjId,
+	Directory(SleuthkitCase db,
+			long objId,
+			long dataSourceObjectId,
+			long fsObjId,
 			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
-			String name, long metaAddr, int metaSeq,
+			String name,
+			long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, long ctime, long crtime, long atime, long mtime, short modes,
-			int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
-		this(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath);
-	}
-
-	Directory(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId,
-			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
-			String name, long metaAddr, int metaSeq,
-			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
-			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, long ctime, long crtime, long atime, long mtime, short modes,
-			int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes, int uid, int gid,
+			String md5Hash, FileKnown knownState, String parentPath) {
 		super(db, objId, dataSourceObjectId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
 	}
 
-	@Override
-	public <T> T accept(SleuthkitItemVisitor<T> v) {
-		return v.visit(this);
-	}
-
-	@Override
-	public <T> T accept(ContentVisitor<T> v) {
-		return v.visit(this);
-	}
-
+	/**
+	 * Gets the files, if any, that are children of this directory.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Content> getChildren() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildren(this);
 	}
 
+	/**
+	 * Gets the object ids of the files, if any, that are children of this
+	 * directory.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Long> getChildrenIds() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildrenIds(this);
 	}
 
+	/**
+	 * Accepts a content visitor (Visitor design pattern).
+	 *
+	 * @param visitor A ContentVisitor supplying an algorithm to run using this
+	 * directory as input.
+	 * @return The output of the algorithm.
+	 */
+	@Override
+	public <T> T accept(SleuthkitItemVisitor<T> v) {
+		return v.visit(this);
+	}
+
+	/**
+	 * Accepts a Sleuthkit item visitor (Visitor design pattern).
+	 *
+	 * @param visitor A SleuthkitItemVisitor supplying an algorithm to run using
+	 * this directory as input.
+	 * @return The output of the algorithm.
+	 */
+	@Override
+	public <T> T accept(ContentVisitor<T> v) {
+		return v.visit(this);
+	}
+
+	/**
+	 * Provides a string representation of this directory.
+	 *
+	 * @param preserveState True if state should be included in the string
+	 * representation of this object.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public String toString(boolean preserveState) {
 		return super.toString(preserveState) + "Directory [\t" + "]\t"; //NON-NLS
 	}
+
+	/**
+	 * Constructs a representation of a file system directory that has been
+	 * added to a case.
+	 *
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param fsObjId The object id of the file system to which this file
+	 * belongs.
+	 * @param attrType The type attribute given to the file by the file system.
+	 * @param attrId The type id given to the file by the file system.
+	 * @param name The name of the file.
+	 * @param metaAddr The meta address of the file.
+	 * @param metaSeq The meta sequence number of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param modes The modes for the file.
+	 * @param uid The UID for the file.
+	 * @param gid The GID for the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @deprecated Do not make subclasses outside of this package.
+	 */
+	@Deprecated
+	@SuppressWarnings("deprecation")
+	protected Directory(SleuthkitCase db,
+			long objId,
+			long fsObjId,
+			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+			String name,
+			long metaAddr, int metaSeq,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes, int uid, int gid,
+			String md5Hash, FileKnown knownState, String parentPath) {
+		this(db, objId, db.getDataSourceObjectId(objId), fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath);
+	}
+
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/File.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/File.java
@@ -1,5 +1,5 @@
 /*
- * Sleuth Kit Data Model
+ * SleuthKit Java Bindings
  * 
  * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
@@ -26,81 +26,177 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * Representation of File object, stored in tsk_files table. This is for a
- * file-system file (allocated, not-derived, or a "virtual" file) File does not
- * have content children objects associated with it. There are many similarities
- * to a Directory otherwise, which are defined in the parent FsContent class.
+ * A representation of a file system file that has been added to a case.
  */
 public class File extends FsContent {
 
 	/**
-	 * Create a File from db
+	 * Constructs a representation of a file system file that has been added to
+	 * the case.
 	 *
-	 * @param db
-	 * @param objId
-	 * @param fsObjId
-	 * @param attrType
-	 * @param attrId
-	 * @param name
-	 * @param metaAddr
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param modes
-	 * @param uid
-	 * @param gid
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath
-	 * @deprecated Do not make subclasses of File outside of this package.
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param dataSourceObjectId The object id of the data source for the file.
+	 * @param fsObjId The object id of the file system to which this file
+	 * belongs.
+	 * @param attrType The type attribute given to the file by the file system.
+	 * @param attrId The type id given to the file by the file system.
+	 * @param name The name of the file.
+	 * @param metaAddr The meta address of the file.
+	 * @param metaSeq The meta sequence number of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param modes The modes for the file.
+	 * @param uid The UID for the file.
+	 * @param gid The GID for the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @param mimeType The MIME type of the file, null if it has not yet been
+	 * determined.
 	 */
-	@Deprecated
-	protected File(SleuthkitCase db, long objId, long fsObjId,
-			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId, String name, long metaAddr, int metaSeq,
+	File(SleuthkitCase db,
+			long objId,
+			long dataSourceObjectId,
+			long fsObjId,
+			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+			String name,
+			long metaAddr, int metaSeq,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, long ctime, long crtime, long atime, long mtime,
-			short modes, int uid, int gid, String md5Hash, FileKnown knownState, String parentPath) {
-		this(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
-	}
-
-	File(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId,
-			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId, String name, long metaAddr, int metaSeq,
-			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
-			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, long ctime, long crtime, long atime, long mtime,
-			short modes, int uid, int gid, String md5Hash, FileKnown knownState, String parentPath, String mimeType) {
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes, int uid, int gid,
+			String md5Hash, FileKnown knownState, String parentPath, String mimeType) {
 		super(db, objId, dataSourceObjectId, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, mimeType);
 	}
 
-	@Override
-	public <T> T accept(SleuthkitItemVisitor<T> v) {
-		return v.visit(this);
-	}
-
-	@Override
-	public <T> T accept(ContentVisitor<T> v) {
-		return v.visit(this);
-	}
-
+	/**
+	 * Gets the derived files, if any, that are children of this file.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Content> getChildren() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildren(this, TskData.TSK_DB_FILES_TYPE_ENUM.DERIVED);
 	}
 
+	/**
+	 * Gets the object ids of the derived files, if any, that are children of
+	 * this file.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Long> getChildrenIds() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildrenIds(this, TskData.TSK_DB_FILES_TYPE_ENUM.DERIVED);
 	}
 
+	/**
+	 * Accepts a content visitor (Visitor design pattern).
+	 *
+	 * @param visitor A ContentVisitor supplying an algorithm to run using this
+	 * file as input.
+	 * @return The output of the algorithm.
+	 */
+	@Override
+	public <T> T accept(SleuthkitItemVisitor<T> v) {
+		return v.visit(this);
+	}
+
+	/**
+	 * Accepts a Sleuthkit item visitor (Visitor design pattern).
+	 *
+	 * @param visitor A SleuthkitItemVisitor supplying an algorithm to run using
+	 * this file as input.
+	 * @return The output of the algorithm.
+	 */
+	@Override
+	public <T> T accept(ContentVisitor<T> v) {
+		return v.visit(this);
+	}
+
+	/**
+	 * Provides a string representation of this file.
+	 *
+	 * @param preserveState True if state should be included in the string
+	 * representation of this object.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public String toString(boolean preserveState) {
 		return super.toString(preserveState) + "File [\t" + "]\t"; //NON-NLS
 	}
+
+	/**
+	 * Constructs a representation of a file system file that has been added to
+	 * the case.
+	 *
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param fsObjId The object id of the file system to which this file
+	 * belongs.
+	 * @param attrType The type attribute given to the file by the file system.
+	 * @param attrId The type id given to the file by the file system.
+	 * @param name The name of the file.
+	 * @param metaAddr The meta address of the file.
+	 * @param metaSeq The meta sequence number of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param modes The modes for the file.
+	 * @param uid The UID for the file.
+	 * @param gid The GID for the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @deprecated Do not make subclasses outside of this package.
+	 */
+	@Deprecated
+	@SuppressWarnings("deprecation")
+	protected File(SleuthkitCase db,
+			long objId,
+			long fsObjId,
+			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+			String name,
+			long metaAddr, int metaSeq,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes, int uid, int gid,
+			String md5Hash, FileKnown knownState, String parentPath) {
+		this(db, objId, db.getDataSourceObjectId(objId), fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+	}
+
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
@@ -1,5 +1,5 @@
 /*
- * Sleuth Kit Data Model
+ * SleuthKit Java Bindings
  * 
  * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
@@ -30,9 +30,8 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * Generalized class that stores metadata that are common to both File and
- * Directory objects stored in tsk_files table Caches internal tsk file handle
- * and reuses it for reads
+ * An abstract base class for representations of a file system files or
+ * directories that have been added to a case.
  *
  * TODO move common getters to AbstractFile class
  */
@@ -40,94 +39,111 @@ public abstract class FsContent extends AbstractFile {
 
 	private static final Logger logger = Logger.getLogger(AbstractFile.class.getName());
 	private static final ResourceBundle bundle = ResourceBundle.getBundle("org.sleuthkit.datamodel.Bundle");
-	///read only database tsk_files fields
-	protected final long fsObjId;
 	private String uniquePath;
-	///read-write database tsk_files fields
 	private final SleuthkitCase tskCase;
-
 	private List<String> metaDataText = null;
+	private volatile FileSystem parentFileSystem;
 
 	/**
-	 * parent file system
+	 * @deprecated Use getFileSystemId instead.
 	 */
-	private volatile FileSystem parentFileSystem;
-	///other members
+	// TODO: Make private.
+	@Deprecated
+	protected final long fsObjId;
+
 	/**
-	 * file Handle
+	 *
+	 * @deprecated Use getFileHandle instead.
 	 */
+	// TODO: Make private.
+	@Deprecated
 	protected volatile long fileHandle = 0;
 
 	/**
-	 * Create an FsContent object from a database object
+	 * Constructs an abstract base class for representations of a file system
+	 * files or directories that have been added to a case.
 	 *
-	 * @param db
-	 * @param objId
-	 * @param fsObjId
-	 * @param attrType
-	 * @param attrId
-	 * @param name
-	 * @param metaAddr
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size
-	 * @param ctime
-	 * @param crtime
-	 * @param atime
-	 * @param mtime
-	 * @param modes
-	 * @param uid
-	 * @param gid
-	 * @param md5Hash String of MD5 hash of content or null if not known
-	 * @param knownState
-	 * @param parentPath
-	 * @deprecated Do not make subclasses of FsContent outside of this package.
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param dataSourceObjectId The object id of the data source for the file.
+	 * @param fsObjId The object id of the file system to which this file
+	 * belongs.
+	 * @param attrType The type attribute given to the file by the file system.
+	 * @param attrId The type id given to the file by the file system.
+	 * @param name The name of the file.
+	 * @param metaAddr The meta address of the file.
+	 * @param metaSeq The meta sequence number of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param modes The modes for the file.
+	 * @param uid The UID for the file.
+	 * @param gid The GID for the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @param mimeType The MIME type of the file, null if it has not yet been
+	 * determined.
 	 */
-	@Deprecated
-	FsContent(SleuthkitCase db, long objId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
-			String name, long metaAddr, int metaSeq,
-			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
-			String parentPath) {
-		this(db, objId, 0, fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
-	}
-
-	FsContent(SleuthkitCase db, long objId, long dataSourceObjectId, long fsObjId, TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
-			String name, long metaAddr, int metaSeq,
-			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, long ctime, long crtime, long atime, long mtime, short modes, int uid, int gid, String md5Hash, FileKnown knownState,
-			String parentPath, String mimeType) {
+	@SuppressWarnings("deprecation")
+	FsContent(SleuthkitCase db,
+			long objId,
+			long dataSourceObjectId,
+			long fsObjId,
+			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+			String name,
+			long metaAddr, int metaSeq,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes, int uid, int gid,
+			String md5Hash, FileKnown knownState,
+			String parentPath,
+			String mimeType) {
 		super(db, objId, dataSourceObjectId, attrType, attrId, name, TskData.TSK_DB_FILES_TYPE_ENUM.FS, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, mimeType);
 		this.tskCase = db;
 		this.fsObjId = fsObjId;
 	}
 
 	/**
-	 * Get the parent file system id
+	 * Get the object id of the parent file system of this file or directory.
 	 *
 	 * @return the parent file system id
 	 */
+	@SuppressWarnings("deprecation")
 	public long getFileSystemId() {
 		return fsObjId;
 	}
 
 	/**
-	 * Sets the parent file system, called by parent during object creation
+	 * Sets the parent file system of this file or directory.
 	 *
-	 * @param parent parent file system object
+	 * @param parent The parent file system object.
 	 */
 	void setFileSystem(FileSystem parent) {
 		parentFileSystem = parent;
 	}
 
 	/**
-	 * Get the parent file system
+	 * Gets the parent file system of this file or directory.
 	 *
 	 * @return the file system object of the parent
 	 * @throws org.sleuthkit.datamodel.TskCoreException
 	 */
+	@SuppressWarnings("deprecation")
 	public FileSystem getFileSystem() throws TskCoreException {
 		if (parentFileSystem == null) {
 			synchronized (this) {
@@ -140,10 +156,11 @@ public abstract class FsContent extends AbstractFile {
 	}
 
 	/**
-	 * Open JNI file handle if it is not open already
+	 * Opens a JNI file handle for this file or directory.
 	 *
-	 * @throws TskCoreException
+	 * @throws TskCoreException if there is a problem opening the handle.
 	 */
+	@SuppressWarnings("deprecation")
 	private void loadFileHandle() throws TskCoreException {
 		if (fileHandle == 0) {
 			synchronized (this) {
@@ -154,6 +171,26 @@ public abstract class FsContent extends AbstractFile {
 		}
 	}
 
+	/**
+	 * Gets the JNI file handle for this file or directory, zero if the file has
+	 * not been opened by calling loadHandle.
+	 *
+	 * @return The JNI file handle.
+	 */
+	@SuppressWarnings("deprecation")
+	long getFileHandle() {
+		return fileHandle;
+	}
+
+	/**
+	 * Reads bytes from this file or directory.
+	 *
+	 * @param buf Buffer to read into.
+	 * @param offset Start position in the file.
+	 * @param len Number of bytes to read.
+	 * @return Number of bytes read.
+	 * @throws TskCoreException if there is a problem reading the file.
+	 */
 	@Override
 	@SuppressWarnings("deprecation")
 	protected int readInt(byte[] buf, long offset, long len) throws TskCoreException {
@@ -188,26 +225,34 @@ public abstract class FsContent extends AbstractFile {
 		}
 	}
 
-	/*
-	 * -------------------------------------------------------------------------
-	 * Getters to retrieve meta-data attributes values
-	 * -------------------------------------------------------------------------
-	 */
 	/**
-	 * Gets parent directory
+	 * Gets the parent directory of this file or directory.
 	 *
-	 * @return the parent Directory
-	 * @throws TskCoreException exception thrown if error occurred in tsk core
+	 * @return The parent directory
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
 	 */
 	public AbstractFile getParentDirectory() throws TskCoreException {
 		return getSleuthkitCase().getParentDirectory(this);
 	}
 
+	/**
+	 * Gets the data source (image) for this file or directory directory.
+	 *
+	 * @return The data source.
+	 * @throws TskCoreException if there is an error querying the case database.
+	 */
 	@Override
 	public Content getDataSource() throws TskCoreException {
 		return getFileSystem().getDataSource();
 	}
 
+	/**
+	 * Get the full path to this file or directory, starting with a "/" and the
+	 * image name and then all the other segments in the path.
+	 *
+	 * @throws TskCoreException if there is an error querying the case database.
+	 */
 	@Override
 	public synchronized String getUniquePath() throws TskCoreException {
 		if (uniquePath == null) {
@@ -221,11 +266,11 @@ public abstract class FsContent extends AbstractFile {
 	}
 
 	/**
-	 * Return a text-based description of the file's metadata. This is the same
-	 * content as the TSK istat tool produces. Is different information for each
-	 * type of file system.
+	 * Gets a text-based description of the file's metadata. This is the same
+	 * content as the TSK istat tool produces and is different information for
+	 * each type of file system.
 	 *
-	 * @return List of text, one string per line.
+	 * @return List of text, one element per line.
 	 * @throws TskCoreException
 	 */
 	public synchronized List<String> getMetaDataText() throws TskCoreException {
@@ -245,7 +290,11 @@ public abstract class FsContent extends AbstractFile {
 		return metaDataText;
 	}
 
+	/**
+	 * Closes the JNI file handle for this file or directory.
+	 */
 	@Override
+	@SuppressWarnings("deprecation")
 	public void close() {
 		if (fileHandle != 0) {
 			synchronized (this) {
@@ -258,6 +307,10 @@ public abstract class FsContent extends AbstractFile {
 		}
 	}
 
+	/**
+	 * Closes the JNI file handle for this file or directory when the FsContent
+	 * object is garbage-collected.
+	 */
 	@Override
 	public void finalize() throws Throwable {
 		try {
@@ -267,7 +320,16 @@ public abstract class FsContent extends AbstractFile {
 		}
 	}
 
+	/**
+	 * Provides a string representation of this file or directory.
+	 *
+	 * @param preserveState True if state should be included in the string
+	 * representation of this object.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
+	@SuppressWarnings("deprecation")
 	public String toString(boolean preserveState) {
 		return super.toString(preserveState)
 				+ "FsContent [\t" //NON-NLS
@@ -276,4 +338,59 @@ public abstract class FsContent extends AbstractFile {
 				+ "\t" + "fileHandle " + fileHandle //NON-NLS
 				+ "]\t";
 	}
+
+	/**
+	 * Constructs an abstract base class for representations of a file system
+	 * files or directories that have been added to a case.
+	 *
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param fsObjId The object id of the file system to which this file
+	 * belongs.
+	 * @param attrType The type attribute given to the file by the file system.
+	 * @param attrId The type id given to the file by the file system.
+	 * @param name The name of the file.
+	 * @param metaAddr The meta address of the file.
+	 * @param metaSeq The meta sequence number of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param ctime The changed time of the file.
+	 * @param crtime The created time of the file.
+	 * @param atime The accessed time of the file.
+	 * @param mtime The modified time of the file.
+	 * @param modes The modes for the file.
+	 * @param uid The UID for the file.
+	 * @param gid The GID for the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @deprecated Do not make subclasses outside of this package.
+	 */
+	@Deprecated
+	@SuppressWarnings("deprecation")
+	FsContent(SleuthkitCase db,
+			long objId,
+			long fsObjId,
+			TSK_FS_ATTR_TYPE_ENUM attrType, short attrId,
+			String name,
+			long metaAddr, int metaSeq,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size,
+			long ctime, long crtime, long atime, long mtime,
+			short modes, int uid, int gid,
+			String md5Hash, FileKnown knownState,
+			String parentPath) {
+		this(db, objId, db.getDataSourceObjectId(objId), fsObjId, attrType, attrId, name, metaAddr, metaSeq, dirType, metaType, dirFlag, metaFlags, size, ctime, crtime, atime, mtime, modes, uid, gid, md5Hash, knownState, parentPath, null);
+	}
+
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
@@ -1,5 +1,5 @@
 /*
- * Autopsy Forensic Browser
+ * SleuthKit Java Bindings
  * 
  * Copyright 2011-2016 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
@@ -29,105 +29,131 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * Layout file object representation of a layout file stored in tsk_files table.
- * Layout files are not fs files, but "virtual" files created from blocks of
- * data (e.g. unallocated) that are treated as files for convenience and
- * uniformity.
+ * A representation of a layout file that has been added to a case. Layout files
+ * are not file system files, but "virtual" files created from blocks of data
+ * (e.g. unallocated) that are treated as files for convenience and uniformity.
  *
- * Because layout files are not real fs files, they only utilize a subset of
- * meta-data attributes. A layout file normally contains 1 or more entry in
- * tsk_file_layout table that define ordered byte block ranges, with respect to
- * the image.
+ * Because layout files are not real file system files, they only utilize a
+ * subset of meta-data attributes. A layout file normally contains one or more
+ * entry in tsk_file_layout table that define ordered byte block ranges, with
+ * respect to the image.
  *
  * The class also supports reads of layout files, reading blocks across ranges
- * in a sequence
+ * in a sequence.
  */
 public class LayoutFile extends AbstractFile {
 
 	private long imageHandle = -1;
 
 	/**
-	 * Constructs a layout file.
+	 * Constructs a representation of a layout file that has been added to a
+	 * case. Layout files are not file system files, but "virtual" files created
+	 * from blocks of data (e.g. unallocated) that are treated as files for
+	 * convenience and uniformity.
 	 *
-	 * @param db
-	 * @param objId
-	 * @param name
-	 * @param fileType
-	 * @param dirType
-	 * @param metaType
-	 * @param dirFlag
-	 * @param metaFlags
-	 * @param size
-	 * @param md5Hash
-	 * @param knownState
-	 * @param parentPath
-	 * @deprecated
-	 * @deprecated Do not make subclasses of LayoutFile outside of this package.
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param dataSourceObjectId The object id of the data source for the file.
+	 * @param name The name of the file.
+	 * @param fileType The type of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @param mimeType The MIME type of the file, null if it has not yet been
+	 * determined.
 	 */
-	@Deprecated
-	protected LayoutFile(SleuthkitCase db, long objId, String name,
+	LayoutFile(SleuthkitCase db,
+			long objId,
+			long dataSourceObjectId,
+			String name,
 			TSK_DB_FILES_TYPE_ENUM fileType,
 			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
 			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, String md5Hash, FileKnown knownState, String parentPath) {
-		this(db, objId, 0, name, fileType, dirType, metaType, dirFlag, metaFlags, size, md5Hash, knownState, parentPath, null);
-	}
-
-	LayoutFile(SleuthkitCase db, long objId, long dataSourceObjectId, String name,
-			TSK_DB_FILES_TYPE_ENUM fileType,
-			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
-			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, String md5Hash, FileKnown knownState, String parentPath, String mimeType) {
+			long size,
+			String md5Hash, FileKnown knownState,
+			String parentPath, String mimeType) {
 		super(db, objId, dataSourceObjectId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0, name, fileType, 0L, 0, dirType, metaType, dirFlag, metaFlags, size, 0L, 0L, 0L, 0L, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);
 	}
-		
+
 	/**
-	 * Get number of file layout ranges associated with this layout file
+	 * Gets the number of file layout ranges associated with this layout file.
 	 *
-	 * @return number of file layout ranges objects associated
+	 * @return The number of file layout ranges.
 	 */
 	public int getNumParts() {
 		int numParts = 0;
 		try {
 			numParts = getRanges().size();
 		} catch (TskCoreException ex) {
-			Logger.getLogger(LayoutFile.class.getName()).log(Level.INFO, "Error getting layout content ranges for size", ex); //NON-NLS
+			Logger.getLogger(LayoutFile.class.getName()).log(Level.SEVERE, String.format("Error getting layout ranges for layout file (objId = %d)", getId()), ex); //NON-NLS
 		}
 		return numParts;
 	}
 
+	/**
+	 * Indicates whether or not this layout file is the root of a file system,
+	 * always returns false.
+	 *
+	 * @return False.
+	 */
+	@Override
+	public boolean isRoot() {
+		return false;
+	}
+
+	/**
+	 * Gets the derived files, if any, that are children of this file.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Content> getChildren() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildren(this, TskData.TSK_DB_FILES_TYPE_ENUM.DERIVED);
 	}
 
+	/**
+	 * Gets the object ids of the derived files, if any, that are children of
+	 * this file.
+	 *
+	 * @return A list of the children.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public List<Long> getChildrenIds() throws TskCoreException {
 		return getSleuthkitCase().getAbstractFileChildrenIds(this, TskData.TSK_DB_FILES_TYPE_ENUM.DERIVED);
 	}
 
 	/**
-	 * Calculate the size from all ranges / blocks
-	 *
-	 * @return total content size in bytes
+	 * Does nothing, a layout file cannot be directly opened, read, or closed.
+	 * Use the readInt method to get layout file content.
 	 */
-	private long calcSize() {
-		long calcSize = 0;
-		try {
-			for (TskFileRange range : getRanges()) {
-				calcSize += range.getByteLen();
-			}
-		} catch (TskCoreException ex) {
-			Logger.getLogger(LayoutFile.class.getName()).log(Level.SEVERE, "Error calculating layout file size from ranges", ex); //NON-NLS
-		}
-		return calcSize;
-	}
-
 	@Override
 	public void close() {
-		//nothing to be closed
 	}
 
+	/**
+	 * Reads bytes from the layout ranges associated with this file.
+	 *
+	 * @param buf Buffer to read into.
+	 * @param offset Start position in the file.
+	 * @param len Number of bytes to read.
+	 * @return Number of bytes read.
+	 * @throws TskCoreException if there is a problem reading the file.
+	 */
 	@Override
 	protected int readInt(byte[] buf, long offset, long len) throws TskCoreException {
 		long offsetInThisLayoutContent = 0; // current offset in this LayoutContent
@@ -166,14 +192,15 @@ public class LayoutFile extends AbstractFile {
 		return bytesRead;
 	}
 
-	/*
-	 * Read bytes from an image into a buffer, starting at given position in buffer
-	 * 
-	 * @param imgHandle		the image to read from
-	 * @param buf			the array to read into
-	 * @param offsetInBuf	where to start in the array
-	 * @param offsetInImage	where to start in the image
-	 * @param lenToRead		how far to read in the image
+	/**
+	 * Reads bytes from an image into a buffer, starting at given position in
+	 * buffer.
+	 *
+	 * @param imgHandle	The image to read from.
+	 * @param buf	The array to read into.
+	 * @param offsetInBuf	Where to start in the array.
+	 * @param offsetInImage	Where to start in the image.
+	 * @param lenToRead	How far to read in the image.
 	 */
 	private int readImgToOffset(long imgHandle, byte[] buf, int offsetInBuf, long offsetInImage, int lenToRead) throws TskCoreException {
 		byte[] currentBuffer = new byte[lenToRead]; // the buffer for the current range object
@@ -182,23 +209,80 @@ public class LayoutFile extends AbstractFile {
 		return lenRead;
 	}
 
+	/**
+	 * Accepts a content visitor (Visitor design pattern).
+	 *
+	 * @param visitor A ContentVisitor supplying an algorithm to run using this
+	 * file as input.
+	 * @return The output of the algorithm.
+	 */
 	@Override
 	public <T> T accept(ContentVisitor<T> v) {
 		return v.visit(this);
 	}
 
+	/**
+	 * Accepts a Sleuthkit item visitor (Visitor design pattern).
+	 *
+	 * @param visitor A SleuthkitItemVisitor supplying an algorithm to run using
+	 * this file as input.
+	 * @return The output of the algorithm.
+	 */
 	@Override
 	public <T> T accept(SleuthkitItemVisitor<T> v) {
 		return v.visit(this);
 	}
 
-	@Override
-	public boolean isRoot() {
-		return false;
-	}
-
+	/**
+	 * Provides a string representation of this file.
+	 *
+	 * @param preserveState True if state should be included in the string
+	 * representation of this object.
+	 * @throws TskCoreException if there was an error querying the case
+	 * database.
+	 */
 	@Override
 	public String toString(boolean preserveState) {
 		return super.toString(preserveState) + "LayoutFile [\t" + "]\t"; //NON-NLS
 	}
+
+	/**
+	 * Constructs a representation of a layout file that has been added to a
+	 * case. Layout files are not file system files, but "virtual" files created
+	 * from blocks of data (e.g. unallocated) that are treated as files for
+	 * convenience and uniformity.
+	 *
+	 * @param db The case database to which the file has been added.
+	 * @param objId The object id of the file in the case database.
+	 * @param dataSourceObjectId The object id of the data source for the file.
+	 * @param name The name of the file.
+	 * @param dirType The type of the file, usually as reported in the name
+	 * structure of the file system. May be set to TSK_FS_NAME_TYPE_ENUM.UNDEF.
+	 * @param metaType The type of the file, usually as reported in the metadata
+	 * structure of the file system. May be set to
+	 * TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_UNDEF.
+	 * @param dirFlag The allocated status of the file, usually as reported in
+	 * the name structure of the file system.
+	 * @param metaFlags The allocated status of the file, usually as reported in
+	 * the metadata structure of the file system.
+	 * @param size The size of the file.
+	 * @param md5Hash The MD5 hash of the file, null if not yet calculated.
+	 * @param knownState The known state of the file from a hash database
+	 * lookup, null if not yet looked up.
+	 * @param parentPath The path of the parent of the file.
+	 * @param mimeType The MIME type of the file, null if it has not yet been
+	 * determined.
+	 * @deprecated
+	 * @deprecated Do not make subclasses outside of this package.
+	 */
+	@Deprecated
+	@SuppressWarnings("deprecation")
+	protected LayoutFile(SleuthkitCase db, long objId, String name,
+			TSK_DB_FILES_TYPE_ENUM fileType,
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType,
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size, String md5Hash, FileKnown knownState, String parentPath) {
+		this(db, objId, db.getDataSourceObjectId(objId), name, fileType, dirType, metaType, dirFlag, metaFlags, size, md5Hash, knownState, parentPath, null);
+	}
+
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
@@ -28,13 +28,13 @@ import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_FLAG_ENUM;
 import org.sleuthkit.datamodel.TskData.TSK_FS_NAME_TYPE_ENUM;
 
 /**
- * A representation of a local/logical file (e.g., on user's machine) that has
- * been added to the case.
+ * A representation of a local/logical file (e.g., on a user's machine) that has
+ * been added to a case.
  */
 public class LocalFile extends AbstractFile {
 
 	/**
-	 * Constructs a representation of a local/logical file (e.g., on user's
+	 * Constructs a representation of a local/logical file (e.g., on a user's
 	 * machine) that has been added to the case database.
 	 *
 	 * @param db The case database to which the file has been added.
@@ -79,7 +79,7 @@ public class LocalFile extends AbstractFile {
 			String localPath) {
 		super(db, objId, dataSourceObjectId, TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, (short) 0,
 				name, fileType, 0L, 0, dirType, metaType, dirFlag,
-				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);		
+				metaFlags, size, ctime, crtime, atime, mtime, (short) 0, 0, 0, md5Hash, knownState, parentPath, mimeType);
 		// TODO (AUT-1904): The parent id should be passed to AbstractContent 
 		// through the class hierarchy contructors, using 
 		// AbstractContent.UNKNOWN_ID as needed.
@@ -149,7 +149,7 @@ public class LocalFile extends AbstractFile {
 	 * Accepts a content visitor (Visitor design pattern).
 	 *
 	 * @param visitor A ContentVisitor supplying an algorithm to run using this
-	 * virtual directory as input.
+	 * local file as input.
 	 * @return The output of the algorithm.
 	 */
 	@Override
@@ -161,7 +161,7 @@ public class LocalFile extends AbstractFile {
 	 * Accepts a Sleuthkit item visitor (Visitor design pattern).
 	 *
 	 * @param visitor A SleuthkitItemVisitor supplying an algorithm to run using
-	 * this virtual directory as input.
+	 * this local file as input.
 	 * @return The output of the algorithm.
 	 */
 	@Override
@@ -170,7 +170,7 @@ public class LocalFile extends AbstractFile {
 	}
 
 	/**
-	 * Provides a string representation of this virtual directory.
+	 * Provides a string representation of this local file.
 	 *
 	 * @param preserveState True if state should be included in the string
 	 * representation of this object.
@@ -183,7 +183,7 @@ public class LocalFile extends AbstractFile {
 	}
 
 	/**
-	 * Constructs a representation of a local/logical file (e.g., on user's
+	 * Constructs a representation of a local/logical file (e.g., on a user's
 	 * machine) that has been added to the case database.
 	 *
 	 * @param db The case database to which the file has been added.
@@ -239,7 +239,7 @@ public class LocalFile extends AbstractFile {
 	}
 
 	/**
-	 * Constructs a representation of a local/logical file (e.g., on user's
+	 * Constructs a representation of a local/logical file (e.g., on a user's
 	 * machine) that has been added to the case database.
 	 *
 	 * @param db The case database to which the file has been added.
@@ -283,7 +283,7 @@ public class LocalFile extends AbstractFile {
 	}
 
 	/**
-	 * Constructs a representation of a local/logical file (e.g., on user's
+	 * Constructs a representation of a local/logical file (e.g., on a user's
 	 * machine) that has been added to the case.
 	 *
 	 * @param db The case database to which the file has been added.

--- a/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
@@ -224,10 +224,16 @@ public class VirtualDirectory extends AbstractFile {
 	 * @deprecated Do not make subclasses outside of this package.
 	 */
 	@Deprecated
-	VirtualDirectory(SleuthkitCase db, long objId, String name, TSK_FS_NAME_TYPE_ENUM dirType,
-			TSK_FS_META_TYPE_ENUM metaType, TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
-			long size, String md5Hash, FileKnown knownState, String parentPath) {
-		this(db, objId, 0, name, dirType, metaType, dirFlag, metaFlags, md5Hash, knownState, parentPath);
+	@SuppressWarnings("deprecation")
+	VirtualDirectory(SleuthkitCase db, 
+			long objId, 
+			String name, 
+			TSK_FS_NAME_TYPE_ENUM dirType, TSK_FS_META_TYPE_ENUM metaType, 
+			TSK_FS_NAME_FLAG_ENUM dirFlag, short metaFlags,
+			long size, 
+			String md5Hash, FileKnown knownState, 
+			String parentPath) {
+		this(db, objId, db.getDataSourceObjectId(objId), name, dirType, metaType, dirFlag, metaFlags, md5Hash, knownState, parentPath);
 	}
-
+	
 }


### PR DESCRIPTION
- TSK objects use SleuthkitCase.getDataSourceObjectId in ctors
- AbstractFile.getDataSource uses data source id to get data source. 
- Removed obsolete getDataSource method from DerivedFile
- Updated comments, headers, and formatting for most of the files involved.
- Deprecated protected fields of FsContent class.