### PR TITLE
Unify fs_name.c functions newline behaviour

### DIFF
--- a/tsk/fs/fls_lib.c
+++ b/tsk/fs/fls_lib.c
@@ -75,6 +75,7 @@ printit(TSK_FS_FILE * fs_file, const char *a_path,
 				tsk_fs_name_print_mac_md5(stdout, fs_file, a_path, fs_attr,
 					fls_data->macpre, fls_data->sec_skew,
 					hash_results.md5_digest);
+                                tsk_printf("\n");
 			}
 			else{
 				// If the hash calculation had errors, pass in a buffer of nulls
@@ -82,11 +83,13 @@ printit(TSK_FS_FILE * fs_file, const char *a_path,
 				tsk_fs_name_print_mac_md5(stdout, fs_file, a_path, fs_attr,
 					fls_data->macpre, fls_data->sec_skew,
 					null_buf);
+                                tsk_printf("\n");
 			}
         }
         else {
             tsk_fs_name_print_mac(stdout, fs_file, a_path,
                 fs_attr, fls_data->macpre, fls_data->sec_skew);
+            tsk_printf("\n");
         }
     }
     else if (fls_data->flags & TSK_FS_FLS_LONG) {

--- a/tsk/fs/fls_lib.c
+++ b/tsk/fs/fls_lib.c
@@ -1,8 +1,8 @@
 /*
 ** fls
-** The Sleuth Kit 
+** The Sleuth Kit
 **
-** Given an image and directory inode, display the file names and 
+** Given an image and directory inode, display the file names and
 ** directories that exist (both active and deleted)
 **
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
@@ -20,13 +20,13 @@
 **
 */
 
-/** \file fls_lib.c 
+/** \file fls_lib.c
  * Contains the library code associated with the TSK fls tool to list files in a directory.
  */
 
 #include "tsk_fs_i.h"
 
-/** \internal 
+/** \internal
 * Structure to store data for callbacks.
 */
 typedef struct {
@@ -43,7 +43,7 @@ typedef struct {
 
 /* this is a wrapper type function that takes care of the runtime
  * flags
- * 
+ *
  * fs_attr should be set to NULL for all non-NTFS file systems
  */
 static void
@@ -93,6 +93,7 @@ printit(TSK_FS_FILE * fs_file, const char *a_path,
         tsk_fs_name_print_long(stdout, fs_file, a_path, fs_file->fs_info,
             fs_attr, TSK_FS_FLS_FULL & fls_data->flags ? 1 : 0,
             fls_data->sec_skew);
+        tsk_printf("\n");
     }
     else {
         tsk_fs_name_print(stdout, fs_file, a_path, fs_file->fs_info,
@@ -102,7 +103,7 @@ printit(TSK_FS_FILE * fs_file, const char *a_path,
 }
 
 
-/* 
+/*
  * call back action function for dent_walk
  */
 static TSK_WALK_RET_ENUM
@@ -159,8 +160,8 @@ print_dent_act(TSK_FS_FILE * fs_file, const char *a_path, void *ptr)
                     printed = 1;
 
                     /* If it is . or .. only print it if the flags say so,
-                     * we continue with other streams though in case the 
-                     * directory has a data stream 
+                     * we continue with other streams though in case the
+                     * directory has a data stream
                      */
                     if (!((TSK_FS_ISDOT(fs_file->name->name)) &&
                             ((fls_data->flags & TSK_FS_FLS_DOT) == 0)))
@@ -172,8 +173,8 @@ print_dent_act(TSK_FS_FILE * fs_file, const char *a_path, void *ptr)
                     (fs_attr->id == fs_file->meta->time2.ntfs.fn_id) &&
                     (fls_data->flags & TSK_FS_FLS_MAC)) {
                     /* If it is . or .. only print it if the flags say so,
-                     * we continue with other streams though in case the 
-                     * directory has a data stream 
+                     * we continue with other streams though in case the
+                     * directory has a data stream
                      */
                     if (!((TSK_FS_ISDOT(fs_file->name->name)) &&
                             ((fls_data->flags & TSK_FS_FLS_DOT) == 0)))

--- a/tsk/fs/fs_name.c
+++ b/tsk/fs/fs_name.c
@@ -1,14 +1,14 @@
 /*
 ** fs_name
-** The Sleuth Kit 
+** The Sleuth Kit
 **
-** Display and manipulate directory entries 
+** Display and manipulate directory entries
 ** This file contains generic functions that call the appropriate function
 ** depending on the file system type.
 **
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2013 Brian Carrier.  All Rights reserved
-** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved 
+** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
 **
 ** TASK
 ** Copyright (c) 2002 Brian Carrier, @stake Inc.  All rights reserved
@@ -139,7 +139,7 @@ tsk_fs_name_free(TSK_FS_NAME * fs_name)
 
 /** \internal
  * Copy the contents of a TSK_FS_NAME structure to another
- * structure. 
+ * structure.
  * @param a_fs_name_to Destination structure to copy to
  * @param a_fs_name_from Source structure to copy from
  * @returns 1 on error
@@ -214,7 +214,7 @@ tsk_fs_name_copy(TSK_FS_NAME * a_fs_name_to,
 
 /**
  * \ingroup fslib
- * Makes the "ls -l" permissions string for a file. 
+ * Makes the "ls -l" permissions string for a file.
  *
  * @param a_fs_meta File to be processed
  * @param a_buf [out] Buffer to write results to (must be 12 bytes or longer)
@@ -351,7 +351,7 @@ tsk_fs_print_time(FILE * hFile, time_t time)
 
 // @@@ We could merge this with the tsk_fs_time_to_str in
 // the future when the feature to include time resolution
-// is added to TSK_FS_META (and then that value would be 
+// is added to TSK_FS_META (and then that value would be
 // passed in and tsk_fs_time_to_str would decide what to
 // round up/down to
 
@@ -379,14 +379,14 @@ tsk_fs_print_day(FILE * hFile, time_t time)
 
 
 /**
-* \internal
+ * \internal
  * Simple print of dentry type / inode type, deleted, inode, and
  * name
  *
  * fs_attr is used for alternate data streams in NTFS, set to NULL
  * for all other file systems
  *
- * A newline is not printed at the end
+ * Newline is not printed at the end
  *
  * If path is NULL, then skip else use. it has the full directory name
  *  It needs to end with "/"
@@ -409,7 +409,7 @@ tsk_fs_name_print(FILE * hFile, const TSK_FS_FILE * fs_file,
     /* type of file - based on inode type: we want letters though for
      * regular files so we use the dent_str though */
     if (fs_file->meta) {
-        /* 
+        /*
          * An NTFS directory can have a Data stream, in which
          * case it would be printed with modes of a
          * directory, although it is really a file
@@ -495,12 +495,13 @@ tsk_fs_name_print(FILE * hFile, const TSK_FS_FILE * fs_file,
 /**
  * \internal
  * Print contents of  fs_name entry format like ls -l
-**
-** All elements are tab delimited 
-**
-** If path is NULL, then skip else use. it has the full directory name
-**  It needs to end with "/"
-*/
+ *
+ * All elements are tab delimited.
+ * Newline is not printed at the end
+ *
+ * If path is NULL, then skip else use. it has the full directory name
+ *  It needs to end with "/"
+ */
 void
 tsk_fs_name_print_long(FILE * hFile, const TSK_FS_FILE * fs_file,
     const char *a_path, TSK_FS_INFO * fs, const TSK_FS_ATTR * fs_attr,
@@ -520,7 +521,7 @@ tsk_fs_name_print_long(FILE * hFile, const TSK_FS_FILE * fs_file,
         tsk_fs_print_time(hFile, 0);    // crtime
 
         // size, uid, gid
-        tsk_fprintf(hFile, "\t0\t0\t0\n");
+        tsk_fprintf(hFile, "\t0\t0\t0");
     }
     else {
 
@@ -556,7 +557,7 @@ tsk_fs_name_print_long(FILE * hFile, const TSK_FS_FILE * fs_file,
         else
             tsk_fprintf(hFile, "\t%" PRIuOFF, fs_file->meta->size);
 
-        tsk_fprintf(hFile, "\t%" PRIuGID "\t%" PRIuUID "\n",
+        tsk_fprintf(hFile, "\t%" PRIuGID "\t%" PRIuUID,
             fs_file->meta->gid, fs_file->meta->uid);
     }
 

--- a/tsk/fs/fs_name.c
+++ b/tsk/fs/fs_name.c
@@ -570,20 +570,21 @@ tsk_fs_name_print_long(FILE * hFile, const TSK_FS_FILE * fs_file,
 /**
  * \internal
  *
-** Print output in the format that mactime reads.
-**
-** If the flags in the fs_file->meta structure are set to FS_FLAG_ALLOC
-** then it is assumed that the inode has been reallocated and the
-** contents are not displayed
-**
-** fs is not required (only used for block size).
+ * Print output in the format that mactime reads.
+ *
+ * If the flags in the fs_file->meta structure are set to FS_FLAG_ALLOC
+ * then it is assumed that the inode has been reallocated and the
+ * contents are not displayed
+ * Newline is not printed at the end
+ *
+ * fs is not required (only used for block size).
  * @param hFile handle to print results to
  * @param fs_file File to print details about
  * @param a_path Parent directory of file (needs to end with "/")
  * @param fs_attr Attribute in file that is being called for (NULL for non-NTFS)
  * @param prefix Path of mounting point for image
  * @param time_skew number of seconds skew to adjust time
-*/
+ */
 void
 tsk_fs_name_print_mac(FILE * hFile, const TSK_FS_FILE * fs_file,
     const char *a_path, const TSK_FS_ATTR * fs_attr,
@@ -596,13 +597,14 @@ tsk_fs_name_print_mac(FILE * hFile, const TSK_FS_FILE * fs_file,
 /**
  * \internal
  *
-** Print output in the format that mactime reads.
-**
-** If the flags in the fs_file->meta structure are set to FS_FLAG_ALLOC
-** then it is assumed that the inode has been reallocated and the
-** contents are not displayed
-**
-** fs is not required (only used for block size).
+ * Print output in the format that mactime reads.
+ *
+ * If the flags in the fs_file->meta structure are set to FS_FLAG_ALLOC
+ * then it is assumed that the inode has been reallocated and the
+ * contents are not displayed
+ * Newline is not printed at the end
+ *
+ * fs is not required (only used for block size).
  * @param hFile handle to print results to
  * @param fs_file File to print details about
  * @param a_path Parent directory of file (needs to end with "/")
@@ -610,7 +612,7 @@ tsk_fs_name_print_mac(FILE * hFile, const TSK_FS_FILE * fs_file,
  * @param prefix Path of mounting point for image
  * @param time_skew number of seconds skew to adjust time
  * @param hash_results Holds the calculated md5 hash
-*/
+ */
 void
 tsk_fs_name_print_mac_md5(FILE * hFile, const TSK_FS_FILE * fs_file,
     const char *a_path, const TSK_FS_ATTR * fs_attr,
@@ -735,7 +737,7 @@ tsk_fs_name_print_mac_md5(FILE * hFile, const TSK_FS_FILE * fs_file,
     }
 
     if (!fs_file->meta) {
-        tsk_fprintf(hFile, "0|0|0|0\n");
+        tsk_fprintf(hFile, "0|0|0|0");
     }
     else {
         // special case for NTFS FILE_NAME attribute
@@ -763,10 +765,10 @@ tsk_fs_name_print_mac_md5(FILE * hFile, const TSK_FS_FILE * fs_file,
                     fs_file->meta->time2.ntfs.fn_ctime);
 
             if (fs_file->meta->time2.ntfs.fn_crtime)
-                tsk_fprintf(hFile, "%" PRIu32 "\n",
+                tsk_fprintf(hFile, "%" PRIu32,
                     fs_file->meta->time2.ntfs.fn_crtime - time_skew);
             else
-                tsk_fprintf(hFile, "%" PRIu32 "\n",
+                tsk_fprintf(hFile, "%" PRIu32,
                     fs_file->meta->time2.ntfs.fn_crtime);
         }
         else {
@@ -790,10 +792,10 @@ tsk_fs_name_print_mac_md5(FILE * hFile, const TSK_FS_FILE * fs_file,
                 tsk_fprintf(hFile, "%" PRIu32 "|", fs_file->meta->ctime);
 
             if (fs_file->meta->crtime)
-                tsk_fprintf(hFile, "%" PRIu32 "\n",
+                tsk_fprintf(hFile, "%" PRIu32,
                     fs_file->meta->crtime - time_skew);
             else
-                tsk_fprintf(hFile, "%" PRIu32 "\n", fs_file->meta->crtime);
+                tsk_fprintf(hFile, "%" PRIu32, fs_file->meta->crtime);
         }
     }
 }

--- a/tsk/fs/ifind_lib.c
+++ b/tsk/fs/ifind_lib.c
@@ -3,7 +3,7 @@
 ** The Sleuth Kit
 **
 ** Given an image  and block number, identify which inode it is used by
-** 
+**
 ** Brian Carrier [carrier <at> sleuthkit [dot] org]
 ** Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved
 ** Copyright (c) 2003-2005 Brian Carrier.  All rights reserved
@@ -40,7 +40,7 @@ typedef struct {
 } IFIND_PAR_DATA;
 
 
-/* inode walk call back for tsk_fs_ifind_par to find unallocated files 
+/* inode walk call back for tsk_fs_ifind_par to find unallocated files
  * based on parent directory
  */
 static TSK_WALK_RET_ENUM
@@ -63,13 +63,13 @@ ifind_par_act(TSK_FS_FILE * fs_file, void *ptr)
             if ((fs_name = tsk_fs_name_alloc(256, 0)) == NULL)
                 return TSK_WALK_ERROR;
 
-            /* Fill in the basics of the fs_name entry 
+            /* Fill in the basics of the fs_name entry
              * so we can print in the fls formats */
             fs_name->meta_addr = fs_file->meta->addr;
             fs_name->flags = TSK_FS_NAME_FLAG_UNALLOC;
             strncpy(fs_name->name, fs_name_list->name, fs_name->name_size);
 
-            // now look for the $Data and $IDXROOT attributes 
+            // now look for the $Data and $IDXROOT attributes
             fs_file->name = fs_name;
             printed = 0;
 
@@ -87,6 +87,7 @@ ifind_par_act(TSK_FS_FILE * fs_file, void *ptr)
                     if (data->flags & TSK_FS_IFIND_PAR_LONG) {
                         tsk_fs_name_print_long(stdout, fs_file, NULL,
                             fs_file->fs_info, fs_attr, 0, 0);
+                        tsk_printf("\n");
                     }
                     else {
                         tsk_fs_name_print(stdout, fs_file, NULL,
@@ -102,6 +103,7 @@ ifind_par_act(TSK_FS_FILE * fs_file, void *ptr)
                 if (data->flags & TSK_FS_IFIND_PAR_LONG) {
                     tsk_fs_name_print_long(stdout, fs_file, NULL,
                         fs_file->fs_info, NULL, 0, 0);
+                    tsk_printf("\n");
                 }
                 else {
                     tsk_fs_name_print(stdout, fs_file, NULL,
@@ -121,7 +123,7 @@ ifind_par_act(TSK_FS_FILE * fs_file, void *ptr)
 
 
 /**
- * Searches for unallocated MFT entries that have a given 
+ * Searches for unallocated MFT entries that have a given
  * MFT entry as their parent directory (as reported in FILE_NAME).
  * @param fs File system to search
  * @param lclflags Flags
@@ -152,11 +154,11 @@ tsk_fs_ifind_par(TSK_FS_INFO * fs, TSK_FS_IFIND_FLAG_ENUM lclflags,
 
 /**
  * \ingroup fslib
- * 
+ *
  * Find the meta data address for a given file name (UTF-8).
  * The basic idea of the function is to break the given name into its
  * subdirectories and start looking for each (starting in the root
- * directory). 
+ * directory).
  *
  * @param a_fs FS to analyze
  * @param a_path UTF-8 path of file to search for
@@ -174,7 +176,7 @@ tsk_fs_path2inum(TSK_FS_INFO * a_fs, const char *a_path,
     char *cur_attr;             // The "current" attribute of the dir we are looking for
     TSK_INUM_T next_meta;
     uint8_t is_done;
-    char *strtok_last; 
+    char *strtok_last;
     *a_result = 0;
 
     // copy path to a buffer that we can modify
@@ -184,7 +186,7 @@ tsk_fs_path2inum(TSK_FS_INFO * a_fs, const char *a_path,
     }
     strncpy(cpath, a_path, clen);
 
-    // Get the first part of the directory path. 
+    // Get the first part of the directory path.
     cur_dir = (char *) strtok_r(cpath, "/", &strtok_last);
     cur_attr = NULL;
 
@@ -221,7 +223,7 @@ tsk_fs_path2inum(TSK_FS_INFO * a_fs, const char *a_path,
     // initialize the first place to look, the root dir
     next_meta = a_fs->root_inum;
 
-    // we loop until we know the outcome and then exit. 
+    // we loop until we know the outcome and then exit.
     // everything should return from inside the loop.
     is_done = 0;
     while (is_done == 0) {
@@ -262,7 +264,7 @@ tsk_fs_path2inum(TSK_FS_INFO * a_fs, const char *a_path,
                 return -1;
             }
 
-            /* 
+            /*
              * Check if this is the name that we are currently looking for,
              * as identified in 'cur_dir'
              */
@@ -343,7 +345,7 @@ tsk_fs_path2inum(TSK_FS_INFO * a_fs, const char *a_path,
             }
         }
 
-        // we found a directory, go into it 
+        // we found a directory, go into it
         if ((fs_file_alloc) || (fs_file_del)) {
 
             const char *pname;
@@ -374,9 +376,9 @@ tsk_fs_path2inum(TSK_FS_INFO * a_fs, const char *a_path,
                     tsk_fs_name_copy(a_fs_name, fs_file_tmp->name);
                 }
 
-                if (fs_file_alloc) 
+                if (fs_file_alloc)
                     tsk_fs_file_close(fs_file_alloc);
-                if (fs_file_del) 
+                if (fs_file_del)
                     tsk_fs_file_close(fs_file_del);
 
                 tsk_fs_dir_close(fs_dir);
@@ -565,7 +567,7 @@ ifind_data_act(TSK_FS_FILE * fs_file, void *ptr)
 
 
 
-/* 
+/*
  * Find the inode that has allocated block blk
  * Return 1 on error, 0 if no error */
 uint8_t


### PR DESCRIPTION
All print functions now do not print newline at the end leaving the caller the responsibility for that.

This allows the caller to choose different line termination characters such as null char.

The pull request contains several whitespace fixed automatically provided by my editor. To ignore them, append the string "?w=1" to the diff URL.