### PR TITLE
Missing braces for this conditional causes 'return 1' to happen unconditionally

### DIFF
--- a/tsk/base/tsk_error.c
+++ b/tsk/base/tsk_error.c
@@ -185,7 +185,7 @@ tsk_error_get()
 
     memset(errstr_print, 0, TSK_ERROR_STRING_MAX_LENGTH);
     if (t_errno & TSK_ERR_AUX) {
-        if ((TSK_ERR_MASK && t_errno) < TSK_ERR_AUX_MAX)
+        if ((TSK_ERR_MASK & t_errno) < TSK_ERR_AUX_MAX)
             snprintf(&errstr_print[pidx],
                 TSK_ERROR_STRING_MAX_LENGTH - pidx, "%s",
                 tsk_err_aux_str[t_errno & TSK_ERR_MASK]);

--- a/tsk/vs/mac.c
+++ b/tsk/vs/mac.c
@@ -155,7 +155,7 @@ mac_load_table(TSK_VS_INFO * vs)
     free(part_buf);
     part_buf = NULL;
 
-    // Bail if we did find any valid entries
+    // Bail if we didn't find any valid entries
     if (vs->part_count == 0) {
         return 1;
     }

--- a/tsk/vs/mac.c
+++ b/tsk/vs/mac.c
@@ -147,9 +147,10 @@ mac_load_table(TSK_VS_INFO * vs)
 
         if (NULL == tsk_vs_part_add(vs, (TSK_DADDR_T) part_start,
                 (TSK_DADDR_T) part_size, (TSK_VS_PART_FLAG_ENUM)flag, str, -1,
-                idx))
+                idx)) {
             free(part_buf);
             return 1;
+        }
     }
     free(part_buf);
     part_buf = NULL;


### PR DESCRIPTION
Fixes bug introduced in 3ba58ccd.

In 3ba58ccd, a missing `free()` was added, but it  replaced the `return 1` which had been the consequent of an unbraced conditional and made that `return 1` execute unconditionally. This prevents lots of OS X images from being read. This patch correctly puts braces around the `free()` and the `return 1`, so that they happen together.

There's also a fix for a misuse of `&&` instead of `&`.