### PR TITLE
Set TSK_FS_META_FLAG_USED or TSK_FS_META_FLAG_UNUSED once again for

### DIFF
--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -361,12 +361,13 @@ fatxxfs_dinode_copy(FATFS_INFO *a_fatfs, TSK_INUM_T a_inum,
     fs_meta->addr = a_inum;
 
     if (a_cluster_is_alloc) {
-
 		if(FATXXFS_IS_DELETED(dentry->name, a_fatfs)){
-				flags = TSK_FS_META_FLAG_UNALLOC;
+			flags = TSK_FS_META_FLAG_UNALLOC;
 		}
 		else{
-			flags = TSK_FS_META_FLAG_ALLOC;
+			flags = TSK_FS_META_FLAG_ALLOC |
+                (dentry->name[0] == FATXXFS_SLOT_EMPTY ?
+                 TSK_FS_META_FLAG_UNUSED : TSK_FS_META_FLAG_USED);
 		}
     }
     else {

--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -365,14 +365,16 @@ fatxxfs_dinode_copy(FATFS_INFO *a_fatfs, TSK_INUM_T a_inum,
 			flags = TSK_FS_META_FLAG_UNALLOC;
 		}
 		else{
-			flags = TSK_FS_META_FLAG_ALLOC |
-                (dentry->name[0] == FATXXFS_SLOT_EMPTY ?
-                 TSK_FS_META_FLAG_UNUSED : TSK_FS_META_FLAG_USED);
+			flags = TSK_FS_META_FLAG_ALLOC;
 		}
     }
     else {
         flags = TSK_FS_META_FLAG_UNALLOC;
     }
+
+    flags |= (dentry->name[0] == FATXXFS_SLOT_EMPTY ?
+              TSK_FS_META_FLAG_UNUSED : TSK_FS_META_FLAG_USED);
+
     fs_meta->flags = (TSK_FS_META_FLAG_ENUM)flags;
 
     if ((dentry->attrib & FATFS_ATTR_LFN) == FATFS_ATTR_LFN) {

--- a/tsk/fs/tsk_fatxxfs.h
+++ b/tsk/fs/tsk_fatxxfs.h
@@ -32,6 +32,7 @@
 /* constants for first byte of name[] */
 #define FATXXFS_SLOT_E5		0x05    /* actual value is 0xe5 */
 #define FATXXFS_SLOT_DELETED	0xe5
+#define FATXXFS_SLOT_EMPTY 0x00
 
 /* Macro to test allocation status
  * Have seen FAT image that uses non-standard flags in the short name (00 00 -> unallocated, 20 00 -> allocated)


### PR DESCRIPTION
directory inodes on FAT{12,16,32} filesystems.