### PR TITLE
Converted NTFS fs_attr_id from uint16 to int16

### DIFF
--- a/tsk/fs/fs_attr.c
+++ b/tsk/fs/fs_attr.c
@@ -275,7 +275,7 @@ tsk_fs_attr_set_str(TSK_FS_FILE * a_fs_file, TSK_FS_ATTR * a_fs_attr,
 uint8_t
 tsk_fs_attr_set_run(TSK_FS_FILE * a_fs_file, TSK_FS_ATTR * a_fs_attr,
     TSK_FS_ATTR_RUN * a_data_run_new, const char *name,
-    TSK_FS_ATTR_TYPE_ENUM type, uint16_t id, TSK_OFF_T size,
+    TSK_FS_ATTR_TYPE_ENUM type, int16_t id, TSK_OFF_T size,
     TSK_OFF_T init_size, TSK_OFF_T alloc_size,
     TSK_FS_ATTR_FLAG_ENUM flags, uint32_t compsize)
 {

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1678,7 +1678,6 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
 
         int retVal, i;
         uint32_t type;
-        uint16_t id_temp_unit;
         int16_t id, id_new;
         
         // sanity check on bounds of attribute. Prevents other
@@ -1690,7 +1689,6 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
         
         /* Get the type of this attribute */
         type = tsk_getu32(fs->endian, attr->type);
-        id_temp_unit = tsk_getu16(fs->endian, attr->id);
         id = (int16_t)tsk_getu16(fs->endian, attr->id);
         id_new = id;
 

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1678,7 +1678,8 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
 
         int retVal, i;
         uint32_t type;
-        uint16_t id, id_new;
+        uint16_t id_temp_unit;
+        int16_t id, id_new;
         
         // sanity check on bounds of attribute. Prevents other
         // issues later on that use attr->len for bounds checks.
@@ -1689,7 +1690,8 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
         
         /* Get the type of this attribute */
         type = tsk_getu32(fs->endian, attr->type);
-        id = tsk_getu16(fs->endian, attr->id);
+        id_temp_unit = tsk_getu16(fs->endian, attr->id);
+        id = (int16_t)tsk_getu16(fs->endian, attr->id);
         id_new = id;
 
         /* If the map was supplied, search through it to see if this 

--- a/tsk/fs/tsk_fs.h
+++ b/tsk/fs/tsk_fs.h
@@ -277,7 +277,7 @@ extern "C" {
         char *name;             ///< Name of attribute (in UTF-8).  Will be NULL if attribute doesn't have a name. 
         size_t name_size;       ///< Number of bytes allocated to name
         TSK_FS_ATTR_TYPE_ENUM type;     ///< Type of attribute
-        uint16_t id;            ///< Id of attribute
+        int16_t id;            ///< Id of attribute
 
         TSK_OFF_T size;         ///< Size in bytes of the attribute resident and non-resident content (does not include skiplen for non-resident attributes)
 
@@ -481,7 +481,7 @@ extern "C" {
                 time_t fn_atime_nano;   ///< NTFS access time stored in FILE_NAME in nano-second resolution
                 time_t fn_ctime;   ///< NTFS change (MFT Entry) time stored in FILE_NAME
                 time_t fn_ctime_nano;   ///< NTFS change (MFT Entry) time stored in FILE_NAME in nano-second resolution
-                uint16_t fn_id; ///< Attribute ID used to populate FN times. 
+                int16_t fn_id; ///< Attribute ID used to populate FN times. 
             } ntfs;
         } time2;
 

--- a/tsk/fs/tsk_fs_i.h
+++ b/tsk/fs/tsk_fs_i.h
@@ -93,7 +93,7 @@ extern "C" {
         const char *, TSK_FS_ATTR_TYPE_ENUM, uint16_t, void *, size_t);
     extern uint8_t tsk_fs_attr_set_run(TSK_FS_FILE *,
         TSK_FS_ATTR * a_fs_attr, TSK_FS_ATTR_RUN * data_run_new,
-        const char *name, TSK_FS_ATTR_TYPE_ENUM type, uint16_t id,
+        const char *name, TSK_FS_ATTR_TYPE_ENUM type, int16_t id,
         TSK_OFF_T size, TSK_OFF_T initsize, TSK_OFF_T allocsize,
         TSK_FS_ATTR_FLAG_ENUM flags, uint32_t compsize);
     extern uint8_t tsk_fs_attr_add_run(TSK_FS_INFO * fs,


### PR DESCRIPTION
Autopsy treats fs_id as SHORT. This code change adds ability to handle attribute ids that are larger than 32K by converting them to signed short values. 