### PR TITLE
JNI Function for Bitlocker Support

### DIFF
--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -1284,6 +1284,31 @@ JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_openFsNat
     return (jlong) fs_info;
 }
 
+/*
+ * Open file system with the given offset
+ * @return the offset to the volume from vol_id
+ * @param env pointer to java environment this was called from
+ * @param obj the java object this was called from
+ * @param a_vs_info the pointer to the volume system object
+ * @param vol_id the id of the volume 
+ */
+JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_getVolOffsetNat
+	(JNIEnv * env, jclass obj, jlong a_vs_info, jlong vol_id) {
+    TSK_VS_INFO *vs_info = castVsInfo(env, a_vs_info);
+    if (vs_info == 0) {
+        return 0;
+    }
+    const TSK_VS_PART_INFO *vol_part_info;
+
+    vol_part_info = tsk_vs_part_get(vs_info, (TSK_PNUM_T) vol_id);
+    if (vol_part_info == NULL) {
+        setThrowTskCoreError(env, tsk_error_get());
+    }
+
+    TSK_DADDR_T offset = vol_part_info->start;
+    return offset;
+}
+
 
 /*
  * Open the file with the given id in the given file system

--- a/bindings/java/jni/dataModel_SleuthkitJNI.h
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.h
@@ -289,6 +289,15 @@ JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_openFileNat
 
 /*
  * Class:     org_sleuthkit_datamodel_SleuthkitJNI
+ * Method:    getVolOffsetNat
+ * Signature: (JJ)J
+ */
+JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_getVolOffsetNat
+  (JNIEnv *, jclass, jlong, jlong);
+
+
+/*
+ * Class:     org_sleuthkit_datamodel_SleuthkitJNI
  * Method:    readImgNat
  * Signature: (J[BJJ)I
  */

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -119,6 +119,8 @@ public class SleuthkitJNI {
 
 	private static native long openFileNat(long fsHandle, long fileId, int attrType, int attrId) throws TskCoreException;
 
+	private static native long getVolOffsetNat(long vsHandle, long volId) throws TskCoreException;
+
 	//read functions
 	private static native int readImgNat(long imgHandle, byte[] readBuffer, long offset, long len) throws TskCoreException;
 
@@ -485,6 +487,21 @@ public class SleuthkitJNI {
 	public static long openVs(long imgHandle, long vsOffset) throws TskCoreException {
 		return openVsNat(imgHandle, vsOffset);
 	}
+
+	/**
+	 * Get offset to volume 
+	 * 
+	 * @param vsHandle a handle to previously opened volume system
+	 * @param volId the id of the volume on the volume system
+	 * 
+	 * @return the offset to the volume from volId
+	 * 
+	 * @throws TskCoreException exception thrown if critical error occurs within
+	 *                          TSK
+	 */
+	public static long getVolOffset(long vsHandle, long volId) throws TskCoreException { 
+		return getVolOffsetNat(vsHandle, volId);
+	} 
 
 	//get pointers
 	/**


### PR DESCRIPTION
To allow autopsy the implementation of a Bitlocker-Module, we need to know where the volumes start. 

+ added getVolOffset JNI function