### PR TITLE
Fix NTFS attrlist bounds checks, memory leaks

### DIFF
--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -1220,6 +1220,15 @@ tsk_fs_dir_find_orphans(TSK_FS_INFO * a_fs, TSK_FS_DIR * a_fs_dir)
                     &a_fs_dir->names[a_fs_dir->names_used - 1]);
             }
             a_fs_dir->names_used--;
+            TSK_FS_NAME *fs_name = &a_fs_dir->names[a_fs_dir->names_used];
+            if (fs_name->name) {
+                free(fs_name->name);
+                fs_name->name = NULL;
+            }
+            if (fs_name->shrt_name) {
+                free(fs_name->shrt_name);
+                fs_name->shrt_name = NULL;
+            }
         }
     }
 

--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -1192,6 +1192,10 @@ tsk_fs_dir_find_orphans(TSK_FS_INFO * a_fs, TSK_FS_DIR * a_fs_dir)
             TSK_FS_META_FLAG_UNALLOC | TSK_FS_META_FLAG_USED,
             find_orphan_meta_walk_cb, &data)) {
         tsk_fs_name_free(data.fs_name);
+        if (data.orphan_subdir_list) {
+            tsk_list_free(data.orphan_subdir_list);
+            data.orphan_subdir_list = NULL;
+        }
         tsk_release_lock(&a_fs->orphan_dir_lock);
         return TSK_ERR;
     }

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -2335,9 +2335,12 @@ ntfs_proc_attrlist(NTFS_INFO * ntfs,
      * process. */
     nextid = fs_attr_attrlist->id;      // we won't see this entry in the list
     for (list = (ntfs_attrlist *) buf;
-        (list) && ((uintptr_t) list < endaddr)
-        && ((uintptr_t)list + sizeof(ntfs_attrlist) < endaddr)
-        && (tsk_getu16(fs->endian, list->len) > 0);
+        (list)
+        // ntfs_attrlist contains the first byte of the name, which might actually be 0-length
+        && (uintptr_t) list + sizeof(ntfs_attrlist) - 1 <= endaddr
+        && tsk_getu16(fs->endian, list->len) > 0
+        && (uintptr_t) list + tsk_getu16(fs->endian, list->len) <= endaddr
+        && (uintptr_t) list + sizeof(ntfs_attrlist) - 1 + 2 * list->nlen <= endaddr;
         list =
         (ntfs_attrlist *) ((uintptr_t) list + tsk_getu16(fs->endian,
                 list->len))) {


### PR DESCRIPTION
- Fixes bounds checks in `ntfs_proc_attrlist()`. Note that `ntfs_attrlist` contains the first byte of its name, but that the name's length is possibly 0. In addition to checking that the attribute struct itself fits inside the current buffer, check the attribute's name length and and declared size.
- Fixes two memory leaks in `tsk_fs_dir_find_orphans()`. if the fs_dir's name's used is decremented, the names must be freed, since `tsk_fs_dir_close()` won't know to free them. Also frees the `orphan_subdir_list` in certain error conditions.
