### PR TITLE
Use system sqlite3

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ nobase_include_HEADERS = tsk/libtsk.h tsk/tsk_incs.h \
     tsk/fs/tsk_fs.h tsk/fs/tsk_ffs.h tsk/fs/tsk_ext2fs.h tsk/fs/tsk_fatfs.h \
     tsk/fs/tsk_ntfs.h tsk/fs/tsk_iso9660.h tsk/fs/tsk_hfs.h tsk/fs/tsk_yaffs.h \
     tsk/fs/tsk_exfatfs.h tsk/fs/tsk_fatxxfs.h \
-    tsk/hashdb/tsk_hashdb.h tsk/auto/tsk_auto.h tsk/auto/sqlite3.h
+    tsk/hashdb/tsk_hashdb.h tsk/auto/tsk_auto.h
 
 nobase_dist_data_DATA = tsk/sorter/default.sort tsk/sorter/freebsd.sort \
     tsk/sorter/images.sort tsk/sorter/linux.sort tsk/sorter/openbsd.sort \

--- a/framework/tsk/framework/services/TskImgDBSqlite.h
+++ b/framework/tsk/framework/services/TskImgDBSqlite.h
@@ -27,7 +27,7 @@ using namespace std;
 #include "TskBlackboardAttribute.h"
 
 #include "tsk/libtsk.h"
-#include "tsk/auto/sqlite3.h"
+#include <sqlite3.h>
 
 /** 
  * Implementation of TskImgDB that uses SQLite to store the data.

--- a/tsk/auto/Makefile.am
+++ b/tsk/auto/Makefile.am
@@ -3,7 +3,8 @@ EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskauto.la
 # Note that the .h files are in the top-level Makefile
-libtskauto_la_SOURCES = auto.cpp auto_db.cpp sqlite3.c sqlite3.h db_sqlite.cpp db_postgresql.cpp case_db.cpp guid.cpp tsk_db.cpp tsk_case_db.h tsk_auto.h tsk_auto_i.h tsk_case_db.h tsk_db.h tsk_db_sqlite.h tsk_db_postgresql.h db_connection_info.h guid.h
+libtskauto_la_SOURCES = auto.cpp auto_db.cpp db_sqlite.cpp db_postgresql.cpp case_db.cpp guid.cpp tsk_db.cpp tsk_case_db.h tsk_auto.h tsk_auto_i.h tsk_case_db.h tsk_db.h tsk_db_sqlite.h tsk_db_postgresql.h db_connection_info.h guid.h
+libtskauto_la_LIBADD = -lsqlite3
 
 indent:
 	indent *.cpp *.h

--- a/tsk/hashdb/tsk_hashdb.h
+++ b/tsk/hashdb/tsk_hashdb.h
@@ -17,7 +17,7 @@
 * \defgroup hashdblib_cpp C++ Hash Database Classes
 */
 
-#include "tsk/auto/sqlite3.h"
+#include <sqlite3.h>
 
 #ifndef _TSK_HDB_H
 #define _TSK_HDB_H


### PR DESCRIPTION
This patch use system sqlite3 instead of the bundled copy.
