### PR TITLE
Fix buffer overrun in fatfs_utf16_inode_str_2_utf8

### DIFF
--- a/tsk/fs/fatfs_utils.c
+++ b/tsk/fs/fatfs_utils.c
@@ -293,7 +293,9 @@ fatfs_utf16_inode_str_2_utf8(FATFS_INFO *a_fatfs, UTF16 *a_src, size_t a_src_len
         return TSKsourceIllegal; 
     }
 
-    conv_result = tsk_UTF16toUTF8(fs->endian, (const UTF16**)&a_src, (UTF16*)&a_src[a_src_len], &a_dest, (UTF8*)&a_dest[a_dest_len], TSKlenientConversion);
+    conv_result = tsk_UTF16toUTF8(fs->endian,
+                                  (const UTF16**)&a_src, (UTF16*) ((uintptr_t) a_src + a_src_len),
+                                  &a_dest, (UTF8*) ((uintptr_t) a_dest + a_dest_len), TSKlenientConversion);
     if (conv_result == TSKconversionOK) {
         /* Make sure the result is NULL-terminated. */
         if ((uintptr_t) a_dest > (uintptr_t)a_dest + sizeof(a_dest)) {


### PR DESCRIPTION
I noticed valgrind reporting errors on an exFAT image:

```
==2797== Conditional jump or move depends on uninitialised value(s)
==2797==    at 0x5D9BF4B: tsk_UTF16toUTF8 (tsk_unicode.c:163)
==2797==    by 0x5DD0C9C: fatfs_utf16_inode_str_2_utf8 (fatfs_utils.c:296)
==2797==    by 0x5D951BA: exfatfs_copy_file_inode (exfatfs_meta.c:1251)
==2797==    by 0x5DCF096: exfatfs_inode_lookup (exfatfs_meta.c:1683)
==2797==    by 0x5DA957B: tsk_fs_dir_walk_lcl (fs_dir.c:577)
==2797==    by 0x5DA9BB0: tsk_fs_dir_walk.part.5 (fs_dir.c:803)
```

This fixes those errors.