### PR TITLE
Added command line option to invoke fls flag TSK_FS_FLS_HASH

### DIFF
--- a/tools/fstools/fls.cpp
+++ b/tools/fstools/fls.cpp
@@ -49,6 +49,7 @@ usage()
         "\t-m: Display output in mactime input format with\n");
     tsk_fprintf(stderr,
         "\t      dir/ as the actual mount point of the image\n");
+    tsk_fprintf(stderr, "\t-h: Include MD5 hash in mactime output\n");
     tsk_fprintf(stderr,
         "\t-o imgoffset: Offset into image file (in sectors)\n");
     tsk_fprintf(stderr, "\t-p: Display full path for each file\n");
@@ -102,7 +103,7 @@ main(int argc, char **argv1)
     fls_flags = TSK_FS_FLS_DIR | TSK_FS_FLS_FILE;
 
     while ((ch =
-            GETOPT(argc, argv, _TSK_T("ab:dDf:Fi:m:lo:prs:uvVz:"))) > 0) {
+            GETOPT(argc, argv, _TSK_T("ab:dDf:Fi:m:hlo:prs:uvVz:"))) > 0) {
         switch (ch) {
         case _TSK_T('?'):
         default:
@@ -163,6 +164,9 @@ main(int argc, char **argv1)
         case _TSK_T('m'):
             fls_flags |= TSK_FS_FLS_MAC;
             macpre = OPTARG;
+            break;
+        case _TSK_T('h'):
+            fls_flags |= TSK_FS_FLS_HASH;
             break;
         case _TSK_T('o'):
             if ((imgaddr = tsk_parse_offset(OPTARG)) == -1) {


### PR DESCRIPTION
It seems strange that this flag exists and is supported by all the code behind `tsk_fs_fls()`, yet is not exposed in the fls command line.  In particular because the mactime/bodyfile format has a field for MD5 hash (position 0).

Ref: https://wiki.sleuthkit.org/index.php?title=Body_file

I'm not tied to a particular flag.  -m was taken and -h was not, so I just went with it, although I'd recognize -h is widely use for help/usage statements.