### PR TITLE
Fixed SQL escaping issue for addSource feature

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -2354,7 +2354,7 @@ public class SleuthkitCase {
 			if (BlackboardAttribute.TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.BYTE != valueType) {
 				switch (valueType) {
 					case STRING:
-						valueClause = " value_text = '" + attr.getValueString() + "'";
+						valueClause = " value_text = '" + escapeSingleQuotes(attr.getValueString()) + "'";
 						break;
 					case INTEGER:
 						valueClause = " value_int32 = " + attr.getValueInt();


### PR DESCRIPTION
I was getting SQL errors while attempting to use the "addSource" feature on a string attribute with a value containing single quotes. I've not tested my solution, but I believe escaping single quotes should resolve the issue.