### PR TITLE
Fix double free on HFS+ images

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -3987,6 +3987,7 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
                 }
 
                 free(buffer);
+                buffer = NULL;
 
                 attribute_counter++;
             }                   // END if comp == 0


### PR DESCRIPTION
Set buffer to null after it's freed normally, since subsequent code will try to free the buffer on error. This prevents double frees.