### PR TITLE
Fix EXTn filesystem leaks

### DIFF
--- a/tsk/fs/ext2fs.c
+++ b/tsk/fs/ext2fs.c
@@ -1431,6 +1431,7 @@ ext2fs_make_data_run_extent_index(TSK_FS_INFO * fs_info,
         }
         tsk_error_set_errstr("ext2fs_make_data_run_extent_index: Block %"
             PRIuDADDR, idx_block);
+        free(buf);
         return 1;
     }
     header = (ext2fs_extent_header *) buf;
@@ -1440,17 +1441,21 @@ ext2fs_make_data_run_extent_index(TSK_FS_INFO * fs_info,
         tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
         tsk_error_set_errstr
             ("ext2fs_make_data_run_extent_index: extent header magic valid incorrect!");
+        free(buf);
         return 1;
     }
 
     data_run = tsk_fs_attr_run_alloc();
     if (data_run == NULL) {
+        free(buf);
         return 1;
     }
     data_run->addr = idx_block;
     data_run->len = fs_blocksize;
 
     if (tsk_fs_attr_add_run(fs_info, fs_attr_extent, data_run)) {
+        tsk_fs_attr_run_free(data_run);
+        free(buf);
         return 1;
     }
 
@@ -1461,6 +1466,7 @@ ext2fs_make_data_run_extent_index(TSK_FS_INFO * fs_info,
             i++) {
             ext2fs_extent extent = extents[i];
             if (ext2fs_make_data_run_extent(fs_info, fs_attr, &extent)) {
+                free(buf);
                 return 1;
             }
         }
@@ -1477,6 +1483,7 @@ ext2fs_make_data_run_extent_index(TSK_FS_INFO * fs_info,
                 endian, index->ei_leaf_lo);
             if (ext2fs_make_data_run_extent_index(fs_info, fs_attr,
                     fs_attr_extent, child_block)) {
+                free(buf);
                 return 1;
             }
         }

--- a/tsk/fs/unix_misc.c
+++ b/tsk/fs/unix_misc.c
@@ -317,7 +317,7 @@ tsk_fs_unix_make_data_run(TSK_FS_FILE * fs_file)
     /* if there is still data left, read the indirect */
     if (length > 0) {
         int level;
-        char **buf;
+        char *buf[4];
         size_t fs_bufsize0;
         size_t fs_bufsize1;
         size_t ptrsperblock;
@@ -356,18 +356,9 @@ tsk_fs_unix_make_data_run(TSK_FS_FILE * fs_file)
          * equal to one block size.  The others will store TSK_DADDR_T structures
          * and will have a size depending on the FS type. 
          */
-        if ((buf = (char **) tsk_malloc(sizeof(char *) * 4)) == NULL)
-            return 1;
-
-        if ((buf[0] = (char *) tsk_malloc(fs_bufsize0)) == NULL) {
-            free(buf);
-            return 1;
-        }
-
         if ((fs_attr_indir =
                 tsk_fs_attrlist_getnew(fs_meta->attr,
                     TSK_FS_ATTR_NONRES)) == NULL) {
-            free(buf);
             return 1;
         }
 
@@ -399,7 +390,10 @@ tsk_fs_unix_make_data_run(TSK_FS_FILE * fs_file)
                     numTripIndirect),
                 fs_bufsize0 * (numSingIndirect + numDblIndirect +
                     numTripIndirect), 0, 0)) {
-            free(buf);
+            return 1;
+        }
+
+        if ((buf[0] = (char *) tsk_malloc(fs_bufsize0)) == NULL) {
             return 1;
         }
 
@@ -408,9 +402,9 @@ tsk_fs_unix_make_data_run(TSK_FS_FILE * fs_file)
 
             if ((buf[level] = (char *) tsk_malloc(fs_bufsize1)) == NULL) {
                 int f;
-                for (f = 0; f < level; f++)
+                for (f = 0; f < level; f++) {
                     free(buf[f]);
-                free(buf);
+                }
                 return 1;
             }
 
@@ -427,9 +421,10 @@ tsk_fs_unix_make_data_run(TSK_FS_FILE * fs_file)
         /*
          * Cleanup.
          */
-        for (level = 0; level < 4; level++) {
-            if (buf[level])
+        for (level = 0; level < 4; ++level) {
+            if (buf[level]) {
                 free(buf[level]);
+            }
         }
     }
 

--- a/tsk/fs/unix_misc.c
+++ b/tsk/fs/unix_misc.c
@@ -317,7 +317,7 @@ tsk_fs_unix_make_data_run(TSK_FS_FILE * fs_file)
     /* if there is still data left, read the indirect */
     if (length > 0) {
         int level;
-        char *buf[4];
+        char *buf[4] = {NULL};
         size_t fs_bufsize0;
         size_t fs_bufsize1;
         size_t ptrsperblock;


### PR DESCRIPTION
Fixed memory leaks in `tsk_fs_unix_make_data_run`, `ext2fs_make_data_run_extent_index`.