### PR TITLE
Revert e0e260a6, fixes Issue 748

### DIFF
--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -141,33 +141,6 @@ tsk_fs_dir_copy(const TSK_FS_DIR * a_src_dir, TSK_FS_DIR * a_dst_dir)
 }
 
 
-
-
-/**
- * Test if a_fs_dir already contains an entry for the given
- * meta data address. If so, return the allocation state.
- *
- * @returns TSK_FS_NAME_FLAG_ALLOC, TSK_FS_NAME_FLAG_UNALLOC, or 0 if not found.
- */
-uint8_t
-tsk_fs_dir_contains(TSK_FS_DIR * a_fs_dir, TSK_INUM_T meta_addr)
-{
-    size_t i;
-    uint8_t bestFound = 0;
-
-    for (i = 0; i < a_fs_dir->names_used; i++) {
-        if (meta_addr == a_fs_dir->names[i].meta_addr) {
-            bestFound = a_fs_dir->names[i].flags;
-            // stop as soon as we get an alloc. 
-            // if we get unalloc, keep going in case there
-            // is alloc later.
-            if (bestFound == TSK_FS_NAME_FLAG_ALLOC) 
-                break;
-        }
-    }
-    return bestFound;
-}
-
 /** \internal
  * Add a FS_DENT structure to a FS_DIR structure by copying its
  * contents into the internal buffer. Checks for

--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -1264,16 +1264,6 @@ ntfs_dir_open_meta(TSK_FS_INFO * a_fs, TSK_FS_DIR ** a_fs_dir,
         for (size_t a = 0; a < childFiles.size(); a++) {
             TSK_FS_FILE *fs_file_orp = NULL;
 
-            /* Check if fs_dir already has an allocated entry for this
-             * file.  If so, ignore it. We used to rely on fs_dir_add
-             * to get rid of this, but it wasted a lot of lookups. If 
-             * We have only unalloc for this same entry (from idx entries),
-             * then try to add it.   If we got an allocated entry from
-             * the idx entries, then assume we have everything. */
-            if (tsk_fs_dir_contains(fs_dir, childFiles[a].getAddr()) == TSK_FS_NAME_FLAG_ALLOC) {
-                continue;
-            }
-
             /* Fill in the basics of the fs_name entry
              * so we can print in the fls formats */
             fs_name->meta_addr = childFiles[a].getAddr();

--- a/tsk/fs/tsk_fs_i.h
+++ b/tsk/fs/tsk_fs_i.h
@@ -139,7 +139,6 @@ extern "C" {
     extern uint8_t tsk_fs_dir_add(TSK_FS_DIR * a_fs_dir,
         const TSK_FS_NAME * a_fs_dent);
     extern void tsk_fs_dir_reset(TSK_FS_DIR * a_fs_dir);
-    extern uint8_t tsk_fs_dir_contains(TSK_FS_DIR * a_fs_dir, TSK_INUM_T meta_addr);
 
     /* Orphan Directory Support */
     TSK_RETVAL_ENUM tsk_fs_dir_load_inum_named(TSK_FS_INFO * a_fs);


### PR DESCRIPTION
This reverts commit e0e260a64114842cac7cff9653ede8f8789b49c4.

The optimization is incorrect. It's only a highly probable accident that
filenames read from index buffers are the same as what's listed in the MFT.