### PR TITLE
Use system sqlite3 when available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ nobase_include_HEADERS = tsk/libtsk.h tsk/tsk_incs.h \
     tsk/fs/tsk_fs.h tsk/fs/tsk_ffs.h tsk/fs/tsk_ext2fs.h tsk/fs/tsk_fatfs.h \
     tsk/fs/tsk_ntfs.h tsk/fs/tsk_iso9660.h tsk/fs/tsk_hfs.h tsk/fs/tsk_yaffs.h \
     tsk/fs/tsk_exfatfs.h tsk/fs/tsk_fatxxfs.h \
-    tsk/hashdb/tsk_hashdb.h tsk/auto/tsk_auto.h tsk/auto/sqlite3.h \
+    tsk/hashdb/tsk_hashdb.h tsk/auto/tsk_auto.h \
     tsk/auto/tsk_is_image_supported.h
 
 nobase_dist_data_DATA = tsk/sorter/default.sort tsk/sorter/freebsd.sort \

--- a/configure.ac
+++ b/configure.ac
@@ -122,12 +122,17 @@ AC_CHECK_HEADERS(streambuf, , , AC_MSG_ERROR([missing STL streambuf class header
 AC_CHECK_HEADERS(string, , , AC_MSG_ERROR([missing STL string class header])) 
 AC_CHECK_HEADERS(vector, , , AC_MSG_ERROR([missing STL vector class header])) 
 
-
-dnl needed for sqllite
-AC_CHECK_LIB(dl, dlopen) 
-dnl sqlite requires pthread libraries - this was copied from its configure.ac
-dnl AC_SEARCH_LIBS(pthread_create, pthread)
-dnl AC_SEARCH_LIBS(dlopen, dl)
+dnl Check for sqlite and its dependencies
+AC_CHECK_HEADERS([sqlite3.h],
+                 [AC_CHECK_LIB(dl, dlopen)
+                  AC_CHECK_LIB(sqlite3, sqlite3_open)])
+dnl Compile the bundled sqlite if there is no system one installed
+AC_MSG_CHECKING(which sqlite3 to use)
+AS_IF([test "x$ac_cv_lib_sqlite3_sqlite3_open" = "xyes"],
+      [AC_MSG_RESULT([system])],
+      [AC_MSG_RESULT([bundled])])
+AM_CONDITIONAL([HAVE_LIBSQLITE3],
+               [test "x$ac_cv_lib_sqlite3_sqlite3_open" = "xyes"])
 
 # Check if we should link afflib.
 AC_ARG_WITH([afflib],
@@ -230,10 +235,6 @@ AS_IF([test "x$with_libewf" != "xno"],
     )]
 )
 AS_IF([test "x$ac_cv_lib_ewf_libewf_get_version" = "xyes"], [ax_libewf=yes], [ax_libewf=no])
-
-dnl sqlite requires pthread libraries - this was copied from its configure.ac
-dnl AC_SEARCH_LIBS(pthread_create, pthread)
-AC_SEARCH_LIBS(dlopen, dl)
 
 dnl Test for the various java things that we need for bindings
 AS_IF([test "x$enable_java" != "xno"], [

--- a/framework/tsk/framework/services/TskImgDBSqlite.h
+++ b/framework/tsk/framework/services/TskImgDBSqlite.h
@@ -27,7 +27,12 @@ using namespace std;
 #include "TskBlackboardAttribute.h"
 
 #include "tsk/libtsk.h"
-#include "tsk/auto/sqlite3.h"
+
+#ifdef HAVE_LIBSQLITE3
+  #include <sqlite3.h>
+#else
+  #include "tsk/auto/sqlite3.h"
+#endif
 
 /** 
  * Implementation of TskImgDB that uses SQLite to store the data.

--- a/tsk/auto/Makefile.am
+++ b/tsk/auto/Makefile.am
@@ -3,7 +3,15 @@ EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskauto.la
 # Note that the .h files are in the top-level Makefile
-libtskauto_la_SOURCES = auto.cpp auto_db.cpp sqlite3.c sqlite3.h db_sqlite.cpp db_postgresql.cpp case_db.cpp guid.cpp tsk_db.cpp tsk_case_db.h tsk_auto.h tsk_auto_i.h tsk_case_db.h tsk_db.h tsk_db_sqlite.h tsk_db_postgresql.h db_connection_info.h guid.h 
+libtskauto_la_SOURCES = auto.cpp auto_db.cpp db_sqlite.cpp \
+	db_postgresql.cpp case_db.cpp guid.cpp tsk_db.cpp tsk_case_db.h \
+	tsk_auto.h tsk_auto_i.h tsk_case_db.h tsk_db.h tsk_db_sqlite.h \
+	tsk_db_postgresql.h db_connection_info.h guid.h
+
+# Compile the bundled sqlite3 if there isn't an existing lib to use
+if !HAVE_LIBSQLITE3
+libtskauto_la_SOURCES += sqlite3.c sqlite3.h
+endif
 
 indent:
 	indent *.cpp *.h

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -14,7 +14,6 @@
 */
 
 #include "tsk_db_sqlite.h"
-#include "sqlite3.h"
 #include "guid.h"
 #include <string.h>
 #include <sstream>

--- a/tsk/auto/tsk_db_sqlite.h
+++ b/tsk/auto/tsk_db_sqlite.h
@@ -19,8 +19,13 @@
 
 #include <map>
 
-#include "sqlite3.h"
 #include "tsk_db.h"
+
+#ifdef HAVE_LIBSQLITE3
+  #include <sqlite3.h>
+#else
+  #include "sqlite3.h"
+#endif
 
 using std::map;
 using std::vector;

--- a/tsk/hashdb/sqlite_hdb.cpp
+++ b/tsk/hashdb/sqlite_hdb.cpp
@@ -12,6 +12,8 @@
 #include "tsk_hashdb_i.h"
 #include "tsk_hash_info.h"
 
+#include "tsk/auto/sqlite3.h"
+
 /**
 * \file sqlite_hdb.cpp
 * Contains hash database functions for SQLite hash databases.
@@ -22,6 +24,21 @@ static const char *SCHEMA_VERSION_NO = "1";
 static const char *SQLITE_FILE_HEADER = "SQLite format 3";
 static const size_t MD5_BLOB_LEN = ((TSK_HDB_HTYPE_MD5_LEN) / 2);
 static const char hex_digits[] = "0123456789abcdef";
+
+/**
+ * Represents a TSK SQLite hash database (it doesn't need an external index).
+ */
+typedef struct TSK_SQLITE_HDB_INFO {
+    TSK_HDB_INFO base;
+    sqlite3 *db;
+
+    sqlite3_stmt *insert_md5_into_hashes; ///< Once initialized, prepared statements are tied to a specific database
+    sqlite3_stmt *insert_into_file_names;
+    sqlite3_stmt *insert_into_comments;
+    sqlite3_stmt *select_from_hashes_by_md5;
+    sqlite3_stmt *select_from_file_names;
+    sqlite3_stmt *select_from_comments;
+} TSK_SQLITE_HDB_INFO;
 
 static uint8_t 
     sqlite_hdb_attempt(int resultCode, int expectedResultCode, const char *errfmt, 

--- a/tsk/hashdb/tsk_hashdb.h
+++ b/tsk/hashdb/tsk_hashdb.h
@@ -17,8 +17,6 @@
 * \defgroup hashdblib_cpp C++ Hash Database Classes
 */
 
-#include "tsk/auto/sqlite3.h"
-
 #ifndef _TSK_HDB_H
 #define _TSK_HDB_H
 
@@ -156,22 +154,6 @@ extern "C" {
         TSK_TCHAR *idx_idx_fname;     ///< Name of index of index file, may be NULL
         uint64_t *idx_offsets;        ///< Maps the first three bytes of a hash value to an offset in the index file
     } TSK_HDB_BINSRCH_INFO;    
-
-    /** 
-    * Represents a TSK SQLite hash database (it doesn't need an external index).
-    */
-    typedef struct TSK_SQLITE_HDB_INFO {
-        TSK_HDB_INFO base;
-        sqlite3 *db;
-
-        sqlite3_stmt *insert_md5_into_hashes; ///< Once initialized, prepared statements are tied to a specific database 
-        sqlite3_stmt *insert_into_file_names; 
-        sqlite3_stmt *insert_into_comments; 
-        sqlite3_stmt *select_from_hashes_by_md5;
-        sqlite3_stmt *select_from_file_names;
-        sqlite3_stmt *select_from_comments;
-
-    } TSK_SQLITE_HDB_INFO;    
 
     /**
     * Options for opening a hash database

--- a/tsk/tsk_config.h.in
+++ b/tsk/tsk_config.h.in
@@ -36,6 +36,9 @@
 /* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
 #undef HAVE_FSEEKO
 
+/* Define to 1 if you have the `getline' function. */
+#undef HAVE_GETLINE
+
 /* Define to 1 if you have the `getrusage' function. */
 #undef HAVE_GETRUSAGE
 
@@ -56,6 +59,9 @@
 
 /* Define to 1 if you have the <libewf.h> header file. */
 #undef HAVE_LIBEWF_H
+
+/* Define to 1 if you have the `sqlite3' library (-lsqlite3). */
+#undef HAVE_LIBSQLITE3
 
 /* Define to 1 if you have the `stdc++' library (-lstdc++). */
 #undef HAVE_LIBSTDC__
@@ -84,6 +90,9 @@
 
 /* Define to 1 if you have the <set> header file. */
 #undef HAVE_SET
+
+/* Define to 1 if you have the <sqlite3.h> header file. */
+#undef HAVE_SQLITE3_H
 
 /* Define to 1 if you have the <stack> header file. */
 #undef HAVE_STACK
@@ -167,8 +176,7 @@
    slash. */
 #undef LSTAT_FOLLOWS_SLASHED_SYMLINK
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */


### PR DESCRIPTION
The #ifndef guards in sqlite3.h changed from `_SQLITE3_H_` to `SQLITE3_H` in commit 5471aca015 to sqlite, and this change first appears in release 3.14, from August 2016. This causes a problem for any program which compiles against both libtsk and the system-installed sqlite3, as the system sqlite3.h header from 3.14 onward is no longer compatible with the sqlite3.h header bundled with sleuthkit.

This PR modifies autotools builds to use the system sqlite3 when it is available. There are no changes for VC++ builds.