### PR TITLE
Fix HFS+ highest inum lookup

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -1730,6 +1730,15 @@ hfs_cat_file_lookup(HFS_INFO * hfs, TSK_INUM_T inum, HFS_ENTRY * entry,
 }
 
 
+static uint8_t
+hfs_find_highest_inum_cb(HFS_INFO * hfs, int8_t level_type,
+    const hfs_btree_key_cat * cur_key,
+    TSK_OFF_T key_off, void *ptr)
+{
+  *((TSK_INUM_T*) ptr) = tsk_getu32(hfs->fs_info.endian, cur_key->parent_cnid);
+  return HFS_BTREE_CB_IDX_LT;
+}
+
 /** \internal
 * Returns the largest inode number in file system
 * @param hfs File system being analyzed
@@ -1739,19 +1748,21 @@ static TSK_INUM_T
 hfs_find_highest_inum(HFS_INFO * hfs)
 {
     // @@@ get actual number from Catalog file (go to far right) (we can't always trust the vol header)
-    /* I haven't gotten looking at the end of the Catalog B-Tree to work
-       properly. A fast method: if HFS_VH_ATTR_CNIDS_REUSED is set, then
-       the maximum CNID is 2^32-1; if it's not set, then nextCatalogId is
-       supposed to be larger than all CNIDs on disk.
-     */
-
-    TSK_FS_INFO *fs = (TSK_FS_INFO *) & (hfs->fs_info);
-
-    if (tsk_getu32(fs->endian, hfs->fs->attr) & HFS_VH_ATTR_CNIDS_REUSED)
-        return (TSK_INUM_T) 0xffffffff;
-    else
-        return (TSK_INUM_T) tsk_getu32(fs->endian,
-            hfs->fs->next_cat_id) - 1;
+    TSK_INUM_T inum;
+    if (hfs_cat_traverse(hfs, hfs_find_highest_inum_cb, &inum)) {
+      /* Catalog traversal failed, fallback on legacy method :
+         if HFS_VH_ATTR_CNIDS_REUSED is set, then
+         the maximum CNID is 2^32-1; if it's not set, then nextCatalogId is
+         supposed to be larger than all CNIDs on disk.
+       */
+        TSK_FS_INFO *fs = (TSK_FS_INFO *) & (hfs->fs_info);
+        if (tsk_getu32(fs->endian, hfs->fs->attr) & HFS_VH_ATTR_CNIDS_REUSED)
+            return (TSK_INUM_T) 0xffffffff;
+        else
+            return (TSK_INUM_T) tsk_getu32(fs->endian,
+                hfs->fs->next_cat_id) - 1;
+    }
+    return inum;
 }
 
 


### PR DESCRIPTION
This spake @zweger in PR #819 :

> This changes hfs_find_highest_inum's behavior to first check the HFS+ catalog file for the largest inum before falling back on the current method.

> I came across a piece of evidence recently in which the HFS+ volume header next_cat_id slightly undershoots the highest inum on an HFS+ volume. This can cause problems for applications which rely on last_inum / inum_count for allocating arrays and such, although I don't believe this can cause other issues in sleuthkit itself.

> There's a comment in the source indicating my proposed patch is problematic, but git blame indicates it's been some time since hfs_find_highest_inum has been looked at. I'm assuming hfs_cat_traverse has been improved since then.