### PR TITLE
tsk/img/aff: loop initial declarations are not allowed in C89

### DIFF
--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -214,9 +214,10 @@ aff_imgstat(TSK_IMG_INFO * img_info, FILE * hFile)
 static void
 aff_close(TSK_IMG_INFO * img_info)
 {
+    int i;
     IMG_AFF_INFO *aff_info = (IMG_AFF_INFO *) img_info;
     af_close(aff_info->af_file);
-	for (int i = 0; i < img_info->num_img; i++) {
+	for (i = 0; i < img_info->num_img; i++) {
 		if (img_info->images[i])
 			free(img_info->images[i]);
 	}


### PR DESCRIPTION
Declaring an integer inside a for loop as in for(int i;;) is not
allowed in C89 and causes a build failure. Fix it by declaring the
variable just before the for loop.