### PR TITLE
bindings/java/build-unix.xml: do not check for the static library presence

### DIFF
--- a/bindings/java/build-unix.xml
+++ b/bindings/java/build-unix.xml
@@ -39,8 +39,14 @@
         <property environment="env"/>
         <available file="./jni/.libs/libtsk_jni.dylib" property="tsk_dylib.present"/>
         <available file="./jni/.libs/libtsk_jni.so" property="tsk_so.present"/>
-		<available file="./jni/.libs/libtsk_jni.a" property="present"/>
-		<fail unless="present" message="JNI native library not built."/>
+	<fail message="JNI native library not built.">
+		<condition>
+			<not><or>
+				<isset property="tsk_dylib.present"/>
+				<isset property="tsk_so.present"/>
+			</or></not>
+		</condition>
+	</fail>
    	<!-- Default location to find zlib and libewf. Overwritten by properties in makefile -->	
 	<property name="lib.z.path" value="/usr/lib"/>
 	<property name="lib.ewf.path" value="/usr/local/lib"/>


### PR DESCRIPTION
When the build system is configured with '--enable-java
--disable-static', it will not generate the 'libtsk_jni.a' file, even
though the shared library (.so file) is still created. This
configuration results in ant failing with "JNI native library not
built". However, the check for the static library is not meaningful
since only the shared library is of interest for the JNI.

Rewrite the logic so that it checks for the presence of either the
dylib or the so file.