### PR TITLE
Fixed compile error on Windows

### DIFF
--- a/tools/fstools/usnjls.cpp
+++ b/tools/fstools/usnjls.cpp
@@ -17,7 +17,7 @@
 
 
 static TSK_TCHAR *progname;
-static const TSK_TCHAR *usnjrnl_path = "$Extend/$UsnJrnl";
+static const char *usnjrnl_path = "$Extend/$UsnJrnl";
 
 
 /* usage - explain and terminate */


### PR DESCRIPTION
`usnjrnl_path` was assigned the wrong type, causing compiler errors on Windows.