### PR TITLE
HFS+: Fix warnings and add function documentation

### DIFF
--- a/bindings/java/jni/Makefile.am
+++ b/bindings/java/jni/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../../.. -I$(srcdir)/../../.. -Wall $(JNI_CPPFLAGS)
+AM_CPPFLAGS = -I../../.. -I$(srcdir)/../../.. $(JNI_CPPFLAGS)
 EXTRA_DIST = .indent.pro 
 
 lib_LTLIBRARIES = libtsk_jni.la

--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,12 @@ dnl Dependencies for fiwalk
 AC_CHECK_FUNCS([getline])
 AC_SEARCH_LIBS(regexec, [regex], , AC_MSG_ERROR([missing regex]))
 
+dnl Enable compliation warnings
+WARNINGS='-Wall -Wextra -Wpedantic'
+
+AC_SUBST(AM_CFLAGS, $WARNINGS)
+AC_SUBST(AM_CXXFLAGS, $WARNINGS)
+
 AC_CONFIG_FILES([
     Makefile
     tsk/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,8 @@ AC_CHECK_FUNCS([getline])
 AC_SEARCH_LIBS(regexec, [regex], , AC_MSG_ERROR([missing regex]))
 
 dnl Enable compliation warnings
+dnl TODO: Maybe turn on -Wpedantic after fixing all the other warnings?
+dnl WARNINGS='-Wall -Wextra -Wpedantic'
 WARNINGS='-Wall -Wextra -Wpedantic'
 
 AC_SUBST(AM_CFLAGS, $WARNINGS)

--- a/framework/modules/c_FileTypeSigModule/Makefile.am
+++ b/framework/modules/c_FileTypeSigModule/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-AM_CXXFLAGS = $(FW_INCLUDE) $(TSK_INCLUDE) -Wall
+AM_CPPFLAGS = $(FW_INCLUDE) $(TSK_INCLUDE)
 LDFLAGS="-lmagic"
 
 # this will be true if libmagic was found by configure. 

--- a/framework/modules/c_LibExifModule/Makefile.am
+++ b/framework/modules/c_LibExifModule/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-AM_CXXFLAGS = $(FW_INCLUDE) $(TSK_INCLUDE) -Wall
+AM_CPPFLAGS = $(FW_INCLUDE) $(TSK_INCLUDE)
 LDFLAGS="-lexif"
 
 # this will be true if libexif was found by configure. 

--- a/framework/tools/tsk_analyzeimg/Makefile.am
+++ b/framework/tools/tsk_analyzeimg/Makefile.am
@@ -1,4 +1,4 @@
-tsk_analyzeimg_CXXFLAGS = -I.. -I../.. -I../../.. -Wall
+tsk_analyzeimg_CPPFLAGS = -I.. -I../.. -I../../..
 LDADD = ../../tsk/framework/libtskframework.la ../../../tsk/libtsk.la
 
 bin_PROGRAMS = tsk_analyzeimg

--- a/framework/tools/tsk_validatepipeline/Makefile.am
+++ b/framework/tools/tsk_validatepipeline/Makefile.am
@@ -1,4 +1,4 @@
-tsk_validatepipeline_CXXFLAGS = -I.. -I../.. -I../../.. -Wall
+tsk_validatepipeline_CPPFLAGS = -I.. -I../.. -I../../..
 LDADD = ../../tsk/framework/libtskframework.la ../../../tsk/libtsk.la
 
 bin_PROGRAMS = tsk_validatepipeline

--- a/framework/tsk/framework/extraction/Makefile.am
+++ b/framework/tsk/framework/extraction/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I.. -I../.. -I../../../.. -Wall
+AM_CPPFLAGS = -I.. -I../.. -I../../../..
 
 noinst_LTLIBRARIES = libfwextract.la
 libfwextract_la_SOURCES = TskAutoImpl.cpp TskAutoImpl.h \

--- a/framework/tsk/framework/file/Makefile.am
+++ b/framework/tsk/framework/file/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I.. -I../.. -I../../../.. -Wall
+AM_CPPFLAGS = -I.. -I../.. -I../../../..
 
 noinst_LTLIBRARIES = libfwfile.la
 libfwfile_la_SOURCES = \

--- a/framework/tsk/framework/pipeline/Makefile.am
+++ b/framework/tsk/framework/pipeline/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I.. -I../.. -I../../../.. -Wall
+AM_CPPFLAGS = -I.. -I../.. -I../../../..
 
 noinst_LTLIBRARIES = libfwpipe.la
 libfwpipe_la_SOURCES = \

--- a/framework/tsk/framework/services/Makefile.am
+++ b/framework/tsk/framework/services/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I.. -I../.. -I../../../.. -Wall
+AM_CPPFLAGS = -I.. -I../.. -I../../../..
 
 noinst_LTLIBRARIES = libfwserv.la
 libfwserv_la_SOURCES = \

--- a/framework/tsk/framework/utilities/Makefile.am
+++ b/framework/tsk/framework/utilities/Makefile.am
@@ -1,4 +1,4 @@
-AM_CXXFLAGS = -I.. -I../.. -I../../../.. -Wall
+AM_CPPFLAGS = -I.. -I../.. -I../../../..
 
 noinst_LTLIBRARIES = libfwutil.la
 libfwutil_la_SOURCES = SectorRuns.cpp SectorRuns.h \

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I.. -I$(srcdir)/.. -Wall 
+AM_CPPFLAGS = -I.. -I$(srcdir)/..
 LDADD = ../tsk/libtsk.la
 AM_LDFLAGS = -static
 EXTRA_DIST = .indent.pro 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,6 @@
-AM_CPPFLAGS = -I.. -I$(srcdir)/.. -Wall $(PTHREAD_CFLAGS)
+AM_CPPFLAGS = -I.. -I$(srcdir)/..
+AM_CFLAGS += $(PTHREAD_CFLAGS)
+AM_CXXFLAGS += $(PTHREAD_CFLAGS)
 LDADD = ../tsk/libtsk.la
 LDFLAGS += -static $(PTHREAD_LIBS)
 EXTRA_DIST = .indent.pro runtests.sh

--- a/tools/autotools/Makefile.am
+++ b/tools/autotools/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 LDADD = ../../tsk/libtsk.la
 LDFLAGS += -static
 EXTRA_DIST = .indent.pro

--- a/tools/fiwalk/src/Makefile.am
+++ b/tools/fiwalk/src/Makefile.am
@@ -1,7 +1,6 @@
 bin_PROGRAMS = fiwalk 
 
-AM_CFLAGS = -Wall
-AM_CPPFLAGS = -I../../.. -Wall
+AM_CPPFLAGS = -I../../..
 LDADD = ../../../tsk/libtsk.la
 
 EXTRA_DIST = README_PLUGINS.txt ficonfig.txt \

--- a/tools/fstools/Makefile.am
+++ b/tools/fstools/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 LDADD = ../../tsk/libtsk.la
 LDFLAGS += -static
 EXTRA_DIST = .indent.pro fscheck.cpp

--- a/tools/hashtools/Makefile.am
+++ b/tools/hashtools/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall 
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 LDADD = ../../tsk/libtsk.la
 LDFLAGS += -static
 EXTRA_DIST = .indent.pro md5.c sha1.c

--- a/tools/imgtools/Makefile.am
+++ b/tools/imgtools/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 LDADD = ../../tsk/libtsk.la
 LDFLAGS += -static
 EXTRA_DIST = .indent.pro

--- a/tools/srchtools/Makefile.am
+++ b/tools/srchtools/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = srch_strings sigfind
 EXTRA_DIST = .indent.pro
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 
 srch_strings_SOURCES = srch_strings.c
 

--- a/tools/vstools/Makefile.am
+++ b/tools/vstools/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall 
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 LDADD = ../../tsk/libtsk.la
 LDFLAGS += -static
 EXTRA_DIST = .indent.pro

--- a/tsk/auto/Makefile.am
+++ b/tsk/auto/Makefile.am
@@ -1,4 +1,6 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall  -Wmultichar -Wstrict-null-sentinel -Woverloaded-virtual -Wsign-promo
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
+AM_CFLAGS += -Wmultichar -Wstrict-null-sentinel -Woverloaded-virtual -Wsign-promo
+AM_CXXFLAGS += -Wmultichar -Wstrict-null-sentinel -Woverloaded-virtual -Wsign-promo
 EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskauto.la

--- a/tsk/auto/auto.cpp
+++ b/tsk/auto/auto.cpp
@@ -595,7 +595,7 @@ TskAuto::processAttribute(TSK_FS_FILE * fs_file,
                                          const TSK_FS_ATTR * fs_attr, const char *path) 
 {
     return TSK_OK;
-};
+}
 
 
 void TskAuto::setStopProcessing() {
@@ -695,7 +695,7 @@ std::string TskAuto::errorRecordToString(error_record &rec) {
 uint8_t 
 TskAuto::handleError() {
     return 0;
-};
+}
 
 
 /**

--- a/tsk/base/Makefile.am
+++ b/tsk/base/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -Wall 
+AM_CPPFLAGS = -I../..
 
 noinst_LTLIBRARIES = libtskbase.la
 libtskbase_la_SOURCES = md5c.c mymalloc.c sha1c.c \

--- a/tsk/fs/Makefile.am
+++ b/tsk/fs/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskfs.la

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -239,7 +239,7 @@ hfs_checked_read_random(TSK_FS_INFO * fs, char *buf, size_t len,
     ssize_t r;
 
     r = tsk_fs_read(fs, offs, buf, len);
-    if (r != len) {
+    if (r != (ssize_t) len) {
         if (r >= 0) {
             tsk_error_reset();
             tsk_error_set_errno(TSK_ERR_FS_READ);
@@ -2679,7 +2679,7 @@ hfs_read_zlib_block_table(const TSK_FS_ATTR *rAttr, CMP_OFFSET_ENTRY** offsetTab
 
     attrReadResult = tsk_fs_attr_read(rAttr, offsetTableOffset + 4,
         offsetTableData, tableSize * 8, TSK_FS_FILE_READ_FLAG_NONE);
-    if (attrReadResult != tableSize * 8) {
+    if (attrReadResult != (ssize_t) tableSize * 8) {
         error_returned
             (" %s: reading in the compression offset table, "
             "return value %u should have been %u", __func__, attrReadResult,
@@ -2752,7 +2752,7 @@ hfs_read_lzvn_block_table(const TSK_FS_ATTR *rAttr, CMP_OFFSET_ENTRY** offsetTab
 
     attrReadResult = tsk_fs_attr_read(rAttr, 0,
         offsetTableData, tableDataSize, TSK_FS_FILE_READ_FLAG_NONE);
-    if (attrReadResult != tableDataSize) {
+    if (attrReadResult != (ssize_t) tableDataSize) {
         error_returned
             (" %s: reading in the compression offset table, "
             "return value %u should have been %u", __func__, attrReadResult,
@@ -2898,7 +2898,7 @@ static ssize_t read_and_decompress_block(
     // Read in the block of compressed data
     attrReadResult = tsk_fs_attr_read(rAttr, offset,
         rawBuf, len, TSK_FS_FILE_READ_FLAG_NONE);
-    if (attrReadResult != len) {
+    if (attrReadResult != (ssize_t) len) {
         char msg[] =
             "%s%s: reading in the compression offset table, "
             "return value %u should have been %u";
@@ -4437,7 +4437,7 @@ hfs_parse_resource_fork(TSK_FS_FILE * fs_file)
         tsk_fs_attr_read(rAttr, (uint64_t) mapOffset, map,
         (size_t) mapLength, TSK_FS_FILE_READ_FLAG_NONE);
 
-    if (attrReadResult < 0 || attrReadResult != mapLength) {
+    if (attrReadResult < 0 || attrReadResult != (ssize_t) mapLength) {
         error_returned
             ("- hfs_parse_resource_fork: could not read the map");
         free(map);
@@ -4976,7 +4976,7 @@ hfs_block_is_alloc(HFS_INFO * hfs, TSK_DADDR_T a_addr)
     // see if it is in the cache
     if ((hfs->blockmap_cache_start == -1)
         || (hfs->blockmap_cache_start > b)
-        || (hfs->blockmap_cache_start + hfs->blockmap_cache_len <= b)) {
+        || (hfs->blockmap_cache_start + hfs->blockmap_cache_len <= (size_t) b)) {
         size_t cnt = tsk_fs_attr_read(hfs->blockmap_attr, b,
             hfs->blockmap_cache,
             sizeof(hfs->blockmap_cache), 0);

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -823,12 +823,12 @@ hfs_cat_compare_keys(HFS_INFO * hfs, const hfs_btree_key_cat * key1,
 
 
 /** \internal
- * 
+ *
  * Traverse the HFS catalog file.  Call the callback for each
- * record. 
+ * record.
  *
  * @param hfs File system
- * @param a_cb callback 
+ * @param a_cb callback
  * @param ptr Pointer to pass to callback
  * @returns 1 on error
  */
@@ -1155,7 +1155,7 @@ hfs_cat_get_record_offset_cb(HFS_INFO * hfs, int8_t level_type,
             return HFS_BTREE_CB_LEAF_GO;
         }
         else if (diff == 0) {
-            offset_data->off = 
+            offset_data->off =
                 key_off + 2 + tsk_getu16(hfs->fs_info.endian,
                 cur_key->key_len);
         }
@@ -1728,7 +1728,7 @@ hfs_find_highest_inum_cb(HFS_INFO * hfs, int8_t level_type,
 {
     // NOTE: This assumes that the biggest inum is the last one that we
     // see.  the traverse method does not currently promise that as part of
-    // its callback "contract". 
+    // its callback "contract".
     *((TSK_INUM_T*) ptr) = tsk_getu32(hfs->fs_info.endian, cur_key->parent_cnid);
     return HFS_BTREE_CB_IDX_LT;
 }
@@ -3936,7 +3936,7 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
                 goto on_error;
             }
 
-            recData = &recordBytes[keyLength + 2];   
+            recData = &recordBytes[keyLength + 2];
 
             // Data must start on an even offset from the beginning of the record.
             // So, correct this if needed.
@@ -3977,11 +3977,11 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
 
         // Loop over the records in this node
         for (recIndx = 0; recIndx < numRec; ++recIndx) {
-            
+
             // The offset to the record is stored in table at end of node
             uint8_t *recOffsetTblEntry = &nodeData[attrFile.nodeSize - (2 * (recIndx + 1))];  // data describing where this record is
             uint16_t recOffset = tsk_getu16(endian, recOffsetTblEntry);
-            
+
             int comp;           // comparison result
             char *compStr;      // comparison result as a string
             uint32_t keyFileID;
@@ -3998,7 +3998,7 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
 
             // Cast that to the Attributes file key
             keyB = (hfs_btree_key_attr *) recordBytes;
-            
+
             // Compare recordBytes key to the key that we are seeking
             keyFileID = tsk_getu32(endian, keyB->file_id);
 
@@ -4100,7 +4100,7 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
                 // be because UTF8 is a variable length encoding. However, the longest
                 // it will be is 3 * the max number of UTF16 code units.  Add one for null
                 // termination.   (thanks Judson!)
-                
+
 
                 conversionResult = hfs_UTF16toUTF8(fs, keyB->attr_name,
                     nameLength, nameBuff, HFS_MAX_ATTR_NAME_LEN_UTF8_B+1, 0);

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -3006,7 +3006,7 @@ static ssize_t read_and_decompress_block(
  * @param ptr context for the action callback
  * @param read_block_table pointer to block table read function
  * @param decompress_block pointer to decompression function
- * @return
+ * @return 0 on success, 1 on error
  */
 static uint8_t
 hfs_attr_walk_compressed_rsrc(const TSK_FS_ATTR * fs_attr,
@@ -3175,7 +3175,7 @@ on_error:
     free(offsetTable);
     free(rawBuf);
     free(uncBuf);
-    return 0;
+    return 1;
 }
 
 
@@ -3188,7 +3188,7 @@ on_error:
  * @param flags
  * @param a_action action callback
  * @param ptr context for the action callback
- * @return
+ * @return 0 on success, 1 on error
  */
 static uint8_t
 hfs_attr_walk_zlib_rsrc(const TSK_FS_ATTR * fs_attr,
@@ -3210,7 +3210,7 @@ hfs_attr_walk_zlib_rsrc(const TSK_FS_ATTR * fs_attr,
  * @param flags
  * @param a_action action callback
  * @param ptr context for the action callback
- * @return
+ * @return 0 on success, 1 on error
  */
 static uint8_t
 hfs_attr_walk_lzvn_rsrc(const TSK_FS_ATTR * fs_attr,

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -3171,7 +3171,7 @@ hfs_file_read_compressed_rsrc(const TSK_FS_ATTR * a_fs_attr,
 
     if (a_offset < 0) {
         error_detected(TSK_ERR_FS_ARG,
-            "%s: reading from file at a negative offset, or negative length",
+            "%s: reading from file at a negative offset",
              __func__);
         return -1;
     }

--- a/tsk/fs/lzvn.c
+++ b/tsk/fs/lzvn.c
@@ -529,7 +529,7 @@ copy_literal_and_match:
   //  Check if the match distance is valid; matches must not reference
   //  bytes that preceed the start of the output buffer, nor can the match
   //  distance be zero.
-  if (D > dst_ptr - state->dst_begin || D == 0)
+  if (D > (size_t)(dst_ptr - state->dst_begin) || D == 0)
     goto invalid_match_distance;
 copy_match:
   //  Now we copy the match from dst_ptr - D to dst_ptr. It is important to keep

--- a/tsk/fs/lzvn.c
+++ b/tsk/fs/lzvn.c
@@ -225,8 +225,9 @@ void lzvn_decode(lzvn_decoder_state *state) {
 //  No error checking happens in the first stage, except for ensuring that
 //  the source has enough length to represent the full opcode before
 //  reading past the first byte.
+#if HAVE_LABELS_AS_VALUES
 sml_d:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 0:
   case 1:
   case 2:
@@ -368,8 +369,9 @@ sml_d:
   D = (size_t)extract(opc, 0, 3) << 8 | src_ptr[1];
   goto copy_literal_and_match;
 
+#if HAVE_LABELS_AS_VALUES
 med_d:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 160:
   case 161:
   case 162:
@@ -418,8 +420,9 @@ med_d:
   D = (size_t)extract(opc23, 2, 14);
   goto copy_literal_and_match;
 
+#if HAVE_LABELS_AS_VALUES
 lrg_d:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 7:
   case 15:
   case 23:
@@ -454,8 +457,9 @@ lrg_d:
   D = load2(&src_ptr[1]);
   goto copy_literal_and_match;
 
+#if HAVE_LABELS_AS_VALUES
 pre_d:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 70:
   case 78:
   case 86:
@@ -592,8 +596,9 @@ copy_match:
 //  to encode is the match length. We are able to reuse the match copy
 //  sequence from the literal and match opcodes to perform the actual
 //  copy implementation.
+#if HAVE_LABELS_AS_VALUES
 sml_m:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 241:
   case 242:
   case 243:
@@ -621,8 +626,9 @@ sml_m:
   PTR_LEN_INC(src_ptr, src_len, opc_len);
   goto copy_match;
 
+#if HAVE_LABELS_AS_VALUES
 lrg_m:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 240:
 #endif
   UPDATE_GOOD;
@@ -643,8 +649,9 @@ lrg_m:
 //  These two opcodes (lrg_l and sml_l) encode only a literal.  There is no
 //  match length or match distance to worry about (but we need to *not*
 //  touch D, as it must be preserved between opcodes).
+#if HAVE_LABELS_AS_VALUES
 sml_l:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 225:
   case 226:
   case 227:
@@ -668,8 +675,9 @@ sml_l:
   L = (size_t)extract(opc, 0, 4);
   goto copy_literal;
 
+#if HAVE_LABELS_AS_VALUES
 lrg_l:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 224:
 #endif
   UPDATE_GOOD;
@@ -736,8 +744,9 @@ copy_literal:
 
 // ===============================================================
 // Other opcodes
+#if HAVE_LABELS_AS_VALUES
 nop:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 14:
   case 22:
 #endif
@@ -753,8 +762,9 @@ nop:
   break;
 #endif
 
+#if HAVE_LABELS_AS_VALUES
 eos:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 6:
 #endif
   opc_len = 8;
@@ -768,8 +778,9 @@ eos:
 
 // ===============================================================
 // Return on error
+#if HAVE_LABELS_AS_VALUES
 udef:
-#if !HAVE_LABELS_AS_VALUES
+#else
   case 30:
   case 38:
   case 46:

--- a/tsk/hashdb/Makefile.am
+++ b/tsk/hashdb/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall 
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskhashdb.la

--- a/tsk/img/Makefile.am
+++ b/tsk/img/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 EXTRA_DIST = .indent.pro 
 
 noinst_LTLIBRARIES = libtskimg.la

--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -250,7 +250,7 @@ raw_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf, size_t len)
             }
 
             /* Get the length to read */
-            if ((raw_info->max_off[i] - offset) >= len)
+            if ((size_t) (raw_info->max_off[i] - offset) >= len)
                 read_len = len;
             else
                 read_len = (size_t) (raw_info->max_off[i] - offset);
@@ -267,12 +267,12 @@ raw_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf, size_t len)
             if (cnt < 0) {
                 return -1;
             }
-            if ((TSK_OFF_T) cnt != read_len) {
+            if ((size_t) cnt != read_len) {
                 return cnt;
             }
 
             /* read from the next image segment(s) if needed */
-            if (((TSK_OFF_T) cnt == read_len) && (read_len != len)) {
+            if (((size_t) cnt == read_len) && (read_len != len)) {
 
                 len -= read_len;
 
@@ -281,8 +281,8 @@ raw_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf, size_t len)
                     /* go to the next image segment */
                     i++;
 
-                    if (raw_info->max_off[i] -
-                        raw_info->max_off[i - 1] >= len)
+                    if ((size_t) (raw_info->max_off[i] -
+                        raw_info->max_off[i - 1]) >= len)
                         read_len = len;
                     else
                         read_len = (size_t)
@@ -302,7 +302,7 @@ raw_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf, size_t len)
                     }
                     cnt += cnt2;
 
-                    if ((TSK_OFF_T) cnt2 != read_len) {
+                    if ((size_t) cnt2 != read_len) {
                         return cnt;
                     }
 

--- a/tsk/vs/Makefile.am
+++ b/tsk/vs/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall 
+AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 EXTRA_DIST = .indent.pro
 
 noinst_LTLIBRARIES = libtskvs.la

--- a/unit_tests/base/Makefile.am
+++ b/unit_tests/base/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../.. -Wall $(CPPUNIT_CFLAGS) 
+AM_CPPFLAGS = -I../.. $(CPPUNIT_CFLAGS)
 LDADD = ../../tsk/libtsk.la $(CPPUNIT_LIBS)
 LDFLAGS = -static 
 


### PR DESCRIPTION
This PR:

* enables more warnings for autotools builds (`-Wall -Wextra`)
* rectifies the confusion between `CPPFLAGS` and `CXXFLAGS` in various `Makefile.am`s
* fixes various compilation warnings
* adds documentation to the HFS+ decompression functions
* fixes a return value bug in `hfs_attr_walk_compressed_rsrc`