### PR TITLE
896 get account device instances with communications refactor

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/CommunicationsManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CommunicationsManager.java
@@ -47,44 +47,41 @@ public class CommunicationsManager {
 
 	private final SleuthkitCase db;
 
-	private Map<Account.Type, Integer> accountTypeToTypeIdMap;
-	private Map<String, Account.Type> typeNameToAccountTypeMap;
+	private final Map<Account.Type, Integer> accountTypeToTypeIdMap
+			= new ConcurrentHashMap<Account.Type, Integer>();
+	private final Map<String, Account.Type> typeNameToAccountTypeMap
+			= new ConcurrentHashMap<String, Account.Type>();
 
 	// Artifact types that represent a relationship between accounts 
-	private final Set<Integer> RELATIONSHIP_ARTIFACT_TYPE_IDS = new HashSet<Integer>(Arrays.asList(
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE.getTypeID(),
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_EMAIL_MSG.getTypeID(),
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_CONTACT.getTypeID(),
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG.getTypeID()
-	));
-	private String RELATIONSHIP_ARTIFACT_TYPE_IDS_CSV_STR;
+	private final static Set<Integer> RELATIONSHIP_ARTIFACT_TYPE_IDS
+			= new HashSet<Integer>(Arrays.asList(
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE.getTypeID(),
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_EMAIL_MSG.getTypeID(),
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_CONTACT.getTypeID(),
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG.getTypeID()
+			));
+	private static final String RELATIONSHIP_ARTIFACT_TYPE_IDS_CSV_STR
+			= StringUtils.buildCSVString(RELATIONSHIP_ARTIFACT_TYPE_IDS);
 
 	// Artifact types that represent communications between accounts 
-	private final Set<Integer> COMMUNICATION_ARTIFACT_TYPE_IDS = new HashSet<Integer>(Arrays.asList(
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE.getTypeID(),
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_EMAIL_MSG.getTypeID(),
-			BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG.getTypeID()
-	));
-	private String COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR;
+	private static final Set<Integer> COMMUNICATION_ARTIFACT_TYPE_IDS
+			= new HashSet<Integer>(Arrays.asList(
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE.getTypeID(),
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_EMAIL_MSG.getTypeID(),
+					BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG.getTypeID()
+			));
+	private static final String COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR
+			= StringUtils.buildCSVString(COMMUNICATION_ARTIFACT_TYPE_IDS);
 
 	CommunicationsManager(SleuthkitCase db) throws TskCoreException {
 		this.db = db;
 
-		init();
-	}
-
-	private void init() throws TskCoreException {
-		accountTypeToTypeIdMap = new ConcurrentHashMap<Account.Type, Integer>();
-		typeNameToAccountTypeMap = new ConcurrentHashMap<String, Account.Type>();
-		RELATIONSHIP_ARTIFACT_TYPE_IDS_CSV_STR = StringUtils.buildCSVString(RELATIONSHIP_ARTIFACT_TYPE_IDS);
-		COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR = StringUtils.buildCSVString(COMMUNICATION_ARTIFACT_TYPE_IDS);
 		initAccountTypes();
 	}
 
 	/**
 	 * Make sure the predefined account types are in the account types table.
 	 *
-	 * @throws SQLException
 	 * @throws TskCoreException
 	 */
 	private void initAccountTypes() throws TskCoreException {
@@ -111,12 +108,10 @@ public class CommunicationsManager {
 						resultSet = null;
 					}
 
-					ResultSet rs2 = null;
-					rs2 = connection.executeQuery(statement, "SELECT account_type_id FROM account_types WHERE type_name = '" + type.getTypeName() + "'"); //NON-NLS
+					ResultSet rs2 = connection.executeQuery(statement, "SELECT account_type_id FROM account_types WHERE type_name = '" + type.getTypeName() + "'"); //NON-NLS
 					rs2.next();
 					int typeID = rs2.getInt("account_type_id");
 					rs2.close();
-					rs2 = null;
 
 					Account.Type accountType = new Account.Type(type.getTypeName(), type.getDisplayName());
 					this.accountTypeToTypeIdMap.put(accountType, typeID);
@@ -136,6 +131,8 @@ public class CommunicationsManager {
 	 * Reads in in the account types table.
 	 *
 	 * Returns the number of account types read in
+	 *
+	 * @return The number of account types read.
 	 *
 	 * @throws SQLException
 	 * @throws TskCoreException
@@ -704,12 +701,17 @@ public class CommunicationsManager {
 			// set up applicable filters
 			Set<String> applicableFilters1 = new HashSet<String>();
 			applicableFilters1.add(DateRangeFilter.class.getName());
+			applicableFilters1.add(DeviceFilter.class.getName());
+			String innerQueryTemplate
+					= "SELECT "
+					+ "				%1$1s as account_ID,"
+					+ "				data_source_obj_id"
+					+ " FROM relationships AS relationships"
+					+ "	WHERE relationships.relationship_type IN "
+					+ "		( " + COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR + " )";
 
-			String innerQuery1 = "		SELECT DISTINCT account1_id FROM relationships  AS relationships"
-					+ "		  WHERE relationships.relationship_type IN ( " + COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR + " )";
-
-			String innerQuery2 = "		SELECT DISTINCT account2_id FROM relationships AS relationships"
-					+ "		  WHERE relationships.relationship_type IN ( " + COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR + " )";
+			String innerQuery1 = String.format(innerQueryTemplate, "account1_id");
+			String innerQuery2 = String.format(innerQueryTemplate, "account2_id");
 
 			// Date range filters are applied to the two inner queries
 			String innerQueryfilterSQL = getCommunicationsFilterSQL(filter, applicableFilters1);
@@ -720,27 +722,29 @@ public class CommunicationsManager {
 				innerQuery2 += " AND " + innerQueryfilterSQL;
 			}
 
+			String combinedInnerQuery
+					= "SELECT count(*) as count, account_id, data_source_obj_id "
+					+ " FROM ( " + innerQuery1 + " UNION " + innerQuery2 + " ) "
+					+ " GROUP BY account_id, data_source_obj_id";
+
 			System.out.println("RAMAN innerQueryfilterSQL = " + innerQueryfilterSQL);
 			System.out.println("RAMAN innerQuery1 = " + innerQuery1);
 			System.out.println("RAMAN innerQuery2 = " + innerQuery2);
 			System.out.println("");
 
-			String queryStr = "SELECT DISTINCT accounts.account_id AS account_id,"
+			String queryStr = "SELECT count,"
+					+ " accounts.account_id AS account_id,"
+					+ " account_types.type_name as type_name,"
+					+ " account_types.display_name as display_name,"
+					+ " accounts.account_unique_identifier as account_unique_identifier,"
 					+ " data_source_info.device_id AS device_id"
 					+ " FROM accounts AS accounts"
 					+ " JOIN account_types as account_types"
 					+ "		ON accounts.account_type_id = account_types.account_type_id"
-					+ "	JOIN account_to_instances_map AS account_to_instances_map"
-					+ "		ON accounts.account_id = account_to_instances_map.account_id"
-					+ "	JOIN blackboard_artifacts AS artifacts"
-					+ "		ON account_to_instances_map.account_instance_id = artifacts.artifact_id"
 					+ " JOIN data_source_info as data_source_info"
-					+ "		ON artifacts.data_source_obj_id = data_source_info.obj_id"
-					+ " WHERE accounts.account_id IN ("
-					+ innerQuery1
-					+ "		UNION "
-					+ innerQuery2
-					+ "  )";
+					+ "		ON account_device_instances.data_source_obj_id = data_source_info.obj_id"
+					+ " JOIN ( " + combinedInnerQuery + " ) as account_device_instances "
+					+ "		ON accounts.account_id = account_device_instances.account_id";
 
 			// set up applicable filters
 			Set<String> applicableFilters = new HashSet<String>();
@@ -750,7 +754,8 @@ public class CommunicationsManager {
 			// append SQL for filters
 			String filterSQL = getCommunicationsFilterSQL(filter, applicableFilters);
 			if (!filterSQL.isEmpty()) {
-				queryStr += " AND " + filterSQL;
+				queryStr += " where " + filterSQL
+						+ " GRoup BY accounts.account_id, data_source_info.device_id";
 			}
 
 			System.out.println("RAMAN FilterSQL = " + filterSQL);
@@ -762,7 +767,13 @@ public class CommunicationsManager {
 			while (rs.next()) {
 				long account_id = rs.getLong("account_id");
 				String deviceID = rs.getString("device_id");
-				Account account = this.getAccount(account_id);
+				final String type_name = rs.getString("type_name");
+				final String display_name = rs.getString("display_name");
+				final String account_unique_identifier = rs.getString("account_unique_identifier");
+
+				Account account = new Account(account_id,
+						new Account.Type(type_name, display_name),
+						account_unique_identifier);
 
 				accountDeviceInstances.add(new AccountDeviceInstance(account, deviceID));
 			}
@@ -988,7 +999,7 @@ public class CommunicationsManager {
 	/**
 	 * Converts a list of accountIDs into a set of possible unordered pairs.
 	 *
-	 * @param accountIDs - list of accountID.
+	 * @param account_ids - list of accountID.
 	 *
 	 * @return Set<UnorderedPair<Long>>
 	 */
@@ -1036,6 +1047,13 @@ public class CommunicationsManager {
 	 * Builds the SQL for the given CommunicationsFilter.
 	 *
 	 * Gets the SQL for each subfilter and combines using AND.
+	 *
+	 * @param commFilter        The CommunicationsFilter to get the SQL for.
+	 * @param applicableFilters A Set of names of classes of subfilters that are
+	 *                          applicable. SubFilters not in this list will be
+	 *                          ignored.
+	 *
+	 * @return return SQL suitible for use IN a where clause.
 	 */
 	private String getCommunicationsFilterSQL(CommunicationsFilter commFilter, Set<String> applicableFilters) {
 		if (null == commFilter || commFilter.getAndFilters().isEmpty()) {
@@ -1078,7 +1096,7 @@ public class CommunicationsManager {
 		private final long account1_id;
 		private final long account2_id;
 
-		public UnorderedAccountPair(long account1_id, long account2_id) {
+		UnorderedAccountPair(long account1_id, long account2_id) {
 			this.account1_id = account1_id;
 			this.account2_id = account2_id;
 		}

--- a/bindings/java/src/org/sleuthkit/datamodel/CommunicationsManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CommunicationsManager.java
@@ -640,7 +640,7 @@ public class CommunicationsManager {
 	}
 
 	/**
-	 * Adds a row in relationships table
+	 * Adds a row in account relationships table
 	 *
 	 * @param account1_id                account_id for account1
 	 * @param account2_id                account_id for account2
@@ -664,7 +664,8 @@ public class CommunicationsManager {
 			connection.beginTransaction();
 			s = connection.createStatement();
 
-			s.execute("INSERT INTO relationships (account1_id, account2_id, relationship_source_obj_id, date_time, relationship_type, data_source_obj_id  ) VALUES ( " + account1_id + ", " + account2_id + ", " + relationship_source_obj_id + ", " + dateTime + ", " + relationship_type + ", " + data_source_obj_id + ")"); //NON-NLS
+			s.execute("INSERT INTO account_relationships (account1_id, account2_id, relationship_source_obj_id, date_time, relationship_type, data_source_obj_id  ) "
+					+ "VALUES ( " + account1_id + ", " + account2_id + ", " + relationship_source_obj_id + ", " + dateTime + ", " + relationship_type + ", " + data_source_obj_id + ")"); //NON-NLS
 			connection.commitTransaction();
 		} catch (SQLException ex) {
 			connection.rollbackTransaction();
@@ -710,7 +711,7 @@ public class CommunicationsManager {
 			String innerQueryTemplate
 					= " SELECT %1$1s as account_id,"
 					+ "		  data_source_obj_id"
-					+ " FROM relationships "
+					+ " FROM account_relationships as relationships"
 					+ "	WHERE relationship_type IN "
 					+ "		( " + COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR + " ) "
 					+ (innerQueryfilterSQL.isEmpty() ? "" : " AND " + innerQueryfilterSQL);
@@ -820,7 +821,7 @@ public class CommunicationsManager {
 
 			String internalQueryStr = "SELECT DISTINCT "
 					+ "	relationships.relationship_source_obj_id AS relationship_source_obj_id"
-					+ "	FROM relationships AS relationships"
+					+ "	FROM account_relationships AS relationships"
 					+ " WHERE relationships.data_source_obj_id IN ( " + datasource_obj_ids_list + " )"
 					+ " AND relationships.relationship_type IN ( " + COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR + " )"
 					+ " AND ( relationships.account1_id = " + account_id + " OR  relationships.account2_id = " + account_id + " )";
@@ -926,7 +927,7 @@ public class CommunicationsManager {
 					+ " artifacts.artifact_type_id AS artifact_type_id, "
 					+ " artifacts.review_status_id AS review_status_id  "
 					+ " FROM blackboard_artifacts as artifacts"
-					+ "	JOIN relationships AS relationships"
+					+ "	JOIN account_relationships AS relationships"
 					+ "		ON artifacts.artifact_obj_id = relationships.relationship_source_obj_id"
 					+ " WHERE artifacts.artifact_type_id IN ( " + COMMUNICATION_ARTIFACT_TYPE_IDS_CSV_STR + " )";
 

--- a/bindings/java/src/org/sleuthkit/datamodel/DeviceFilter.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DeviceFilter.java
@@ -86,7 +86,7 @@ public class DeviceFilter implements SubFilter {
 
 		String datasource_obj_ids_list = StringUtils.buildCSVString(ds_ids);
 		if (!datasource_obj_ids_list.isEmpty()) {
-			sql = " artifacts.data_source_obj_id IN ( " + datasource_obj_ids_list + " )";
+			sql = " data_source_obj_id IN ( " + datasource_obj_ids_list + " )";
 		}
 
 		return sql;

--- a/bindings/java/test/org/sleuthkit/datamodel/CommunicationsManagerTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CommunicationsManagerTest.java
@@ -1,7 +1,7 @@
 /*
  * Sleuth Kit Data Model
  *
- * Copyright 2013 Basis Technology Corp.
+ * Copyright 2017 Basis Technology Corp.
  * Contact: carrier <at> sleuthkit <dot> org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ package org.sleuthkit.datamodel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,10 +31,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.AfterClass;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Tests the CommunicationsManager API along with filters.
@@ -186,11 +187,11 @@ public class CommunicationsManagerTest {
 	private static final long AUG_1_2017 = 1501545600;
 	private static final long DEC_31_2017 = 1514678400;
 	private static final long DEC_31_2016 = 1483142400;
-	
+
 	private static String dbPath = null;
 
-	private static List<BlackboardArtifact> emailMessages = new ArrayList<BlackboardArtifact>();
-	
+	private static final List<BlackboardArtifact> emailMessages = new ArrayList<BlackboardArtifact>();
+
 	public CommunicationsManagerTest() {
 	}
 
@@ -245,7 +246,6 @@ public class CommunicationsManagerTest {
 						sourceContent_1);
 				emailMessages.add(emailMsg);
 
-				
 				emailMsg = addEmailMsgArtifact(EMAIL_C, EMAIL_A, "", "",
 						JUL_1_2017, "",
 						"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua", "", "",
@@ -317,7 +317,7 @@ public class CommunicationsManagerTest {
 		// Test no filters - pass null for CommunicationsFilter
 		{
 			List<AccountDeviceInstance> accountDeviceInstances2 = commsMgr.getAccountDeviceInstancesWithCommunications(null);
-			assertEquals(11, accountDeviceInstances2.size());
+			assertEquals(10, accountDeviceInstances2.size());
 		}
 
 		// Test no filters - empty DeviceFilter
@@ -327,7 +327,7 @@ public class CommunicationsManagerTest {
 					null);
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(11, accountDeviceInstances.size());
+			assertEquals(10, accountDeviceInstances.size());
 		}
 
 		// Test filter - filter for DS1 and DS2
@@ -337,7 +337,7 @@ public class CommunicationsManagerTest {
 					null);
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(11, accountDeviceInstances.size());
+			assertEquals(10, accountDeviceInstances.size());
 		}
 
 		// Test filter - filter for DS3 - it has no accounts
@@ -364,7 +364,7 @@ public class CommunicationsManagerTest {
 					new HashSet<Account.Type>());
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(11, accountDeviceInstances.size());
+			assertEquals(10, accountDeviceInstances.size());
 		}
 
 		// Test AccountTypeFilter - Email
@@ -387,7 +387,7 @@ public class CommunicationsManagerTest {
 
 			// @TODO EUR-884: RAMAN dont know why this returns 6, expect 5 here
 			// The above call returns PHONE_NUM3/DS2 extra - it has no communication on DS2
-			//assertEquals(5, accountDeviceInstances.size());
+			assertEquals(5, accountDeviceInstances.size());
 		}
 
 		// Test AccountTypeFilter - Email & Phone
@@ -399,7 +399,7 @@ public class CommunicationsManagerTest {
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
 
 			// @TODO EUR-884: RAMAN dont know why this returns 9, expect 8 here
-			//assertEquals(8, accountDeviceInstances.size());
+			assertEquals(8, accountDeviceInstances.size());
 		}
 
 		// Test AccountTypeFilter - CreditCard
@@ -465,7 +465,7 @@ public class CommunicationsManagerTest {
 					new HashSet<Account.Type>(Arrays.asList(Account.Type.PHONE, Account.Type.EMAIL)));
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(4, accountDeviceInstances.size());
+			assertEquals(3, accountDeviceInstances.size());
 		}
 
 		// Test Device & AccountType filter - DS2 or DS1 & EMAIL
@@ -485,7 +485,7 @@ public class CommunicationsManagerTest {
 					new HashSet<Account.Type>(Arrays.asList(Account.Type.PHONE)));
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(6, accountDeviceInstances.size());
+			assertEquals(5, accountDeviceInstances.size());
 		}
 
 		// Test Device & AccountType filter - DS2 or DS1 & Phone or Email
@@ -495,18 +495,10 @@ public class CommunicationsManagerTest {
 					new HashSet<Account.Type>(Arrays.asList(Account.Type.PHONE, Account.Type.EMAIL)));
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(9, accountDeviceInstances.size());
+			assertEquals(8, accountDeviceInstances.size());
 		}
 
-		// Test Device & AccountType filter - DS1 or DS2 & Phone or Email
-		{
-			CommunicationsFilter commsFilter = buildCommsFilter(
-					new HashSet<String>(Arrays.asList(DS1_DEVICEID, DS2_DEVICEID)),
-					new HashSet<Account.Type>(Arrays.asList(Account.Type.PHONE, Account.Type.EMAIL)));
-
-			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(9, accountDeviceInstances.size());
-		}
+		
 
 		// Test Device & AccountType filter - DS1 or DS2 or DS3 & Phone or Email, Date Range: communications on or BEFORE Dec 31, 2016
 		{
@@ -520,7 +512,6 @@ public class CommunicationsManagerTest {
 			assertEquals(0, accountDeviceInstances.size());
 		}
 
-		
 		// Test Device & AccountType filter - DS1 or DS2 or DS3 & Phone or Email, Date Range: communications on or After Jul 1, 2017
 		{
 			CommunicationsFilter commsFilter = buildCommsFilter(
@@ -530,12 +521,11 @@ public class CommunicationsManagerTest {
 					JUL_1_2017, 0);
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			
+
 			// TBD EUR-884: we expect 4 account device instances here but get 5. Phone 3/DS2 is returned even though it has a Contact entry and no coummincations,
-			assertEquals(5, accountDeviceInstances.size());
+			assertEquals(4, accountDeviceInstances.size());
 		}
-		
-		
+
 		// Test Device & AccountType filter - DS1 or DS2 or DS3 & Phone or Email
 		{
 			CommunicationsFilter commsFilter = buildCommsFilter(
@@ -543,10 +533,9 @@ public class CommunicationsManagerTest {
 					new HashSet<Account.Type>(Arrays.asList(Account.Type.PHONE, Account.Type.EMAIL)));
 
 			List<AccountDeviceInstance> accountDeviceInstances = commsMgr.getAccountDeviceInstancesWithCommunications(commsFilter);
-			assertEquals(9, accountDeviceInstances.size());
+			assertEquals(8, accountDeviceInstances.size());
 		}
-		
-		
+
 	}
 
 	@Test
@@ -807,7 +796,6 @@ public class CommunicationsManagerTest {
 			assertEquals(3, communications.size());
 		}
 
-		
 		// Communications for Email Account A/DS1 B/DS1 & C/DS1: Filter on messages  on or before Jan 1, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -818,15 +806,14 @@ public class CommunicationsManagerTest {
 
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
-					null, 
 					null,
-					0, JAN_1_2017 );
+					null,
+					0, JAN_1_2017);
 
-			
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(1, communications.size());
 		}
-		
+
 		// Communications for Email Account A/DS1 B/DS1 & C/DS1: Filter on messages on or after Jan 1, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -837,14 +824,14 @@ public class CommunicationsManagerTest {
 
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
-					null, 
+					null,
 					null,
 					JAN_1_2017, 0);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(3, communications.size());
 		}
-		
+
 		// Communications for Email Account A/DS1 B/DS1 & C/DS1: Filter on messages on or before Mar 1, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -855,14 +842,14 @@ public class CommunicationsManagerTest {
 
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
-					null, 
+					null,
 					null,
 					0, MAR_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(2, communications.size());
 		}
-		
+
 		// Communications for Email Account A/DS1 B/DS1 & C/DS1: Filter on messages on or before Jul 1, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -873,14 +860,14 @@ public class CommunicationsManagerTest {
 
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
-					null, 
+					null,
 					null,
 					0, JUL_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(3, communications.size());
 		}
-		
+
 		// Communications for Email Account A/DS1 B/DS1 & C/DS1: Filter on messages between  Feb 1, 2017 & Aug 01 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -891,14 +878,14 @@ public class CommunicationsManagerTest {
 
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
-					null, 
+					null,
 					null,
 					FEB_1_2017, AUG_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(2, communications.size());
 		}
-		
+
 		// Communications for Email Account A/DS1 B/DS1 & C/DS1: Filter on messages on or After  Jul 1, 2017 
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -909,15 +896,14 @@ public class CommunicationsManagerTest {
 
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
-					null, 
+					null,
 					null,
 					JUL_1_2017, 0);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(1, communications.size());
 		}
-		
-		
+
 		// Communications for Phone 1/DS2: No Filters
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -937,7 +923,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(1, communications.size());
@@ -952,7 +938,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CONTACT)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CONTACT));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(0, communications.size());
@@ -967,7 +953,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(0, communications.size());
@@ -982,7 +968,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(2, communications.size());
@@ -997,7 +983,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE, BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE, BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(3, communications.size());
@@ -1013,7 +999,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE, BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE, BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(5, communications.size());
@@ -1048,7 +1034,7 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(3, communications.size());
@@ -1086,7 +1072,8 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)));
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE));
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(6, communications.size());
@@ -1105,13 +1092,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					0, JAN_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(2, communications.size());
 		}
-		
+
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, on or after Jan 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1125,13 +1113,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					JAN_1_2017, 0);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(6, communications.size());
 		}
-		
+
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, on or before Mar 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1145,13 +1134,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					0, MAR_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(4, communications.size());
 		}
-		
+
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, on or after Mar 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1165,14 +1155,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					MAR_1_2017, 0);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(4, communications.size());
 		}
 
-		
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, on or after Mar 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1186,13 +1176,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					MAR_1_2017, 0);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(4, communications.size());
 		}
-		
+
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, on or before Jul 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1206,13 +1197,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					0, JUL_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(6, communications.size());
 		}
-		
+
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, on or after Jul 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1226,13 +1218,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					JUL_1_2017, 0);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(2, communications.size());
 		}
-		
+
 		// Communications for Phone 1/DS2 2/DS2 3/DS2 4/DS2 & 5/DS2: Filter on Calllogs, Messages, between Feb 01 2017, and Aug 01, 2017
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1246,13 +1239,14 @@ public class CommunicationsManagerTest {
 			CommunicationsFilter commsFilter = buildCommsFilter(
 					null,
 					null,
-					new HashSet<BlackboardArtifact.ARTIFACT_TYPE>(Arrays.asList(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG, BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE)),
+					EnumSet.of(BlackboardArtifact.ARTIFACT_TYPE.TSK_CALLLOG,
+							BlackboardArtifact.ARTIFACT_TYPE.TSK_MESSAGE),
 					FEB_1_2017, AUG_1_2017);
 
 			Set<BlackboardArtifact> communications = commsMgr.getCommunications(accountDeviceInstanceList, commsFilter);
 			assertEquals(4, communications.size());
 		}
-		
+
 		// Communications for Email A/DS1, Phone 1/DS2  2/DS1: No Filters
 		{
 			Set<AccountDeviceInstance> accountDeviceInstanceList = new HashSet<AccountDeviceInstance>(Arrays.asList(
@@ -1270,7 +1264,7 @@ public class CommunicationsManagerTest {
 	/**
 	 * Builds CommunicationsFilter
 	 *
-	 * @param deviceSet - set of device ids for DeviceFilter
+	 * @param deviceSet      - set of device ids for DeviceFilter
 	 * @param accountTypeSet - set of account types for AccountTypefilter
 	 *
 	 * @return
@@ -1283,25 +1277,26 @@ public class CommunicationsManagerTest {
 	/**
 	 * Builds CommunicationsFilter.
 	 *
-	 * @param deviceSet - set of device ids for DeviceFilter
-	 * @param accountTypeSet - set of account types for AccountTypefilter
-	 * @param relationshipTypeSet - set of blackboard artifact types for relationship filters
+	 * @param deviceSet           - set of device ids for DeviceFilter
+	 * @param accountTypeSet      - set of account types for AccountTypefilter
+	 * @param relationshipTypeSet - set of blackboard artifact types for
+	 *                            relationship filters
 	 *
 	 * @return
 	 */
-	
 	private static CommunicationsFilter buildCommsFilter(Set<String> deviceSet, Set<Account.Type> accountTypeSet, Set<BlackboardArtifact.ARTIFACT_TYPE> relationshipTypeSet) {
 		return buildCommsFilter(deviceSet, accountTypeSet, relationshipTypeSet, 0, 0);
 	}
-	
+
 	/**
 	 * Builds CommunicationsFilter.
 	 *
-	 * @param deviceSet - set of device ids for DeviceFilter
-	 * @param accountTypeSet - set of account types for AccountTypefilter
-	 * @param relationshipTypeSet - set of blackboard artifact types for relationship filters
-	 * @param startDate - start date for DateRangeFilter
-	 * @param endDate - end date for DateRangeFilter
+	 * @param deviceSet           - set of device ids for DeviceFilter
+	 * @param accountTypeSet      - set of account types for AccountTypefilter
+	 * @param relationshipTypeSet - set of blackboard artifact types for
+	 *                            relationship filters
+	 * @param startDate           - start date for DateRangeFilter
+	 * @param endDate             - end date for DateRangeFilter
 	 *
 	 * @return
 	 */
@@ -1321,10 +1316,10 @@ public class CommunicationsManagerTest {
 		if (null != relationshipTypeSet) {
 			commsFilter.addAndFilter(new RelationshipTypeFilter(relationshipTypeSet));
 		}
-		if ( (0 != startDate) || (0 != endDate) ) {
+		if ((0 != startDate) || (0 != endDate)) {
 			commsFilter.addAndFilter(new DateRangeFilter(startDate, endDate));
 		}
-		
+
 		return commsFilter;
 	}
 

--- a/tsk/auto/db_postgresql.cpp
+++ b/tsk/auto/db_postgresql.cpp
@@ -622,7 +622,7 @@ int TskDbPostgreSQL::initialize() {
 		"Error creating account_types table: %s\n")     
 		||
 		attempt_exec
-		("CREATE TABLE relationships  (relationship_id BIGSERIAL PRIMARY KEY, account1_id INTEGER NOT NULL, account2_id INTEGER NOT NULL, relationship_source_obj_id INTEGER NOT NULL, date_time BIGINT NOT NULL, relationship_type INTEGER NOT NULL, data_source_obj_id INTEGER NOT NULL, UNIQUE(account1_id, account2_id, relationship_source_obj_id) ON CONFLICT IGNORE, FOREIGN KEY(account1_id) REFERENCES accounts(account_id), FOREIGN KEY(account2_id) REFERENCES accounts(account_id), FOREIGN KEY(relationship_source_obj_id) REFERENCES tsk_objects(obj_id), FOREIGN KEY(data_source_obj_id) REFERENCES tsk_objects(obj_id))",
+		("CREATE TABLE account_relationships  (relationship_id BIGSERIAL PRIMARY KEY, account1_id INTEGER NOT NULL, account2_id INTEGER NOT NULL, relationship_source_obj_id INTEGER NOT NULL, date_time BIGINT NOT NULL, relationship_type INTEGER NOT NULL, data_source_obj_id INTEGER NOT NULL, UNIQUE(account1_id, account2_id, relationship_source_obj_id) ON CONFLICT IGNORE, FOREIGN KEY(account1_id) REFERENCES accounts(account_id), FOREIGN KEY(account2_id) REFERENCES accounts(account_id), FOREIGN KEY(relationship_source_obj_id) REFERENCES tsk_objects(obj_id), FOREIGN KEY(data_source_obj_id) REFERENCES tsk_objects(obj_id))",
 			"Error creating relationships table: %s\n")
 		||
 		attempt_exec
@@ -673,18 +673,18 @@ int TskDbPostgreSQL::createIndexes() {
 			"Error creating mime_type index on tsk_files: %s\n") ||
 		attempt_exec("CREATE INDEX file_extension ON tsk_files(extension);",  //file extenssion
 			"Error creating file_extension index on tsk_files: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_account1  ON relationships(account1_id);",
-			"Error creating relationships_account1 index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_account2  ON relationships(account2_id);",
-			"Error creating relationships_account2 index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_relationship_source_obj_id  ON relationships(relationship_source_obj_id);",
-			"Error creating relationships_relationship_source_obj_id index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_date_time  ON relationships(date_time);",
-			"Error creating relationships_date_time index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_relationship_type ON relationships(relationship_type);",
-			"Error creating relationships_relationship_type index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_data_source_obj_id  ON relationships(data_source_obj_id);",
-			"Error creating relationships_data_source_obj_id index on relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_account1  ON account_relationships(account1_id);",
+			"Error creating relationships_account1 index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_account2  ON account_relationships(account2_id);",
+			"Error creating relationships_account2 index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_relationship_source_obj_id  ON account_relationships(relationship_source_obj_id);",
+			"Error creating relationships_relationship_source_obj_id index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_date_time  ON account_relationships(date_time);",
+			"Error creating relationships_date_time index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_relationship_type ON account_relationships(relationship_type);",
+			"Error creating relationships_relationship_type index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_data_source_obj_id  ON account_relationships(data_source_obj_id);",
+			"Error creating relationships_data_source_obj_id index on account_relationships: %s\n") ||
 		attempt_exec("CREATE INDEX accounts_map_account_id  ON account_to_instances_map(account_id);",
 			"Error creating accounts_map_account_id index on account_to_instances_map: %s\n") ||
 		attempt_exec("CREATE INDEX accounts_map_account_instance_id  ON account_to_instances_map(account_instance_id);",

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -371,7 +371,7 @@ int
 			"Error creating account_types table: %s\n")
 		||
 		attempt_exec
-		("CREATE TABLE relationships (relationship_id INTEGER PRIMARY KEY, account1_id INTEGER NOT NULL, account2_id INTEGER NOT NULL, relationship_source_obj_id INTEGER NOT NULL,  date_time INTEGER NOT NULL, relationship_type INTEGER NOT NULL, data_source_obj_id INTEGER NOT NULL, UNIQUE(account1_id, account2_id, relationship_source_obj_id) ON CONFLICT IGNORE, FOREIGN KEY(account1_id) REFERENCES accounts(account_id), FOREIGN KEY(account2_id) REFERENCES accounts(account_id), FOREIGN KEY(relationship_source_obj_id) REFERENCES tsk_objects(obj_id), FOREIGN KEY(data_source_obj_id) REFERENCES tsk_objects(obj_id))",
+		("CREATE TABLE account_relationships (relationship_id INTEGER PRIMARY KEY, account1_id INTEGER NOT NULL, account2_id INTEGER NOT NULL, relationship_source_obj_id INTEGER NOT NULL,  date_time INTEGER NOT NULL, relationship_type INTEGER NOT NULL, data_source_obj_id INTEGER NOT NULL, UNIQUE(account1_id, account2_id, relationship_source_obj_id) ON CONFLICT IGNORE, FOREIGN KEY(account1_id) REFERENCES accounts(account_id), FOREIGN KEY(account2_id) REFERENCES accounts(account_id), FOREIGN KEY(relationship_source_obj_id) REFERENCES tsk_objects(obj_id), FOREIGN KEY(data_source_obj_id) REFERENCES tsk_objects(obj_id))",
 			"Error creating relationships table: %s\n")
 		||
 		attempt_exec
@@ -423,18 +423,18 @@ int TskDbSqlite::createIndexes() {
 			"Error creating mime_type index on tsk_files: %s\n") ||
 		attempt_exec("CREATE INDEX file_extension ON tsk_files(extension);",  //file extenssion
 			"Error creating file_extension index on tsk_files: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_account1  ON relationships(account1_id);", 
-			"Error creating relationships_account1 index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_account2  ON relationships(account2_id);",
-			"Error creating relationships_account2 index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_relationship_source_obj_id  ON relationships(relationship_source_obj_id);",
-			"Error creating relationships_relationship_source_obj_id index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_date_time  ON relationships(date_time);",
-			"Error creating relationships_date_time index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_relationship_type  ON relationships(relationship_type);",
-			"Error creating relationships_relationship_type index on relationships: %s\n") ||
-		attempt_exec("CREATE INDEX relationships_data_source_obj_id  ON relationships(data_source_obj_id);",
-			"Error creating relationships_data_source_obj_id index on relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_account1  ON account_relationships(account1_id);", 
+			"Error creating relationships_account1 index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_account2  ON account_relationships(account2_id);",
+			"Error creating relationships_account2 index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_relationship_source_obj_id  ON account_relationships(relationship_source_obj_id);",
+			"Error creating relationships_relationship_source_obj_id index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_date_time  ON account_relationships(date_time);",
+			"Error creating relationships_date_time index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_relationship_type  ON account_relationships(relationship_type);",
+			"Error creating relationships_relationship_type index on account_relationships: %s\n") ||
+		attempt_exec("CREATE INDEX relationships_data_source_obj_id  ON account_relationships(data_source_obj_id);",
+			"Error creating relationships_data_source_obj_id index on account_relationships: %s\n") ||
 		attempt_exec("CREATE INDEX accounts_map_account_id  ON account_to_instances_map(account_id);",
 			"Error creating accounts_map_account_id index on account_to_instances_map: %s\n") ||
 		attempt_exec("CREATE INDEX accounts_map_account_instance_id  ON account_to_instances_map(account_instance_id);",


### PR DESCRIPTION
refactored getAccountDeviceInstancesWithCommunications to use relationship.data_source_obj_id and to eliminate joins against the artifacts and account_to_instances_map tables.

updated unit tests after manual analysis of expected results.  

I also updated the relationship table name in this PR rather than doing another that will almost certainly have merge conflicts