### PR TITLE
Update tsk_img.h

### DIFF
--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -72,7 +72,7 @@ extern "C" {
         TSK_IMG_TYPE_UNSUPP = 0xffff,   ///< Unsupported disk image type
     } TSK_IMG_TYPE_ENUM;
 
-#define TSK_IMG_INFO_CACHE_NUM  4
+#define TSK_IMG_INFO_CACHE_NUM  32
 #define TSK_IMG_INFO_CACHE_LEN  65536
 
     typedef struct TSK_IMG_INFO TSK_IMG_INFO;


### PR DESCRIPTION
Use more number of cache blocks in image layer. Useful when there are a large number of readers, such as with many ingest threads in Autopsy. 