### PR TITLE
Fix libewf V2 API support

### DIFF
--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -67,7 +67,7 @@ ewf_image_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf,
 
     tsk_take_lock(&(ewf_info->read_lock));
 #if defined( HAVE_LIBEWF_V2_API )
-    cnt = libewf_handle_read_random(ewf_info->handle,
+    cnt = libewf_handle_read_buffer_at_offset(ewf_info->handle,
         buf, len, offset, &ewf_error);
     if (cnt < 0) {
         char *errmsg = NULL;

--- a/tsk/img/ewf.h
+++ b/tsk/img/ewf.h
@@ -21,9 +21,9 @@
 #include <libewf.h>
 #include <string>
 
-// libewf version 2 no longer defines LIBEWF_HANDLE
+// libewf version 2 no longer defines LIBEWF_OPEN_READ_WRITE
 #undef HAVE_LIBEWF_V2_API
-#if !defined( LIBEWF_HANDLE )
+#if !defined( LIBEWF_OPEN_READ_WRITE )
 #define HAVE_LIBEWF_V2_API
 #endif
 


### PR DESCRIPTION
The deprecated function `libewf_handle_read_random` was removed in libyal/libewf@54f8d8ffb67ea3808336204d5a072db358066ec5, but at that
point it was just a wrapper for `libewf_handle_read_buffer_at_offset`.[1]

Solution: Replace deprecated libewf_handle_read_random call with the
recommended[2] replacement.

Also replace the the method detecting the presence of the V1 API. While I was unable to get `libewf-20160608` itself to compile anymore, I did confirm the presence of the `LIBEWF_OPEN_READ_WRITE` in the old source[3], and its absence in the new source.

References:

1. https://github.com/libyal/libewf/commit/54f8d8ffb67ea3808336204d5a072db358066ec5#diff-b9e76700775f6f9aa3efde388cb3bba9L74
2. https://github.com/libyal/libewf/commit/54f8d8ffb67ea3808336204d5a072db358066ec5#diff-fedcd7a7973ead791242e3a6d86e1a15L802
3. https://github.com/libyal/legacy/blob/master/libewf/libewf-20140608.tar.gz

Closes #642 
Closes #780  