### PR TITLE
Additional bounds check for HFS+ attr names

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -4066,8 +4066,15 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
                 nameLength = tsk_getu16(endian, keyB->attr_name_len);
                 if (2*nameLength > HFS_MAX_ATTR_NAME_LEN_UTF16_B) {
                     error_detected(TSK_ERR_FS_CORRUPT,
-                        "hfs_load_extended_attrs: Name length (%d) is too long.",
-                        nameLength);
+                        "hfs_load_extended_attrs: Name length in bytes (%d) > max name length in bytes (%d).",
+                        2*nameLength, HFS_MAX_ATTR_NAME_LEN_UTF16_B);
+                    goto on_error;
+                }
+
+                if (2*nameLength > keyLength - 12) {
+                    error_detected(TSK_ERR_FS_CORRUPT,
+                        "hfs_load_extended_attrs: Name length in bytes (%d) > remaining struct length (%d).",
+                        2*nameLength, keyLength - 12);
                     goto on_error;
                 }
 


### PR DESCRIPTION
* Added bounds check for HFS+ attr names. Attr name length should not exceed the remaining space in the attr struct.
* Improved error messages for both attr name length checks, to show the values which caused the failed check.

This addresses the remaining problem in Issue #1080.