### PR TITLE
Fix bad return value when reading block devices on Windows

### DIFF
--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -162,6 +162,13 @@ raw_read_segment(IMG_RAW_INFO * raw_info, int idx, char *buf,
                 lastError);
             return -1;
         }
+        // When the read operation reaches the end of a file,
+        // ReadFile returns TRUE and sets nread to zero.
+        // We need to check if we've reached the end of a file and set nread to
+        // the number of bytes read.
+        if ((raw_info->is_winobj) && (nread == 0) && (rel_offset + len == raw_info->img_info.size)) {
+          nread = len;
+        }
         cnt = (ssize_t) nread;
 
         if (raw_info->img_writer != NULL) {


### PR DESCRIPTION
 Win32 `ReadFile` doesn't set the number of bytes read at the end of the file, so make sure it gets set.