### PR TITLE
Fix several NTFS decompression bugs

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -869,7 +869,7 @@ static uint8_t
 ntfs_uncompress_compunit(NTFS_COMP_INFO * comp)
 {
     size_t cl_index;
-    uint8_t recover_data = 0;
+    uint8_t recover_data = 0; // set to 1 when we proceed even with potentially corrupt data
 
     tsk_error_reset();
 

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1640,7 +1640,7 @@ ntfs_file_read_special(const TSK_FS_ATTR * a_fs_attr,
                             return -1;
                         }
                         // handle the initialized size
-                        int64_t remanining_init_size = a_fs_attr->nrd.initsize - buf_idx;
+                        int64_t remanining_init_size = a_fs_attr->nrd.initsize - buf_idx - a_offset;
                         if (remanining_init_size < comp.buf_size_b) {
                             memset(comp.uncomp_buf + remanining_init_size, 0, comp.buf_size_b - remanining_init_size);
                             init_size_reached = 1;

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1251,6 +1251,7 @@ ntfs_attr_walk_special(const TSK_FS_ATTR * fs_attr,
         TSK_OFF_T off = 0;
         int retval;
         uint8_t stop_loop = 0;
+        uint8_t init_size_reached = 0;
 
         if (fs_attr->nrd.compsize <= 0) {
             tsk_error_set_errno(TSK_ERR_FS_FWALK);
@@ -1366,18 +1367,29 @@ ntfs_attr_walk_special(const TSK_FS_ATTR * fs_attr,
                     size_t i;
 
                     // decompress the unit
-                    if (ntfs_proc_compunit(ntfs, &comp, comp_unit,
+                    uint8_t reset_uncompress_for_init_size = 0;
+                    if (!init_size_reached) {
+                        if (ntfs_proc_compunit(ntfs, &comp, comp_unit,
                             comp_unit_idx)) {
-                        tsk_error_set_errstr2("%" PRIuINUM " - type: %"
-                            PRIu32 "  id: %d Status: %s",
-                            fs_attr->fs_file->meta->addr, fs_attr->type,
-                            fs_attr->id,
-                            (fs_attr->fs_file->meta->
-                                flags & TSK_FS_META_FLAG_ALLOC) ?
-                            "Allocated" : "Deleted");
-                        free(comp_unit);
-                        ntfs_uncompress_done(&comp);
-                        return 1;
+                            tsk_error_set_errstr2("%" PRIuINUM " - type: %"
+                                PRIu32 "  id: %d Status: %s",
+                                fs_attr->fs_file->meta->addr, fs_attr->type,
+                                fs_attr->id,
+                                (fs_attr->fs_file->meta->
+                                    flags & TSK_FS_META_FLAG_ALLOC) ?
+                                "Allocated" : "Deleted");
+                            free(comp_unit);
+                            ntfs_uncompress_done(&comp);
+                            return 1;
+                        }
+
+                        // handle the initialized size
+                        int64_t remanining_init_size = fs_attr->nrd.initsize - off;
+                        if (remanining_init_size < comp.buf_size_b) {
+                            memset(comp.uncomp_buf + remanining_init_size, 0, comp.buf_size_b - remanining_init_size);
+                            init_size_reached = 1;
+                            reset_uncompress_for_init_size = 1;
+                        }               
                     }
 
                     // now call the callback with the uncompressed data
@@ -1445,6 +1457,11 @@ ntfs_attr_walk_special(const TSK_FS_ATTR * fs_attr,
                         }
                     }
                     comp_unit_idx = 0;
+
+                    if (reset_uncompress_for_init_size) { // clear out stale data in the buffers for further callbacks and set up for reading 0's
+                        ntfs_uncompress_reset(&comp);
+                        comp.uncomp_idx = comp.buf_size_b;
+                    }
                 }
 
                 if (stop_loop)


### PR DESCRIPTION
This patch fixes decompression errors in NTFS compressed files that have an initialized size which differs from the logical size, and also allows decompression of an NTFS compressed file to continue in the event that a corrupted compression unit is encountered. 