### PR TITLE
Ignore VS2015 temporary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ win32/BuildErrors.txt
 win32/BuildErrors-64bit.txt
 win32/.vs
 win32/tsk-win.VC.VC.opendb
+win32/tsk-win.VC.opendb
 win32/tsk-win.VC.db
 framework/msvcpp/framework/Debug/
 framework/msvcpp/framework/Release/


### PR DESCRIPTION
Ignore temporary directory for Visual Studio 2015.
Reference for such meta info: https://github.com/github/gitignore/blob/master/VisualStudio.gitignore