### PR TITLE
code review (UTF32)

### DIFF
--- a/tsk/base/tsk_base_i.h
+++ b/tsk/base/tsk_base_i.h
@@ -28,7 +28,6 @@
 // most of the local files need this, so we include it here
 #include <string.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -294,10 +293,10 @@ extern "C" {
     bit mask & shift operations.
 ------------------------------------------------------------------------ */
 
-
-    typedef unsigned short UTF16;       /* at least 16 bits */
-    typedef unsigned char UTF8; /* typically 8 bits */
-    typedef unsigned char Boolean;      /* 0 or 1 */
+	typedef uint32_t UTF32;       /* typically 32 bits */
+    typedef uint16_t UTF16;       /* typically 16 bits */
+    typedef uint8_t UTF8; /* typically 8 bits */
+    typedef uint8_t Boolean;      /* 0 or 1 */
 
 
     typedef enum {
@@ -311,7 +310,11 @@ extern "C" {
         TSKstrictConversion = 0,        ///< Error if invalid surrogate pairs are found
         TSKlenientConversion    ///< Ignore invalid surrogate pairs
     } TSKConversionFlags;
-
+	
+    extern TSKConversionResult tsk_UTF8toUTF32 (
+        const UTF8** sourceStart, const UTF8* sourceEnd,
+        UTF32** targetStart, UTF32* targetEnd, TSKConversionFlags flags);
+		
     extern TSKConversionResult tsk_UTF8toUTF16(const UTF8 ** sourceStart,
         const UTF8 * sourceEnd,
         UTF16 ** targetStart, UTF16 * targetEnd, TSKConversionFlags flags);

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -45,7 +45,6 @@
 #include "tsk_base_i.h"
 
 /* Some fundamental constants */
-typedef unsigned long UTF32;    /* at least 32 bits */
 #define TSK_UNI_REPLACEMENT_CHAR (UTF32)0x0000FFFD
 #define TSK_UNI_MAX_BMP (UTF32)0x0000FFFF
 #define TSK_UNI_MAX_UTF16 (UTF32)0x0010FFFF
@@ -672,3 +671,62 @@ tsk_UTF8toUTF16(const UTF8 ** sourceStart,
     return result;
 }
 
+TSKConversionResult tsk_UTF8toUTF32 (
+        const UTF8** sourceStart, const UTF8* sourceEnd,
+        UTF32** targetStart, UTF32* targetEnd, TSKConversionFlags flags) {
+    TSKConversionResult result = TSKconversionOK;
+    const UTF8* source = *sourceStart;
+    UTF32* target = *targetStart;
+    while (source < sourceEnd) {
+        UTF32 ch = 0;
+        unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+        if (source + extraBytesToRead >= sourceEnd) {
+            result = TSKsourceExhausted; break;
+        }
+        /* Do this check whether lenient or strict */
+        if (! isLegalUTF8(source, extraBytesToRead+1)) {
+            result = TSKsourceIllegal;
+            break;
+        }
+        /*
+         * The cases all fall through. See "Note A" below.
+         */
+        switch (extraBytesToRead) {
+            case 5: ch += *source++; ch <<= 6;
+            case 4: ch += *source++; ch <<= 6;
+            case 3: ch += *source++; ch <<= 6;
+            case 2: ch += *source++; ch <<= 6;
+            case 1: ch += *source++; ch <<= 6;
+            case 0: ch += *source++;
+        }
+        ch -= offsetsFromUTF8[extraBytesToRead];
+
+        if (target >= targetEnd) {
+            source -= (extraBytesToRead+1); /* Back up the source pointer! */
+            result = TSKtargetExhausted; break;
+        }
+        if (ch <= TSK_UNI_MAX_LEGAL_UTF32) {
+            /*
+             * UTF-16 surrogate values are illegal in UTF-32, and anything
+             * over Plane 17 (> 0x10FFFF) is illegal.
+             */
+            if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+                if (flags == TSKstrictConversion) {
+                    source -= (extraBytesToRead+1); /* return to the illegal value itself */
+                    result = TSKsourceIllegal;
+                    break;
+                } else {
+                    *target++ = TSK_UNI_REPLACEMENT_CHAR;
+                }
+            } else {
+                *target++ = ch;
+            }
+        } else { /* i.e., ch > TSK_UNI_MAX_LEGAL_UTF32 */
+            result = TSKsourceIllegal;
+            *target++ = TSK_UNI_REPLACEMENT_CHAR;
+        }
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}


### PR DESCRIPTION
1. UTF32 was defined as unsigned long.sizeof(unsigned long) is 8bytes on 64bit linux(tested on Ubuntu17.10 with gcc7.2) while 4bytes on other cases.unexpacted behaviour may occurred if put self-increase operation on UTF32 pointer.I suggest define UTF32 as uint32_t becasue it has fixed size in any case.  
2. add tsk_UTF8toUTF32 function.