### PR TITLE
Add SPDX short identifiers

### DIFF
--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** dataModel_SleuthkitJNI
  ** The Sleuth Kit 

--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractContent.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractContent.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AbstractFile.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Account.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Account.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/AccountDeviceInstance.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AccountDeviceInstance.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/AccountFileInstance.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AccountFileInstance.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/AccountPair.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/AccountPair.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifactTag.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifactTag.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardAttribute.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardAttribute.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CarvedFileContainer.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CarvedFileContainer.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CarvingResult.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CarvingResult.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDbConnectionInfo.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDbConnectionInfo.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDbSchemaVersionNumber.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDbSchemaVersionNumber.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CollectionUtils.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CollectionUtils.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CommunicationsFilter.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CommunicationsFilter.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/CommunicationsManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CommunicationsManager.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Content.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Content.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/ContentTag.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ContentTag.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/ContentVisitor.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ContentVisitor.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DerivedFile.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Directory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Directory.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/EncodedFileOutputStream.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/EncodedFileOutputStream.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/EncodedFileUtil.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/EncodedFileUtil.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/Examples/Sample.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Examples/Sample.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/File.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/File.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/FileSystem.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FileSystem.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FsContent.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/HashEntry.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HashEntry.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/HashHitInfo.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HashHitInfo.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/HashUtility.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HashUtility.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Image.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Image.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/IngestJobInfo.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/IngestJobInfo.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/IngestModuleInfo.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/IngestModuleInfo.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LayoutFile.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/LibraryUtils.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LibraryUtils.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalDirectory.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFile.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/MessageFolder.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/MessageFolder.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/OSInfo.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OSInfo.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/OSUtility.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OSUtility.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/ReadContentInputStream.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ReadContentInputStream.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Relationship.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Relationship.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Report.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Report.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/SlackFile.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SlackFile.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitItemVisitor.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitItemVisitor.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitVisitableItem.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitVisitableItem.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/SpecialDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SpecialDirectory.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/StringUtils.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/StringUtils.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Tag.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Tag.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/TagName.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TagName.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/TimeUtilities.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TimeUtilities.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/Transaction.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Transaction.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/TskCoreException.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskCoreException.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/TskData.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskData.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/TskDataException.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskDataException.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/TskException.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskException.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/TskFileRange.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskFileRange.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/TskUnsupportedSchemaVersionException.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskUnsupportedSchemaVersionException.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/VersionNumber.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VersionNumber.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VirtualDirectory.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * SleuthKit Java Bindings
  *

--- a/bindings/java/src/org/sleuthkit/datamodel/Volume.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Volume.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  * 

--- a/bindings/java/src/org/sleuthkit/datamodel/VolumeSystem.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/VolumeSystem.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Autopsy Forensic Browser
  * 

--- a/bindings/java/test/org/sleuthkit/datamodel/BottomUpTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BottomUpTest.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/CPPtoJavaCompare.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CPPtoJavaCompare.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/CaseDbSchemaVersionNumberTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CaseDbSchemaVersionNumberTest.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/CommunicationsManagerTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CommunicationsManagerTest.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/CrossCompare.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CrossCompare.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/HashDbTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/HashDbTest.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/ImgTraverser.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/ImgTraverser.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/SequentialTraversal.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/SequentialTraversal.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/bindings/java/test/org/sleuthkit/datamodel/TopDownTraversal.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/TopDownTraversal.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * Sleuth Kit Data Model
  *

--- a/framework/modules/c_FileTypeSigModule/FileTypeModule.cpp
+++ b/framework/modules/c_FileTypeSigModule/FileTypeModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_HashCalcModule/HashCalcModule.cpp
+++ b/framework/modules/c_HashCalcModule/HashCalcModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_InterestingFilesModule/InterestingFilesModule.cpp
+++ b/framework/modules/c_InterestingFilesModule/InterestingFilesModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_LibExifModule/LibExifModule.cpp
+++ b/framework/modules/c_LibExifModule/LibExifModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_RegRipperModule/RegRipperModule.cpp
+++ b/framework/modules/c_RegRipperModule/RegRipperModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_SaveInterestingFilesModule/SaveInterestingFilesModule.cpp
+++ b/framework/modules/c_SaveInterestingFilesModule/SaveInterestingFilesModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_SummaryReportModule/SummaryReport.cpp
+++ b/framework/modules/c_SummaryReportModule/SummaryReport.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_SummaryReportModule/SummaryReport.h
+++ b/framework/modules/c_SummaryReportModule/SummaryReport.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_SummaryReportModule/SummaryReportModule.cpp
+++ b/framework/modules/c_SummaryReportModule/SummaryReportModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_TskHashLookupModule/TskHashLookupModule.cpp
+++ b/framework/modules/c_TskHashLookupModule/TskHashLookupModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/modules/c_ZIPExtractionModule/ZipExtractionModule.cpp
+++ b/framework/modules/c_ZIPExtractionModule/ZipExtractionModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tools/tsk_analyzeimg/tsk_analyzeimg.cpp
+++ b/framework/tools/tsk_analyzeimg/tsk_analyzeimg.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 *
 *  The Sleuth Kit

--- a/framework/tools/tsk_validatepipeline/tsk_validatepipeline.cpp
+++ b/framework/tools/tsk_validatepipeline/tsk_validatepipeline.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 *
 *  The Sleuth Kit

--- a/framework/tsk/framework/TskVersionInfo.h
+++ b/framework/tsk/framework/TskVersionInfo.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/CarveExtract.h
+++ b/framework/tsk/framework/extraction/CarveExtract.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/CarvePrep.h
+++ b/framework/tsk/framework/extraction/CarvePrep.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskAutoImpl.cpp
+++ b/framework/tsk/framework/extraction/TskAutoImpl.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskAutoImpl.h
+++ b/framework/tsk/framework/extraction/TskAutoImpl.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskCarveExtractScalpel.cpp
+++ b/framework/tsk/framework/extraction/TskCarveExtractScalpel.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/extraction/TskCarveExtractScalpel.h
+++ b/framework/tsk/framework/extraction/TskCarveExtractScalpel.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskCarvePrepSectorConcat.cpp
+++ b/framework/tsk/framework/extraction/TskCarvePrepSectorConcat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskCarvePrepSectorConcat.h
+++ b/framework/tsk/framework/extraction/TskCarvePrepSectorConcat.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskExtract.cpp
+++ b/framework/tsk/framework/extraction/TskExtract.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskExtract.h
+++ b/framework/tsk/framework/extraction/TskExtract.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskImageFile.cpp
+++ b/framework/tsk/framework/extraction/TskImageFile.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/extraction/TskImageFile.h
+++ b/framework/tsk/framework/extraction/TskImageFile.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/extraction/TskImageFileTsk.cpp
+++ b/framework/tsk/framework/extraction/TskImageFileTsk.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/extraction/TskImageFileTsk.h
+++ b/framework/tsk/framework/extraction/TskImageFileTsk.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/extraction/TskL01Extract.cpp
+++ b/framework/tsk/framework/extraction/TskL01Extract.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/extraction/TskL01Extract.h
+++ b/framework/tsk/framework/extraction/TskL01Extract.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFile.cpp
+++ b/framework/tsk/framework/file/TskFile.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFile.h
+++ b/framework/tsk/framework/file/TskFile.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFileManager.h
+++ b/framework/tsk/framework/file/TskFileManager.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFileManagerImpl.cpp
+++ b/framework/tsk/framework/file/TskFileManagerImpl.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFileManagerImpl.h
+++ b/framework/tsk/framework/file/TskFileManagerImpl.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFileTsk.cpp
+++ b/framework/tsk/framework/file/TskFileTsk.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/file/TskFileTsk.h
+++ b/framework/tsk/framework/file/TskFileTsk.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/framework.h
+++ b/framework/tsk/framework/framework.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/framework_i.h
+++ b/framework/tsk/framework/framework_i.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskExecutableModule.cpp
+++ b/framework/tsk/framework/pipeline/TskExecutableModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/pipeline/TskExecutableModule.h
+++ b/framework/tsk/framework/pipeline/TskExecutableModule.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskFileAnalysisPipeline.cpp
+++ b/framework/tsk/framework/pipeline/TskFileAnalysisPipeline.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskFileAnalysisPipeline.h
+++ b/framework/tsk/framework/pipeline/TskFileAnalysisPipeline.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskFileAnalysisPluginModule.cpp
+++ b/framework/tsk/framework/pipeline/TskFileAnalysisPluginModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskFileAnalysisPluginModule.h
+++ b/framework/tsk/framework/pipeline/TskFileAnalysisPluginModule.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskModule.cpp
+++ b/framework/tsk/framework/pipeline/TskModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/pipeline/TskModule.h
+++ b/framework/tsk/framework/pipeline/TskModule.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskPipeline.cpp
+++ b/framework/tsk/framework/pipeline/TskPipeline.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskPipeline.h
+++ b/framework/tsk/framework/pipeline/TskPipeline.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskPipelineManager.cpp
+++ b/framework/tsk/framework/pipeline/TskPipelineManager.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskPipelineManager.h
+++ b/framework/tsk/framework/pipeline/TskPipelineManager.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskPluginModule.cpp
+++ b/framework/tsk/framework/pipeline/TskPluginModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskPluginModule.h
+++ b/framework/tsk/framework/pipeline/TskPluginModule.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskReportPipeline.cpp
+++ b/framework/tsk/framework/pipeline/TskReportPipeline.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskReportPipeline.h
+++ b/framework/tsk/framework/pipeline/TskReportPipeline.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskReportPluginModule.cpp
+++ b/framework/tsk/framework/pipeline/TskReportPluginModule.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/pipeline/TskReportPluginModule.h
+++ b/framework/tsk/framework/pipeline/TskReportPluginModule.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/Log.cpp
+++ b/framework/tsk/framework/services/Log.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/Log.h
+++ b/framework/tsk/framework/services/Log.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/Scheduler.cpp
+++ b/framework/tsk/framework/services/Scheduler.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/Scheduler.h
+++ b/framework/tsk/framework/services/Scheduler.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskBlackboard.cpp
+++ b/framework/tsk/framework/services/TskBlackboard.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/framework/tsk/framework/services/TskBlackboard.h
+++ b/framework/tsk/framework/services/TskBlackboard.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskBlackboardArtifact.cpp
+++ b/framework/tsk/framework/services/TskBlackboardArtifact.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/framework/tsk/framework/services/TskBlackboardArtifact.h
+++ b/framework/tsk/framework/services/TskBlackboardArtifact.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/framework/tsk/framework/services/TskBlackboardAttribute.cpp
+++ b/framework/tsk/framework/services/TskBlackboardAttribute.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/framework/tsk/framework/services/TskBlackboardAttribute.h
+++ b/framework/tsk/framework/services/TskBlackboardAttribute.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/framework/tsk/framework/services/TskDBBlackboard.cpp
+++ b/framework/tsk/framework/services/TskDBBlackboard.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskDBBlackboard.h
+++ b/framework/tsk/framework/services/TskDBBlackboard.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/framework/tsk/framework/services/TskImgDB.cpp
+++ b/framework/tsk/framework/services/TskImgDB.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskImgDB.h
+++ b/framework/tsk/framework/services/TskImgDB.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/services/TskImgDBPostgreSQL.cpp
+++ b/framework/tsk/framework/services/TskImgDBPostgreSQL.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/services/TskImgDBPostgreSQL.h
+++ b/framework/tsk/framework/services/TskImgDBPostgreSQL.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/services/TskImgDBSqlite.cpp
+++ b/framework/tsk/framework/services/TskImgDBSqlite.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/services/TskImgDBSqlite.h
+++ b/framework/tsk/framework/services/TskImgDBSqlite.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/services/TskSchedulerQueue.cpp
+++ b/framework/tsk/framework/services/TskSchedulerQueue.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskSchedulerQueue.h
+++ b/framework/tsk/framework/services/TskSchedulerQueue.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskServices.cpp
+++ b/framework/tsk/framework/services/TskServices.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskServices.h
+++ b/framework/tsk/framework/services/TskServices.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskSystemProperties.cpp
+++ b/framework/tsk/framework/services/TskSystemProperties.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *  The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskSystemProperties.h
+++ b/framework/tsk/framework/services/TskSystemProperties.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/services/TskSystemPropertiesImpl.cpp
+++ b/framework/tsk/framework/services/TskSystemPropertiesImpl.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/services/TskSystemPropertiesImpl.h
+++ b/framework/tsk/framework/services/TskSystemPropertiesImpl.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *  The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/SectorRuns.cpp
+++ b/framework/tsk/framework/utilities/SectorRuns.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/SectorRuns.h
+++ b/framework/tsk/framework/utilities/SectorRuns.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/TskException.cpp
+++ b/framework/tsk/framework/utilities/TskException.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/TskException.h
+++ b/framework/tsk/framework/utilities/TskException.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/TskModuleDev.h
+++ b/framework/tsk/framework/utilities/TskModuleDev.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/TskUtilities.cpp
+++ b/framework/tsk/framework/utilities/TskUtilities.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/utilities/TskUtilities.h
+++ b/framework/tsk/framework/utilities/TskUtilities.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/framework/tsk/framework/utilities/UnallocRun.cpp
+++ b/framework/tsk/framework/utilities/UnallocRun.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/framework/tsk/framework/utilities/UnallocRun.h
+++ b/framework/tsk/framework/utilities/UnallocRun.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/rejistry++/include/librejistry++.h
+++ b/rejistry++/include/librejistry++.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/BinaryBlock.cpp
+++ b/rejistry++/src/BinaryBlock.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/BinaryBlock.h
+++ b/rejistry++/src/BinaryBlock.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Buffer.cpp
+++ b/rejistry++/src/Buffer.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Buffer.h
+++ b/rejistry++/src/Buffer.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/ByteBuffer.cpp
+++ b/rejistry++/src/ByteBuffer.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/ByteBuffer.h
+++ b/rejistry++/src/ByteBuffer.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Cell.cpp
+++ b/rejistry++/src/Cell.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Cell.h
+++ b/rejistry++/src/Cell.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/DBIndirectRecord.cpp
+++ b/rejistry++/src/DBIndirectRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/DBIndirectRecord.h
+++ b/rejistry++/src/DBIndirectRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/DBRecord.cpp
+++ b/rejistry++/src/DBRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/DBRecord.h
+++ b/rejistry++/src/DBRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/DirectSubkeyListRecord.cpp
+++ b/rejistry++/src/DirectSubkeyListRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/DirectSubkeyListRecord.h
+++ b/rejistry++/src/DirectSubkeyListRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/EmptySubkeyList.h
+++ b/rejistry++/src/EmptySubkeyList.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/HBIN.cpp
+++ b/rejistry++/src/HBIN.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/HBIN.h
+++ b/rejistry++/src/HBIN.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/LFRecord.cpp
+++ b/rejistry++/src/LFRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/LFRecord.h
+++ b/rejistry++/src/LFRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/LHRecord.cpp
+++ b/rejistry++/src/LHRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/LHRecord.h
+++ b/rejistry++/src/LHRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/LIRecord.cpp
+++ b/rejistry++/src/LIRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/LIRecord.h
+++ b/rejistry++/src/LIRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/NKRecord.cpp
+++ b/rejistry++/src/NKRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/NKRecord.h
+++ b/rejistry++/src/NKRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/REGFHeader.cpp
+++ b/rejistry++/src/REGFHeader.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/REGFHeader.h
+++ b/rejistry++/src/REGFHeader.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RIRecord.cpp
+++ b/rejistry++/src/RIRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RIRecord.h
+++ b/rejistry++/src/RIRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Record.cpp
+++ b/rejistry++/src/Record.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Record.h
+++ b/rejistry++/src/Record.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryByteBuffer.cpp
+++ b/rejistry++/src/RegistryByteBuffer.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryByteBuffer.h
+++ b/rejistry++/src/RegistryByteBuffer.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryHive.h
+++ b/rejistry++/src/RegistryHive.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryHiveBuffer.cpp
+++ b/rejistry++/src/RegistryHiveBuffer.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryHiveBuffer.h
+++ b/rejistry++/src/RegistryHiveBuffer.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryHiveFile.cpp
+++ b/rejistry++/src/RegistryHiveFile.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryHiveFile.h
+++ b/rejistry++/src/RegistryHiveFile.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryKey.cpp
+++ b/rejistry++/src/RegistryKey.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryKey.h
+++ b/rejistry++/src/RegistryKey.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryValue.cpp
+++ b/rejistry++/src/RegistryValue.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RegistryValue.h
+++ b/rejistry++/src/RegistryValue.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/Rejistry.cpp
+++ b/rejistry++/src/Rejistry.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  *
  *  The Sleuth Kit

--- a/rejistry++/src/Rejistry.h
+++ b/rejistry++/src/Rejistry.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RejistryException.cpp
+++ b/rejistry++/src/RejistryException.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/RejistryException.h
+++ b/rejistry++/src/RejistryException.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/SubkeyListRecord.cpp
+++ b/rejistry++/src/SubkeyListRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/SubkeyListRecord.h
+++ b/rejistry++/src/SubkeyListRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/VKRecord.cpp
+++ b/rejistry++/src/VKRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/VKRecord.h
+++ b/rejistry++/src/VKRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/ValueData.cpp
+++ b/rejistry++/src/ValueData.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/ValueData.h
+++ b/rejistry++/src/ValueData.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/ValueListRecord.cpp
+++ b/rejistry++/src/ValueListRecord.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/rejistry++/src/ValueListRecord.h
+++ b/rejistry++/src/ValueListRecord.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  *
  * The Sleuth Kit

--- a/samples/callback-cpp-style.cpp
+++ b/samples/callback-cpp-style.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
 /* 
 *
 * This is a sample file that shows how to use some of the basic C++

--- a/samples/callback-style.cpp
+++ b/samples/callback-style.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
 /* 
 *
 * This is a sample file that shows how to use some of the basic 

--- a/samples/posix-cpp-style.cpp
+++ b/samples/posix-cpp-style.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * 
  * This is a sample file that shows how to use some of the basic C++

--- a/samples/posix-style.cpp
+++ b/samples/posix-style.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * 
  * This is a sample file that shows how to use some of the basic 

--- a/tests/fs_attrlist_apis.cpp
+++ b/tests/fs_attrlist_apis.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tests/fs_fname_apis.cpp
+++ b/tests/fs_fname_apis.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit 
 *

--- a/tests/read_apis.cpp
+++ b/tests/read_apis.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit 
 *

--- a/tools/autotools/tsk_comparedir.cpp
+++ b/tools/autotools/tsk_comparedir.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** tsk_comparedir
  ** The Sleuth Kit 

--- a/tools/autotools/tsk_gettimes.cpp
+++ b/tools/autotools/tsk_gettimes.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** tsk_gettimes
  ** The Sleuth Kit 

--- a/tools/autotools/tsk_loaddb.cpp
+++ b/tools/autotools/tsk_loaddb.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** tsk_loaddb
  ** The Sleuth Kit 

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** tsk_recover
  ** The Sleuth Kit 

--- a/tools/fstools/blkcalc.cpp
+++ b/tools/fstools/blkcalc.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** blkcalc
 ** The Sleuth Kit

--- a/tools/fstools/blkcat.cpp
+++ b/tools/fstools/blkcat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** blkcat
 ** The  Sleuth Kit 

--- a/tools/fstools/blkls.cpp
+++ b/tools/fstools/blkls.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tools/fstools/blkstat.cpp
+++ b/tools/fstools/blkstat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** blkstat
 ** The Sleuth Kit 

--- a/tools/fstools/fcat.cpp
+++ b/tools/fstools/fcat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fcat 
 ** The Sleuth Kit 

--- a/tools/fstools/ffind.cpp
+++ b/tools/fstools/ffind.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ffind  (file find)
 ** The Sleuth Kit 

--- a/tools/fstools/fls.cpp
+++ b/tools/fstools/fls.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fls
 ** The Sleuth Kit 

--- a/tools/fstools/fscheck.cpp
+++ b/tools/fstools/fscheck.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fscheck
 ** The Sleuth Kit 

--- a/tools/fstools/fsstat.cpp
+++ b/tools/fstools/fsstat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fsstat
 ** The Sleuth Kit 

--- a/tools/fstools/icat.cpp
+++ b/tools/fstools/icat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** icat 
 ** The Sleuth Kit 

--- a/tools/fstools/ifind.cpp
+++ b/tools/fstools/ifind.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ifind (inode find)
 ** The Sleuth Kit

--- a/tools/fstools/ils.cpp
+++ b/tools/fstools/ils.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tools/fstools/istat.cpp
+++ b/tools/fstools/istat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** istat
 ** The Sleuth Kit 

--- a/tools/fstools/jcat.cpp
+++ b/tools/fstools/jcat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** jcat
 ** The Sleuth Kit 

--- a/tools/fstools/jls.cpp
+++ b/tools/fstools/jls.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** jls
 ** The Sleuth Kit 

--- a/tools/fstools/usnjls.cpp
+++ b/tools/fstools/usnjls.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** usnjls
 ** The Sleuth Kit

--- a/tools/hashtools/hfind.cpp
+++ b/tools/hashtools/hfind.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tools/imgtools/img_cat.cpp
+++ b/tools/imgtools/img_cat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * img_cat
  * The Sleuth Kit 

--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * imgstat
  * The Sleuth Kit 

--- a/tools/srchtools/sigfind.cpp
+++ b/tools/srchtools/sigfind.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tools/srchtools/srch_strings.c
+++ b/tools/srchtools/srch_strings.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 /* From binutils-2.15
  * removed getopt_long stuff
  *

--- a/tools/vstools/mmcat.cpp
+++ b/tools/vstools/mmcat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tools/vstools/mmls.cpp
+++ b/tools/vstools/mmls.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tools/vstools/mmstat.cpp
+++ b/tools/vstools/mmstat.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/auto/auto.cpp
+++ b/tsk/auto/auto.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit
  **

--- a/tsk/auto/auto_db.cpp
+++ b/tsk/auto/auto_db.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit
  **

--- a/tsk/auto/case_db.cpp
+++ b/tsk/auto/case_db.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/auto/db_connection_info.h
+++ b/tsk/auto/db_connection_info.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/auto/db_postgresql.cpp
+++ b/tsk/auto/db_postgresql.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/auto/guid.cpp
+++ b/tsk/auto/guid.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 /*
 The MIT License (MIT)
 

--- a/tsk/auto/guid.h
+++ b/tsk/auto/guid.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT */
 /*
 The MIT License (MIT)
 

--- a/tsk/auto/is_image_supported.cpp
+++ b/tsk/auto/is_image_supported.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit
  **

--- a/tsk/auto/tsk_auto.h
+++ b/tsk/auto/tsk_auto.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit 
  **

--- a/tsk/auto/tsk_auto_i.h
+++ b/tsk/auto/tsk_auto_i.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit 
  **

--- a/tsk/auto/tsk_case_db.h
+++ b/tsk/auto/tsk_case_db.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit 
  **

--- a/tsk/auto/tsk_db.cpp
+++ b/tsk/auto/tsk_db.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/auto/tsk_db.h
+++ b/tsk/auto/tsk_db.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit 
  **

--- a/tsk/auto/tsk_db_postgresql.h
+++ b/tsk/auto/tsk_db_postgresql.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit
  **

--- a/tsk/auto/tsk_db_sqlite.h
+++ b/tsk/auto/tsk_db_sqlite.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit 
  **

--- a/tsk/auto/tsk_is_image_supported.h
+++ b/tsk/auto/tsk_is_image_supported.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** The Sleuth Kit
  ** 

--- a/tsk/base/mymalloc.c
+++ b/tsk/base/mymalloc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_base.h
+++ b/tsk/base/tsk_base.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_endian.c
+++ b/tsk/base/tsk_endian.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_error.c
+++ b/tsk/base/tsk_error.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_error_win32.cpp
+++ b/tsk/base/tsk_error_win32.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_list.c
+++ b/tsk/base/tsk_list.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit 
  *

--- a/tsk/base/tsk_lock.c
+++ b/tsk/base/tsk_lock.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_parse.c
+++ b/tsk/base/tsk_parse.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_printf.c
+++ b/tsk/base/tsk_printf.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/base/tsk_stack.c
+++ b/tsk/base/tsk_stack.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit 
  *

--- a/tsk/base/tsk_version.c
+++ b/tsk/base/tsk_version.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/fs/dcalc_lib.c
+++ b/tsk/fs/dcalc_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** blkcalc
 ** The Sleuth Kit 

--- a/tsk/fs/dcat_lib.c
+++ b/tsk/fs/dcat_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** blkcat
 ** The  Sleuth Kit

--- a/tsk/fs/dls_lib.c
+++ b/tsk/fs/dls_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/dstat_lib.c
+++ b/tsk/fs/dstat_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** blkstat
 ** The Sleuth Kit 

--- a/tsk/fs/exfatfs.c
+++ b/tsk/fs/exfatfs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/exfatfs_dent.c
+++ b/tsk/fs/exfatfs_dent.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/exfatfs_meta.c
+++ b/tsk/fs/exfatfs_meta.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/ext2fs.c
+++ b/tsk/fs/ext2fs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/ext2fs_dent.c
+++ b/tsk/fs/ext2fs_dent.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ext2fs_dent
 ** The Sleuth Kit

--- a/tsk/fs/ext2fs_journal.c
+++ b/tsk/fs/ext2fs_journal.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
    @@@ UNALLOC only if seq is less - alloc can be less than block if it wrapped around ...
 ** ext2fs_journal

--- a/tsk/fs/fatfs.c
+++ b/tsk/fs/fatfs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/fatfs_dent.cpp
+++ b/tsk/fs/fatfs_dent.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fatfs_dent
 ** The Sleuth Kit

--- a/tsk/fs/fatfs_meta.c
+++ b/tsk/fs/fatfs_meta.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fatfs
 ** The Sleuth Kit

--- a/tsk/fs/fatfs_utils.c
+++ b/tsk/fs/fatfs_utils.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/fatxxfs.c
+++ b/tsk/fs/fatxxfs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fatxxfs
 ** The Sleuth Kit 

--- a/tsk/fs/fatxxfs_dent.c
+++ b/tsk/fs/fatxxfs_dent.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fatfs_dent
 ** The Sleuth Kit

--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fatxxfs
 ** The Sleuth Kit 

--- a/tsk/fs/ffind_lib.c
+++ b/tsk/fs/ffind_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ffind  (file find)
 ** The Sleuth Kit

--- a/tsk/fs/ffs.c
+++ b/tsk/fs/ffs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/ffs_dent.c
+++ b/tsk/fs/ffs_dent.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ffs_dent
 ** The  Sleuth Kit

--- a/tsk/fs/fls_lib.c
+++ b/tsk/fs/fls_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fls
 ** The Sleuth Kit

--- a/tsk/fs/fs_attr.c
+++ b/tsk/fs/fs_attr.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fs_attr
 ** The Sleuth Kit 

--- a/tsk/fs/fs_attrlist.c
+++ b/tsk/fs/fs_attrlist.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  ** fs_attrlist
  ** The Sleuth Kit

--- a/tsk/fs/fs_block.c
+++ b/tsk/fs/fs_block.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * fs_dir
  * The Sleuth Kit

--- a/tsk/fs/fs_file.c
+++ b/tsk/fs/fs_file.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * fs_file
  * The Sleuth Kit 

--- a/tsk/fs/fs_inode.c
+++ b/tsk/fs/fs_inode.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/fs/fs_io.c
+++ b/tsk/fs/fs_io.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/fs/fs_load.c
+++ b/tsk/fs/fs_load.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /* 
  * The Sleuth Kit
  * 

--- a/tsk/fs/fs_name.c
+++ b/tsk/fs/fs_name.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fs_name
 ** The Sleuth Kit

--- a/tsk/fs/fs_open.c
+++ b/tsk/fs/fs_open.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** tsk_fs_open_img
 ** The Sleuth Kit

--- a/tsk/fs/fs_parse.c
+++ b/tsk/fs/fs_parse.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit 
  *

--- a/tsk/fs/fs_types.c
+++ b/tsk/fs/fs_types.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** fs_types
 ** The Sleuth Kit 

--- a/tsk/fs/hfs_journal.c
+++ b/tsk/fs/hfs_journal.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  * 

--- a/tsk/fs/icat_lib.c
+++ b/tsk/fs/icat_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** icat_lib 
 ** The Sleuth Kit 

--- a/tsk/fs/ifind_lib.c
+++ b/tsk/fs/ifind_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ifind (inode find)
 ** The Sleuth Kit

--- a/tsk/fs/ils_lib.c
+++ b/tsk/fs/ils_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tsk/fs/lzvn.c
+++ b/tsk/fs/lzvn.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*
 Copyright (c) 2015-2016, Apple Inc. All rights reserved.
 

--- a/tsk/fs/nofs_misc.c
+++ b/tsk/fs/nofs_misc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ntfs
 ** The Sleuth Kit

--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** ntfs_dent
 ** The Sleuth Kit

--- a/tsk/fs/rawfs.c
+++ b/tsk/fs/rawfs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/swapfs.c
+++ b/tsk/fs/swapfs.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tsk/fs/tsk_exfatfs.h
+++ b/tsk/fs/tsk_exfatfs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/tsk_ext2fs.h
+++ b/tsk/fs/tsk_ext2fs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/tsk_fatfs.h
+++ b/tsk/fs/tsk_fatfs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/tsk_fatxxfs.h
+++ b/tsk/fs/tsk_fatxxfs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tsk/fs/tsk_ffs.h
+++ b/tsk/fs/tsk_ffs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tsk/fs/tsk_fs.h
+++ b/tsk/fs/tsk_fs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/tsk_fs_i.h
+++ b/tsk/fs/tsk_fs_i.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/tsk_ntfs.h
+++ b/tsk/fs/tsk_ntfs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/fs/tsk_yaffs.h
+++ b/tsk/fs/tsk_yaffs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** The Sleuth Kit 
 **

--- a/tsk/fs/unix_misc.c
+++ b/tsk/fs/unix_misc.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit 
  *

--- a/tsk/fs/usn_journal.c
+++ b/tsk/fs/usn_journal.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** usn_journal
 ** The Sleuth Kit

--- a/tsk/fs/usnjls_lib.c
+++ b/tsk/fs/usnjls_lib.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** usnjls
 ** The Sleuth Kit

--- a/tsk/fs/yaffs.cpp
+++ b/tsk/fs/yaffs.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: IPL-1.0 */
 /*
 ** The Sleuth Kit
 **

--- a/tsk/hashdb/binsrch_index.cpp
+++ b/tsk/hashdb/binsrch_index.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/encase.c
+++ b/tsk/hashdb/encase.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/hashkeeper.c
+++ b/tsk/hashdb/hashkeeper.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/hdb_base.c
+++ b/tsk/hashdb/hdb_base.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/idxonly.c
+++ b/tsk/hashdb/idxonly.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/md5sum.c
+++ b/tsk/hashdb/md5sum.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/nsrl.c
+++ b/tsk/hashdb/nsrl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/sqlite_hdb.cpp
+++ b/tsk/hashdb/sqlite_hdb.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/hashdb/tsk_hashdb.c
+++ b/tsk/hashdb/tsk_hashdb.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/aff.h
+++ b/tsk/img/aff.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/img/ewf.c
+++ b/tsk/img/ewf.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit - Add on for Expert Witness Compression Format (EWF) image support
  *

--- a/tsk/img/ewf.h
+++ b/tsk/img/ewf.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit - Add on for Expert Witness Compression Format (EWF) image support
  *

--- a/tsk/img/img_io.c
+++ b/tsk/img/img_io.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2011 Brian Carrier.  All Rights reserved

--- a/tsk/img/img_open.c
+++ b/tsk/img/img_open.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All Rights reserved

--- a/tsk/img/img_types.c
+++ b/tsk/img/img_types.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 ** img_types
 ** The Sleuth Kit 

--- a/tsk/img/img_writer.cpp
+++ b/tsk/img/img_writer.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/img_writer.h
+++ b/tsk/img/img_writer.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/img/mult_files.c
+++ b/tsk/img/mult_files.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2011 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2011 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/raw.h
+++ b/tsk/img/raw.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/img/tsk_img_i.h
+++ b/tsk/img/tsk_img_i.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2016 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/vhd.h
+++ b/tsk/img/vhd.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2016 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2016 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/img/vmdk.h
+++ b/tsk/img/vmdk.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * Brian Carrier [carrier <at> sleuthkit [dot] org]
  * Copyright (c) 2006-2016 Brian Carrier, Basis Technology.  All rights reserved

--- a/tsk/vs/bsd.c
+++ b/tsk/vs/bsd.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/dos.c
+++ b/tsk/vs/dos.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/gpt.c
+++ b/tsk/vs/gpt.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/mac.c
+++ b/tsk/vs/mac.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/mm_io.c
+++ b/tsk/vs/mm_io.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/mm_open.c
+++ b/tsk/vs/mm_open.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/mm_part.c
+++ b/tsk/vs/mm_part.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/mm_types.c
+++ b/tsk/vs/mm_types.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/sun.c
+++ b/tsk/vs/sun.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/tsk_bsd.h
+++ b/tsk/vs/tsk_bsd.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/tsk_dos.h
+++ b/tsk/vs/tsk_dos.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /* 
  * The Sleuth Kit
  *

--- a/tsk/vs/tsk_gpt.h
+++ b/tsk/vs/tsk_gpt.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/tsk_mac.h
+++ b/tsk/vs/tsk_mac.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/tsk_sun.h
+++ b/tsk/vs/tsk_sun.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/tsk/vs/tsk_vs.h
+++ b/tsk/vs/tsk_vs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
 * The Sleuth Kit
 *

--- a/tsk/vs/tsk_vs_i.h
+++ b/tsk/vs/tsk_vs_i.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *

--- a/unit_tests/base/test_base.cpp
+++ b/unit_tests/base/test_base.cpp
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: CPL-1.0 */
 /*
  * The Sleuth Kit
  *


### PR DESCRIPTION
Add SPDX (https://spdx.org/) IDs to quickly and and easily identify licenses for files.

IDs were added only to Java and C/C++ files. IDs were not added to files that were ambiguous in their license definition or did not previously declare a license.

An example of an ambiguous license is `tsk/fs/hfs.c`.  It clearly states it is under the [IBM Public License](https://opensource.org/licenses/IPL-1.0), but [includes verbiage](https://github.com/sleuthkit/sleuthkit/blob/aa42a5e6f6c24d73c42e74bbd95e97b4c5ee6532/tsk/fs/hfs.c#L41-L44) that is not in the license ("[...] or other software that incorporates part of all of [...]").

This was done by
```sh
find . -iname '*.c' -or -iname '*.cpp' -or -iname '*.h' -or -iname '*.java' | \
    xargs grep -l -m 15 '$SEARCH_STRING' | \
    xargs sed -i '1s,^,/* SPDX-License-Identifier: $SDPX_IDENTIFIER */\n,'
```
where `$SEARCH_STRING` was a typical pattern for a license (e.g., "This software is distributed under the IBM Public License") and `$SDPX_IDENTIFIER` was the SPDX ID (e.g., 'IPL-1.0'), then manually checking the diff with a larger context (`-U15`).

Related: #943
