### PR TITLE
Fix CVE-2018-19497. 

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -961,7 +961,7 @@ hfs_cat_traverse(HFS_INFO * hfs,
                     tsk_error_set_errno(TSK_ERR_FS_GENFS);
                     tsk_error_set_errstr
                         ("hfs_cat_traverse: length of key %d in index node %d too large (%d vs %"
-                        PRIu16 ")", rec, cur_node, keylen, nodesize);
+                        PRIu16 ")", rec, cur_node, keylen, nodesize - rec_off);
                     free(node);
                     return 1;
                 }

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -957,11 +957,11 @@ hfs_cat_traverse(HFS_INFO * hfs,
 
                 keylen = 2 + tsk_getu16(hfs->fs_info.endian, key->key_len);
                
-                if (keylen > nodesize - rec_off) {
+                if (keylen >= nodesize - rec_off) {
                     tsk_error_set_errno(TSK_ERR_FS_GENFS);
                     tsk_error_set_errstr
                         ("hfs_cat_traverse: length of key %d in index node %d too large (%d vs %"
-                        PRIu16 ")", rec, cur_node, keylen, nodesize - rec_off);
+                        PRIu16 ")", rec, cur_node, keylen, (nodesize - rec_off));
                     free(node);
                     return 1;
                 }

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -956,7 +956,8 @@ hfs_cat_traverse(HFS_INFO * hfs,
                 key = (hfs_btree_key_cat *) & node[rec_off];
 
                 keylen = 2 + tsk_getu16(hfs->fs_info.endian, key->key_len);
-                if ((keylen) > nodesize) {
+               
+                if (keylen > nodesize - rec_off) {
                     tsk_error_set_errno(TSK_ERR_FS_GENFS);
                     tsk_error_set_errstr
                         ("hfs_cat_traverse: length of key %d in index node %d too large (%d vs %"


### PR DESCRIPTION
An issue was discovered in The Sleuth Kit (TSK) through 4.6.4.
The "tsk_getu16(hfs->fs_info.endian, &rec_buf[rec_off2])" call in hfs_dir_open_meta_cb in
tsk/fs/hfs_dent.c does not properly check boundaries. This results in
a crash (SEGV on unknown address
READ memory access)
when reading too much in the destination buffer.

this is because the boundary check in hfs_traverse_cat wasn't done properly.

Kind Regards,

Jordy Zomer