### PR TITLE
Remove the free() on buf[] as it is causing srch_strings to fail.

### DIFF
--- a/tools/srchtools/srch_strings.c
+++ b/tools/srchtools/srch_strings.c
@@ -554,7 +554,6 @@ print_strings (const char *filename, FILE *stream, uint64_t address,
 	{
 	  c = get_char (stream, &address, &magiccount, &magic);
 	  if (c == EOF) {
-            free(buf);
 	    return;
           }
 	  if (! STRING_ISGRAPHIC (c))
@@ -586,7 +585,6 @@ print_strings (const char *filename, FILE *stream, uint64_t address,
 
       buf[i] = '\0';
       fputs (buf, stdout);
-      free(buf);
 
       while (1)
 	{

--- a/tools/srchtools/srch_strings.c
+++ b/tools/srchtools/srch_strings.c
@@ -554,6 +554,7 @@ print_strings (const char *filename, FILE *stream, uint64_t address,
 	{
 	  c = get_char (stream, &address, &magiccount, &magic);
 	  if (c == EOF) {
+	    free(buf);
 	    return;
           }
 	  if (! STRING_ISGRAPHIC (c))
@@ -598,6 +599,7 @@ print_strings (const char *filename, FILE *stream, uint64_t address,
 
       putchar ('\n');
     }
+  free(buf);
 }
 
 /* Parse string S as an integer, using decimal radix by default,


### PR DESCRIPTION
srch_strings is failing with a 'double free or corruption (fasttop)' and on some Linux systems it will core dump even when processing a simple text file as reported by Tom Yarrish on [sleuthkit-users].  I don't believe we need to free() arrays like this since the buf[] is automatically deallocated once the function returns.  Removing the free() corrects the issue in testing.

Before:

```bash
dk@anubis:~$ srch_strings -a /usr/share/common-licenses/GPL-3
                    GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
double free or corruption (fasttop)
Aborted
```

After:

```bash
dk@anubis:~$ srch_strings -a /usr/share/common-licenses/GPL-3
                    GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 Everyone is permitted to copy and distribute verbatim copies
 of this license document, but changing it is not allowed.
                            Preamble
  The GNU General Public License is a free, copyleft license for
software and other kinds of works.
  The licenses for most software and other practical works are designed
<snip>
<snip>
<snip>
```
