### PR TITLE
Allow --enable-offline to accept a directory argument for jar libs

### DIFF
--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -7,6 +7,10 @@ jar_DATA = $(tsk_jar)
 
 if OFFLINE
  ant_args=-Doffline=true
+if CUSTOM_DEFAULT_JAR_LOCATION
+  ant_args+= -Ddefault-jar-location="@DEFAULT_JAR_LOCATION@"
+else
+endif
 else
 
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -221,10 +221,18 @@ AC_ARG_ENABLE([offline],
     [case "${enableval}" in
 	yes) offline=true ;;
 	no) offline=false ;;
-	*) AC_MSG_ERROR([bad value ${enableval} for --enable-online]) ;;
+	*)
+	    offline=true
+	    default_jar_location="${enableval}"
+	    ;;
      esac],[offline=false])
 
 AM_CONDITIONAL([OFFLINE], [test "x$offline" = xtrue])
+AM_CONDITIONAL([CUSTOM_DEFAULT_JAR_LOCATION], [test "x$default_jar_location" != "x"])
+AM_COND_IF([CUSTOM_DEFAULT_JAR_LOCATION],
+    [AC_SUBST([DEFAULT_JAR_LOCATION], [$default_jar_location])]
+)
+
 
 
 dnl Check if we should link libewf.


### PR DESCRIPTION
Allow the hardcoded default_jar_location in build.xml to
/usr/share/java to be changed using the argument provided to
--enable-offline. Note that this changes the behavior of the switch
from "anything other than yes or no is incorrect" to "anything other
than no implies offline mode".