### PR TITLE
Fix for CT-2917 - fail to get non-ascii registry key names

### DIFF
--- a/rejistry++/src/RegistryByteBuffer.cpp
+++ b/rejistry++/src/RegistryByteBuffer.cpp
@@ -127,12 +127,13 @@ namespace Rejistry {
         if (nullPos == 0) {
             return L"";
         }
-		// NULL Pointer not found
+
+		// UFT16 NULL char not found so add it
+		// Non-ascii registry key names seem to not be NULL terminated 
+		// which leads to conversion errors in from_bytes() (CT-2917)
 		else if (nullPos == data.size()) {
-			// @@@ BC: I'm not sure if this is correct.  But, we got exceptions if
-			// we kept it past the buffer.  
-			// Are these always supposed to be NULL terminated, in which case this is an error?
-			nullPos = data.size() - 1;
+			data.push_back('\0');
+			data.push_back('\0');
 		}
 
         std::wstring result;

--- a/rejistry++/src/RegistryByteBuffer.cpp
+++ b/rejistry++/src/RegistryByteBuffer.cpp
@@ -130,9 +130,23 @@ namespace Rejistry {
 			return L"";
 		}
 
+		// We do this so we can reference the last character in the string
+		// data.size() -2. if we didn't add a char to the string then returned
+		// string would be missing the last character. 
+		data.push_back('\0');
+		data.push_back('\0');
+
+		// We are unsure how from_bytes() works. Microsofts docs seem to indicate that the second pointer
+		// should point to the last character which will be included in the conversion.[1] However, another
+		// reference indicates that the data pointed to by the second pointer will not be included, which is 
+		// what our testing has shown.[2] We previously had the second pointer point to data.size() but there were
+		// concerns that we were pointing to memory we did not own. As a result, we add a char to the end of every
+		// string so we can use data.size() - 2 and still get the original string back.  
+		// 1. https://docs.microsoft.com/en-us/cpp/standard-library/wstring-convert-class?view=vs-2017#from_bytes
+		// 2. http://www.cplusplus.com/reference/locale/wstring_convert/from_bytes/
 		std::wstring result;
 		try {
-			result = conv.from_bytes(reinterpret_cast<const char*>(&data[0]), reinterpret_cast<const char*>(&data[data.size()]));
+			result = conv.from_bytes(reinterpret_cast<const char*>(&data[0]), reinterpret_cast<const char*>(&data[data.size()-2]));
 		}
 		catch (std::exception&)
 		{


### PR DESCRIPTION
Non-ascii registry key names seem to not be Null terminated. I created three non-ascii keys all of which had no Null termination. I verified manually using a hex editor on the registry hive. This led to conversion issues when calling from_bytes() within getUFT16String(). Solution is to append a UFT16 null char to the end of any string that is not null terminated.