### PR TITLE
Fix issue with random seeking in sparse files

### DIFF
--- a/tsk/fs/fs_attr.c
+++ b/tsk/fs/fs_attr.c
@@ -1288,6 +1288,7 @@ tsk_fs_attr_read(const TSK_FS_ATTR * a_fs_attr, TSK_OFF_T a_offset,
 
             }
             len_remain -= len_inrun;
+            byteoffset_toread = 0;
         }
         return (ssize_t) (len_toread - len_remain);
     }


### PR DESCRIPTION
`tsk_fs_attr_read` doesn't always reset `byteoffset_toread`.  This causes errors when reading randomly from sparse files.