### PR TITLE
Fix HFS+ parsing when catalog > 4 GiB in size

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -888,7 +888,7 @@ hfs_cat_traverse(HFS_INFO * hfs,
         }
 
         // read the current node
-        cur_off = cur_node * nodesize;
+        cur_off = (TSK_OFF_T)cur_node * nodesize;
         cnt = tsk_fs_attr_read(hfs->catalog_attr, cur_off,
             node, nodesize, 0);
         if (cnt != nodesize) {


### PR DESCRIPTION
HFS+ parsing can fail when the HFS+ catalog file is larger than 4 GiB (which we've seen in large time machine backups).

The code that calculated the offset of a record was truncating the offset to 32-bits