### PR TITLE
"modify ext4 journal descriptor table structure"

### DIFF
--- a/tsk/fs/tsk_ext2fs.h
+++ b/tsk/fs/tsk_ext2fs.h
@@ -614,6 +614,8 @@ extern "C" {
     typedef struct {
         uint8_t fs_blk[4];
         uint8_t flag[4];
+        uint8_t fs_blk_hi[4];
+        uint8_t checksum[4];
     } ext2fs_journ_dentry;
 
 


### PR DESCRIPTION
The structure of the current sleuthkit version of the ext4 journal descriptor table is problematic.

The value of sizeof (ext2fs_journ_dentry) on lines 463 and 468 of the ext2fs_journal.c file is currently 8 bytes, but the size of the dentry(tag) in the ext4 journal descriptor table should be 16 or 32 bytes.