### PR TITLE
improve addLocalFile method performance

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -6229,18 +6229,21 @@ public class SleuthkitCase {
 			}
 			statement.setString(17, mimeType);
 			String parentPath;
-
+			long dataSourceObjId; 
+			
 			if (parent instanceof AbstractFile) {
-				if (isRootDirectory((AbstractFile)parent, transaction)) {
+				AbstractFile parentFile = (AbstractFile) parent;
+				if (isRootDirectory(parentFile, transaction)) {
 					parentPath = "/";
 				} else {
-					parentPath = ((AbstractFile)parent).getParentPath() + parent.getName() + "/"; //NON-NLS
+					parentPath = parentFile.getParentPath() + parent.getName() + "/"; //NON-NLS
 				}
+				dataSourceObjId = parentFile.getDataSourceObjectId();
 			} else {
 				parentPath = "/";
+				dataSourceObjId = getDataSourceObjectId(connection, parent.getId());
 			}
 			statement.setString(18, parentPath);
-			long dataSourceObjId = getDataSourceObjectId(connection, parent.getId());
 			statement.setLong(19, dataSourceObjId);
 			final String extension = extractExtension(fileName);
 			statement.setString(20, extension);


### PR DESCRIPTION
There are two issues with this function that makes it slow down
- getDataSourceObjectId() is slow and unneeded. We can cast this parent Content object to
  AbstractFile (if it is a that type, which it usually is) and call getDataSourceObjectId() on it.
  It is stored in the structure already
- isRootDirectory() also involves a database round trip
  We could cache the root dirs since there is only one root directory per data source. This change is not 
  implemented in this commit. 