### PR TITLE
adding a fix for Heap Out-Of-Bounds Memory Access (72788059) #1123

### DIFF
--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -1007,7 +1007,7 @@ ntfs_dir_open_meta(TSK_FS_INFO * a_fs, TSK_FS_DIR ** a_fs_dir,
          */
         idxalloc_len = fs_attr_idx->nrd.allocsize;
        if (idxalloc_len % 4096 !=0){
-               idxalloc_len = idxalloc_len+ 40; // align the alloc size to the idxrec header to avoid heap overread  by checking the magic header
+               idxalloc_len = idxalloc_len+ 40; // align the alloc size to the idxrec header to avoid heap overread when the magic header
        }
 	// 40 the size of the idxrec, otherwise it would allocate 1 byte only 4097-4096
         if ((idxalloc = (char *)tsk_malloc((size_t) idxalloc_len)) == NULL) {

--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -1006,6 +1006,10 @@ ntfs_dir_open_meta(TSK_FS_INFO * a_fs, TSK_FS_DIR ** a_fs_dir,
          * Copy the index allocation run into a big buffer
          */
         idxalloc_len = fs_attr_idx->nrd.allocsize;
+       if (idxalloc_len % 4096 !=0){
+               idxalloc_len = idxalloc_len+ 40; // align the alloc size to the idxrec header to avoid heap overread  by checking the magic header
+       }
+	// 40 the size of the idxrec, otherwise it would allocate 1 byte only 4097-4096
         if ((idxalloc = (char *)tsk_malloc((size_t) idxalloc_len)) == NULL) {
             return TSK_ERR;
         }


### PR DESCRIPTION
Heap Out-Of-Bounds Memory Access (72788059) #1123

fix proposal
```
(gdb) p sizeof(*idxrec)
$2 = 40
```
```
==18978==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62100001c901 at pc 0x000000698c5c bp 0x7fffffff9690 sp 0x7fffffff9688
READ of size 1 at 0x62100001c901 thread T0
    #0 0x698c5b in ntfs_dir_open_meta /fuzzing/sleuthkit/tsk/fs/ntfs_dent.cpp:1070:17
    #1 0x516ab3 in tsk_fs_dir_open_meta /fuzzing/sleuthkit/tsk/fs/fs_dir.c:290:14
    #2 0x5182ae in tsk_fs_dir_walk_lcl /fuzzing/sleuthkit/tsk/fs/fs_dir.c:556:19
    #3 0x518091 in tsk_fs_dir_walk /fuzzing/sleuthkit/tsk/fs/fs_dir.c:817:14
    #4 0x512ddd in tsk_fs_fls /fuzzing/sleuthkit/tsk/fs/fls_lib.c:262:12
    #5 0x509e19 in main /fuzzing/sleuthkit/tools/fstools/fls.cpp:307:9
    #6 0x7ffff697a2e0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202e0)
    #7 0x41d179 in _start (/fuzzing/sleuthkit/tools/fstools/fls+0x41d179)

0x62100001c901 is located 0 bytes to the right of 4097-byte region [0x62100001b900,0x62100001c901)
allocated by thread T0 here:
    #0 0x4cca98 in __interceptor_malloc (/fuzzing/sleuthkit/tools/fstools/fls+0x4cca98)
    #1 0x6f5cd4 in tsk_malloc /fuzzing/sleuthkit/tsk/base/mymalloc.c:32:16
    #2 0x697efa in ntfs_dir_open_meta /fuzzing/sleuthkit/tsk/fs/ntfs_dent.cpp:1009:33
    #3 0x516ab3 in tsk_fs_dir_open_meta /fuzzing/sleuthkit/tsk/fs/fs_dir.c:290:14
    #4 0x5182ae in tsk_fs_dir_walk_lcl /fuzzing/sleuthkit/tsk/fs/fs_dir.c:556:19
    #5 0x518091 in tsk_fs_dir_walk /fuzzing/sleuthkit/tsk/fs/fs_dir.c:817:14
    #6 0x512ddd in tsk_fs_fls /fuzzing/sleuthkit/tsk/fs/fls_lib.c:262:12
    #7 0x509e19 in main /fuzzing/sleuthkit/tools/fstools/fls.cpp:307:9
    #8 0x7ffff697a2e0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202e0)

SUMMARY: AddressSanitizer: heap-buffer-overflow /fuzzing/sleuthkit/tsk/fs/ntfs_dent.cpp:1070:17 in ntfs_dir_open_meta
Shadow bytes around the buggy address:
  0x0c427fffb8d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c427fffb8e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c427fffb8f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c427fffb900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c427fffb910: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c427fffb920:[01]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c427fffb930: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c427fffb940: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c427fffb950: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c427fffb960: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c427fffb970: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==18978==ABORTING
[Thread 0x7ffff6607700 (LWP 18979) exited]
[Inferior 1 (process 18978) exited with code 01]

```