### PR TITLE
CT-2984 (handle max key/val name lengths properly)

### DIFF
--- a/rejistry++/src/NKRecord.cpp
+++ b/rejistry++/src/NKRecord.cpp
@@ -58,8 +58,8 @@ namespace Rejistry {
         int32_t offset = (int32_t)getDWord(CLASSNAME_OFFSET_OFFSET);
         uint16_t length = getWord(CLASSNAME_LENGTH_OFFSET);
 
-		// Not sure why we are performing this check. I haven't found any documentation on
-		// a max length for class name or its purpose. 
+        // Not sure why we are performing this check. I haven't found any documentation on
+        // a max length for class name or its purpose. 
         if (length > MAX_NAME_LENGTH) {
             throw RegistryParseException("Class name exceeds maximum length.");
         }
@@ -91,7 +91,7 @@ namespace Rejistry {
 
     std::wstring NKRecord::getName() const {
         uint32_t nameLength = getWord(NAME_LENGTH_OFFSET);
-		uint32_t numOfChars = hasAsciiName() ? nameLength : (nameLength / 2); // CT-2984
+        uint32_t numOfChars = hasAsciiName() ? nameLength : (nameLength / 2); // CT-2984
 
         if (numOfChars > MAX_NAME_LENGTH) {
             throw RegistryParseException("Key name exceeds maximum length.");

--- a/rejistry++/src/NKRecord.cpp
+++ b/rejistry++/src/NKRecord.cpp
@@ -58,6 +58,8 @@ namespace Rejistry {
         int32_t offset = (int32_t)getDWord(CLASSNAME_OFFSET_OFFSET);
         uint16_t length = getWord(CLASSNAME_LENGTH_OFFSET);
 
+		// Not sure why we are performing this check. I haven't found any documentation on
+		// a max length for class name or its purpose. 
         if (length > MAX_NAME_LENGTH) {
             throw RegistryParseException("Class name exceeds maximum length.");
         }
@@ -89,8 +91,9 @@ namespace Rejistry {
 
     std::wstring NKRecord::getName() const {
         uint32_t nameLength = getWord(NAME_LENGTH_OFFSET);
+		uint32_t numOfChars = hasAsciiName() ? nameLength : (nameLength / 2); // CT-2984
 
-        if (nameLength > MAX_NAME_LENGTH) {
+        if (numOfChars > MAX_NAME_LENGTH) {
             throw RegistryParseException("Key name exceeds maximum length.");
         }
 

--- a/rejistry++/src/NKRecord.h
+++ b/rejistry++/src/NKRecord.h
@@ -163,7 +163,7 @@ namespace Rejistry {
         static const uint16_t CLASSNAME_LENGTH_OFFSET = 0x4A;
         static const uint16_t NAME_OFFSET = 0x4C;
 
-        static const uint8_t MAX_NAME_LENGTH = 255;
+        static const uint8_t MAX_NAME_LENGTH = 255; //# of characters
 
         NKRecord() {};
         NKRecord& operator=(const NKRecord &);

--- a/rejistry++/src/VKRecord.cpp
+++ b/rejistry++/src/VKRecord.cpp
@@ -59,8 +59,9 @@ namespace Rejistry {
         }
 
         uint32_t nameLength = getWord(NAME_LENGTH_OFFSET);
+		uint32_t numOfChars = hasAsciiName() ? nameLength : (nameLength / 2); // CT-2984
 
-        if (nameLength > MAX_NAME_LENGTH) {
+        if (numOfChars > MAX_NAME_LENGTH) {
             throw RegistryParseException("Value name length exceeds maximum length.");
         }
 

--- a/rejistry++/src/VKRecord.cpp
+++ b/rejistry++/src/VKRecord.cpp
@@ -59,7 +59,7 @@ namespace Rejistry {
         }
 
         uint32_t nameLength = getWord(NAME_LENGTH_OFFSET);
-		uint32_t numOfChars = hasAsciiName() ? nameLength : (nameLength / 2); // CT-2984
+        uint32_t numOfChars = hasAsciiName() ? nameLength : (nameLength / 2); // CT-2984
 
         if (numOfChars > MAX_NAME_LENGTH) {
             throw RegistryParseException("Value name length exceeds maximum length.");

--- a/rejistry++/src/VKRecord.h
+++ b/rejistry++/src/VKRecord.h
@@ -149,7 +149,7 @@ namespace Rejistry {
         static const uint16_t DB_DATA_SIZE = 0x3FD8;
         static const uint32_t LARGE_DATA_SIZE = 0x80000000;
 
-        static const uint16_t MAX_NAME_LENGTH = 32767;
+        static const uint16_t MAX_NAME_LENGTH = 16383; //# of characters
 
         VKRecord();
         VKRecord& operator=(const VKRecord &);


### PR DESCRIPTION
max name lengths represent # of characters. We were not handling ascii vs utf16 names properly. 