### PR TITLE
Update max key name size

### DIFF
--- a/rejistry++/src/NKRecord.h
+++ b/rejistry++/src/NKRecord.h
@@ -167,7 +167,7 @@ namespace Rejistry {
         // Microsoft docs state that max key name is 255 characters. This is true when testing
         // with regedit.exe and reg.exe. However, when using RegCreateKeyEx() API you can create
         // keys with 256 characters. See CT-2984 for test data. 
-        static const uint8_t MAX_NAME_LENGTH = 256; //# of characters
+        static const uint16_t MAX_NAME_LENGTH = 256; //# of characters
 
         NKRecord() {};
         NKRecord& operator=(const NKRecord &);

--- a/rejistry++/src/NKRecord.h
+++ b/rejistry++/src/NKRecord.h
@@ -163,7 +163,11 @@ namespace Rejistry {
         static const uint16_t CLASSNAME_LENGTH_OFFSET = 0x4A;
         static const uint16_t NAME_OFFSET = 0x4C;
 
-        static const uint8_t MAX_NAME_LENGTH = 255; //# of characters
+        // https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-element-size-limits
+        // Microsoft docs state that max key name is 255 characters. This is true when testing
+        // with regedit.exe and reg.exe. However, when using RegCreateKeyEx() API you can create
+        // keys with 256 characters. See CT-2984 for test data. 
+        static const uint8_t MAX_NAME_LENGTH = 256; //# of characters
 
         NKRecord() {};
         NKRecord& operator=(const NKRecord &);


### PR DESCRIPTION
Max key name size can be larger than what Microsoft docs state.

This is a minor update related to changes made in https://github.com/sleuthkit/sleuthkit/pull/1569.
