### PR TITLE
blackboardutils package was missing from distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ EXTRA_DIST = README_win32.txt README.md INSTALL.txt ChangeLog.txt NEWS.txt API-C
     bindings/java/src/org/sleuthkit/datamodel/*.java \
     bindings/java/src/org/sleuthkit/datamodel/*.html \
     bindings/java/src/org/sleuthkit/datamodel/*.properties \
+    bindings/java/src/org/sleuthkit/datamodel/blackboardutils/*.java \
     bindings/java/src/org/sleuthkit/datamodel/Examples/*.java \
     bindings/java/src/*.html \
     framework/*.txt \


### PR DESCRIPTION
Affects downstream consumers of built artifacts like Arch linux.

I thought this would fix that issue https://github.com/sleuthkit/autopsy/issues/5351 but there seems to be something else I'm missing. Still, these files should clearly be included in the dists.