### PR TITLE
Check that the allocated node is large enough to be treated as a hfs_…

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -953,6 +953,15 @@ hfs_cat_traverse(HFS_INFO * hfs,
                     return 1;
                 }
 
+                if (sizeof(hfs_btree_key_cat) > nodesize - rec_off) {
+                    tsk_error_set_errno(TSK_ERR_FS_GENFS);
+                    tsk_error_set_errstr
+                    ("hfs_cat_traverse: record %d in index node %d truncated",
+                        rec, cur_node);
+                    free(node);
+                    return 1;
+                }
+
                 key = (hfs_btree_key_cat *) & node[rec_off];
 
                 keylen = 2 + tsk_getu16(hfs->fs_info.endian, key->key_len);


### PR DESCRIPTION
…btree_key_cat.

Addresses issue https://github.com/sleuthkit/sleuthkit/issues/1144