### PR TITLE
Change Ivy download URL to HTTPS

### DIFF
--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -90,7 +90,7 @@
 		</path>
 	</target>
 
-	<property name="ivy.install.version" value="2.3.0-rc2"/>
+	<property name="ivy.install.version" value="2.5.0"/>
 	<condition property="ivy.home" value="${env.IVY_HOME}">
 		<isset property="env.IVY_HOME"/>
 	</condition>

--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -105,7 +105,7 @@
 
 	<target name="-download-ivy" unless="ivy.available">
 		<mkdir dir="${ivy.jar.dir}"/>
-		<get src="https://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
+		<get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
 	</target>
 
 	<target name="init-ivy" depends="download-ivy" unless="ivy.lib.path">

--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -105,7 +105,7 @@
 
 	<target name="-download-ivy" unless="ivy.available">
 		<mkdir dir="${ivy.jar.dir}"/>
-		<get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
+		<get src="https://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" dest="${ivy.jar.file}" usetimestamp="true"/>
 	</target>
 
 	<target name="init-ivy" depends="download-ivy" unless="ivy.lib.path">


### PR DESCRIPTION
Maven stopped supporting HTTP on 15 Jan 2020. Changed Ivy download URL to HTTPS.

All of your Travis builds will fail without this fix.