### PR TITLE
5967: Path for derived file attachments should show the path in the d…

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/blackboardutils/attributes/MessageAttachments.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/blackboardutils/attributes/MessageAttachments.java
@@ -168,10 +168,12 @@ public final class MessageAttachments {
 		 * corresponding DerivedFile object.
 		 *
 		 * @param derivedFile Derived file for the attachment.
+		 * 
+		 * @throws TskCoreException
 		 */
-		public FileAttachment(DerivedFile derivedFile) {
+		public FileAttachment(DerivedFile derivedFile) throws TskCoreException {
 			objectID = derivedFile.getId();
-			path = derivedFile.getLocalAbsPath() + "/" + derivedFile.getName();
+			path = derivedFile.getUniquePath();
 		}
 
 		/**


### PR DESCRIPTION
…ata source, not local path in the case.