### PR TITLE
5968 Fix for explicitly defaulted move assignment operator/copy constructo…

### DIFF
--- a/tsk/fs/apfs_fs.hpp
+++ b/tsk/fs/apfs_fs.hpp
@@ -122,11 +122,7 @@ class APFSJObjTree {
                uint64_t root_tree_oid,
                const APFSFileSystem::crypto_info_t &crypto);
 
-  APFSJObjTree(const APFSJObjTree &) = default;
-  APFSJObjTree &operator=(const APFSJObjTree &) = default;
-
   APFSJObjTree(APFSJObjTree &&) = default;
-  APFSJObjTree &operator=(APFSJObjTree &&) = default;
 
   inline APFSJObject obj(uint64_t oid) const { return {jobjs(oid)}; }
 

--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -573,11 +573,8 @@ class APFSJObjBtreeNode : public APFSBtreeNode<> {
   APFSJObjBtreeNode(const APFSObjectBtreeNode *obj_root,
                     apfs_block_num block_num, const uint8_t *key);
 
-  APFSJObjBtreeNode(const APFSJObjBtreeNode &) = default;
-  APFSJObjBtreeNode &operator=(const APFSJObjBtreeNode &) = default;
 
   APFSJObjBtreeNode(APFSJObjBtreeNode &&) = default;
-  APFSJObjBtreeNode &operator=(APFSJObjBtreeNode &&) = default;
 
   using iterator = APFSBtreeNodeIterator<APFSJObjBtreeNode>;
 

--- a/tsk/pool/tsk_apfs.hpp
+++ b/tsk/pool/tsk_apfs.hpp
@@ -35,7 +35,6 @@ class APFSBlock {
 
   // Move constructible
   APFSBlock(APFSBlock &&) = default;
-  APFSBlock &operator=(APFSBlock &&) = default;
 
   virtual ~APFSBlock() = default;
 


### PR DESCRIPTION
…r is implicitly deleted error messages when building on MacOS Catalina.