### PR TITLE
Added HFS types newly missing from tsk_fs_type_toname()

### DIFF
--- a/tsk/fs/fs_types.c
+++ b/tsk/fs/fs_types.c
@@ -36,16 +36,18 @@ typedef struct {
  * legacy strings - in order of expected usage
  */
 static FS_TYPES fs_type_table[] = {
-    {"ntfs", TSK_FS_TYPE_NTFS_DETECT, "NTFS"},
+    {"ntfs", TSK_FS_TYPE_NTFS, "NTFS"},
     {"fat", TSK_FS_TYPE_FAT_DETECT, "FAT (Auto Detection)"},
     {"ext", TSK_FS_TYPE_EXT_DETECT, "ExtX (Auto Detection)"},
-    {"iso9660", TSK_FS_TYPE_ISO9660_DETECT, "ISO9660 CD"},
+    {"iso9660", TSK_FS_TYPE_ISO9660, "ISO9660 CD"},
 #if TSK_USE_HFS
+    {"hfs", TSK_FS_TYPE_HFS, "HFS+"},
     {"hfs", TSK_FS_TYPE_HFS_DETECT, "HFS+"},
+    {"hfs", TSK_FS_TYPE_HFS_LEGACY, "HFS"},
 #endif
     {"ufs", TSK_FS_TYPE_FFS_DETECT, "UFS (Auto Detection)"},
-    {"raw", TSK_FS_TYPE_RAW_DETECT, "Raw Data"},
-    {"swap", TSK_FS_TYPE_SWAP_DETECT, "Swap Space"},
+    {"raw", TSK_FS_TYPE_RAW, "Raw Data"},
+    {"swap", TSK_FS_TYPE_SWAP, "Swap Space"},
     {"fat12", TSK_FS_TYPE_FAT12, "FAT12"},
     {"fat16", TSK_FS_TYPE_FAT16, "FAT16"},
     {"fat32", TSK_FS_TYPE_FAT32, "FAT32"},


### PR DESCRIPTION
* TSK_FS_TYPE_HFS_DETECT enum changed its value when APFS support was added. It's  no longer equal to the TSK_FS_TYPE_HFS enum, so no name was being found for filesystems identified as that; similarly, there was no entry for the newly added TSK_FS_TYPE_HFS_LEGACY. Both are added. (This worked correctly in 4.7.0.)

* Don't use TSK_FS_TYPE_X_DETECT enum when it has the same value as the TSL_FS_TYPE_X enum. That's just asking for trouble.