### PR TITLE
zlib_inflate is used in more than one source file, so it should be in a header

### DIFF
--- a/tsk/fs/decmpfs.c
+++ b/tsk/fs/decmpfs.c
@@ -34,7 +34,7 @@
  * @param bytesConsumed  -- return of the number of input bytes of compressed data used.
  * @return 0 on success, a negative number on error
  */
-static int
+int
 zlib_inflate(char *source, uint64_t sourceLen, char *dest, uint64_t destLen, uint64_t * uncompressedLength, unsigned long *bytesConsumed)       // this is unsigned long because that's what zlib uses.
 {
 

--- a/tsk/fs/decmpfs.h
+++ b/tsk/fs/decmpfs.h
@@ -45,6 +45,13 @@ typedef enum {
 
 #define COMPRESSION_UNIT_SIZE 65536U
 
+extern int zlib_inflate(char* source,
+                        uint64_t sourceLen,
+                        char* dest,
+                        uint64_t destLen,
+                        uint64_t* uncompressedLength,
+                        unsigned long* bytesConsumed);
+
 extern int decmpfs_file_read_zlib_attr(TSK_FS_FILE* fs_file,
                             char* buffer,
                             TSK_OFF_T attributeLength,


### PR DESCRIPTION
`zlib_inflate` was formerly is used only in `tsk/fs/hfs.c` below where it was defined, so needed no declaration. As of 4.8.0, the function definition was moved to `tsk/fs/decmpfs.c`, but `zlib_inflate` continued to be used in `tsk/fs/hfs.c` when `HAVE_LIBZ` is defined. This causes a linker error when building Sleuthkit with libz support. 