### PR TITLE
Fix stack buffer overflow in yaffsfs_istat

### DIFF
--- a/tsk/fs/yaffs.cpp
+++ b/tsk/fs/yaffs.cpp
@@ -2439,7 +2439,7 @@ static uint8_t
     YAFFSFS_INFO *yfs = (YAFFSFS_INFO *)fs;
     char ls[12];
     YAFFSFS_PRINT_ADDR print;
-    char timeBuf[32];
+    char timeBuf[128];
     YaffsCacheObject * obj = NULL;
     YaffsCacheVersion * version = NULL;
     YaffsHeader * header = NULL;


### PR DESCRIPTION
Prevent a stack buffer overflow in yaffsfs_istat by increasing the buffer size to the size required by tsk_fs_time_to_str.

This is potentially exploitable by an attacker creating a file in a yaffs image with abnormally large time values.