### PR TITLE
Prevent buffer over-read in ext4_load_attrs_extents

### DIFF
--- a/tsk/fs/ext2fs.c
+++ b/tsk/fs/ext2fs.c
@@ -1644,7 +1644,7 @@ ext4_load_attrs_extents(TSK_FS_FILE *fs_file)
     
     if (depth == 0) {       /* leaf node */
         if (num_entries >
-            (fs_info->block_size -
+            (fs_meta->content_len -
              sizeof(ext2fs_extent_header)) /
             sizeof(ext2fs_extent)) {
             tsk_error_set_errno(TSK_ERR_FS_INODE_COR);


### PR DESCRIPTION
Update guarding logic around the reading of ext4 extents to properly ensure that num_entries does not exceed the bounds of the allocated buffer.

Fixes #1855