### PR TITLE
Build cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ EXTRA_DIST = README_win32.txt README.md INSTALL.txt ChangeLog.txt NEWS.txt API-C
 ACLOCAL_AMFLAGS = -I m4
 
 # directories to compile
-if CPPUNIT
+if HAVE_CPPUNIT
   UNIT_TESTS=unit_tests
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_CHECK_FUNCS([strlcpy strlcat])
 
 AX_PTHREAD([
     AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.])
-    CLIBS="$PTHREAD_LIBS $LIBS"
+    LIBS="$PTHREAD_LIBS $LIBS"
     CPPFLAGS="$CPPFLAGS $PTHREAD_CFLAGS"
     LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
     CC="$PTHREAD_CC"],[])

--- a/configure.ac
+++ b/configure.ac
@@ -331,11 +331,12 @@ AC_MSG_NOTICE([
 Building:
    afflib support:                        $ax_afflib
    libewf support:                        $ax_libewf
-   zlib support:                          $ax_zlib
-
    libvhdi support:                       $ax_libvhdi
    libvmdk support:                       $ax_libvmdk
+
+   zlib support:                          $ax_zlib
+
 Features:
    Java/JNI support:                      $ax_java_support
    Multithreading:                        $ax_multithread
-]);
+])

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([tsk/base/tsk_base.h])
 AC_CONFIG_HEADERS([tsk/tsk_config.h])
-AM_INIT_AUTOMAKE([foreign tar-ustar])
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-ustar])
 AM_PROG_LIBTOOL
 AM_MAINTAINER_MODE
 

--- a/configure.ac
+++ b/configure.ac
@@ -115,11 +115,16 @@ AS_IF([test "x$ac_cv_prog_PKGCONFIG" = "xyes"],
   )]
 )
 
-dnl needed for sqllite
-AC_CHECK_LIB(dl, dlopen)
-
-AC_CHECK_HEADERS([sqlite3.h], [AC_CHECK_LIB([sqlite3], [sqlite3_open])])
-AS_IF([test "x$ac_cv_lib_sqlite3_sqlite3_open" = "xyes"], [ax_sqlite3=yes])
+dnl check again for sqlite3 if not found by pkgconfig
+AS_IF([test "x$ax_sqlite3" != "xyes"],
+  [
+    AC_CHECK_HEADERS(
+      [sqlite3.h],
+      [AC_CHECK_LIB([dl], [dlopen])
+       AC_CHECK_LIB([sqlite3], [sqlite3_open], [ax_sqlite3=yes], [])]
+    )
+  ]
+)
 
 dnl Compile the bundled sqlite if there is no system one installed
 AC_MSG_CHECKING(which sqlite3 to use)

--- a/configure.ac
+++ b/configure.ac
@@ -81,19 +81,6 @@ AC_ARG_ENABLE([multithreading],
 dnl Enable multithreading by default in the presence of pthread
 AS_IF([test "x$ax_pthread_ok" = "xyes" && test "x$enable_multithreading" != "xno"], [ax_multithread=yes], [ax_multithread=no])
 
-case "$host" in
-*-*-mingw*)
-  dnl Adding the native /usr/local is wrong for cross-compiling
-  ;;
-*)
-  dnl Not all compilers include /usr/local in the include and link path
-  if test -d /usr/local/include; then
-    CPPFLAGS="$CPPFLAGS -I/usr/local/include"
-    LDFLAGS="$LDFLAGS -L/usr/local/lib"
-  fi
-  ;;
-esac
-
 dnl Add enable/disable option
 AC_ARG_ENABLE([java],
     [AS_HELP_STRING([--disable-java], [Do not build the java bindings or jar file])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,29 +1,16 @@
 dnl -*- Autoconf -*-
 dnl Process this file with autoconf to produce a configure script.
 
-
 AC_PREREQ(2.59)
 
 AC_INIT(sleuthkit, 4.11.1)
-m4_include([m4/ax_pthread.m4])
-dnl include the version from 1.12.1. This will work for
-m4_include([m4/cppunit.m4])
-m4_include([m4/ax_jni_include_dir.m4])
-m4_include([m4/ac_prog_javac_works.m4])
-m4_include([m4/ac_prog_javac.m4])
-m4_include([m4/ac_prog_java_works.m4])
-m4_include([m4/ac_prog_java.m4])
-m4_include([m4/ax_cxx_compile_stdcxx.m4])
-
+AC_CONFIG_AUX_DIR([config])
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([tsk/base/tsk_base.h])
 AC_CONFIG_HEADERS([tsk/tsk_config.h])
-AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
-AM_PATH_CPPUNIT(1.12.1)
-AM_CONDITIONAL([CPPUNIT],[test "x$no_cppunit" = x])
 AM_PROG_LIBTOOL
 AM_MAINTAINER_MODE
-AC_CONFIG_MACRO_DIR([m4])
 
 dnl Checks for programs.
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,6 @@ AC_ARG_ENABLE([java],
 
 dnl Checks for libraries.
 
-
 dnl Some platforms will complain about missing included functions if libstdc++ is not included.
 AC_CHECK_LIB(stdc++, main, , AC_MSG_ERROR([missing libstdc++]))
 AC_CHECK_HEADERS(list, , , AC_MSG_ERROR([missing STL list class header]))
@@ -183,7 +182,6 @@ AS_IF([test "x$enable_cppunit" != "xno"], [
 AM_CONDITIONAL([HAVE_CPPUNIT],[test "x$ac_cv_cppunit" = xyes])
 
 dnl check for user online input
-
 AC_ARG_ENABLE([offline],
     [ AS_HELP_STRING([--enable-offline],[Turn on offline mode])],
     [case "${enableval}" in


### PR DESCRIPTION
* Fixes a typo which prevents `-pthread` from appearing in `LIBS`.
* Removes unnecessary `m4_includes` from `configure.ac`. `AC_CONFIG_MACRO_DIR` handles this.
* Removes duplicate and incorrect cppunit detection code.
* Don't automatically add `/usr/local/include` and `/usr/local/lib` to `CPPFLAGS` and `LDFLAGS`. Doing so is nonstandard behavior and causes compilation and linking with unexpected libraries.