### PR TITLE
Check localtime return value

### DIFF
--- a/tsk/fs/fs_name.c
+++ b/tsk/fs/fs_name.c
@@ -297,13 +297,13 @@ tsk_fs_meta_make_ls(const TSK_FS_META * a_fs_meta, char *a_buf,
 char *
 tsk_fs_time_to_str(time_t time, char buf[128])
 {
+    struct tm *tmTime;
+
     buf[0] = '\0';
-    if (time <= 0) {
+    if (time <= 0 || (tmTime = localtime(&time)) == NULL) {
         strncpy(buf, "0000-00-00 00:00:00 (UTC)", 128);
     }
     else {
-        struct tm *tmTime = localtime(&time);
-
         snprintf(buf, 128, "%.4d-%.2d-%.2d %.2d:%.2d:%.2d (%s)",
             (int) tmTime->tm_year + 1900,
             (int) tmTime->tm_mon + 1, (int) tmTime->tm_mday,
@@ -326,13 +326,13 @@ char *
 tsk_fs_time_to_str_subsecs(time_t time, unsigned int subsecs,
     char buf[128])
 {
+    struct tm *tmTime;
+
     buf[0] = '\0';
-    if (time <= 0) {
+    if (time <= 0 || (tmTime = localtime(&time)) == NULL) {
         strncpy(buf, "0000-00-00 00:00:00 (UTC)", 32);
     }
     else {
-        struct tm *tmTime = localtime(&time);
-
         snprintf(buf, 64, "%.4d-%.2d-%.2d %.2d:%.2d:%.2d.%.9d (%s)",
             (int) tmTime->tm_year + 1900,
             (int) tmTime->tm_mon + 1, (int) tmTime->tm_mday,
@@ -368,12 +368,12 @@ tsk_fs_print_time(FILE * hFile, time_t time)
 static void
 tsk_fs_print_day(FILE * hFile, time_t time)
 {
-    if (time <= 0) {
+    struct tm *tmTime;
+
+    if (time <= 0 || (tmTime = localtime(&time)) == NULL) {
         tsk_fprintf(hFile, "0000-00-00 00:00:00 (UTC)");
     }
     else {
-        struct tm *tmTime = localtime(&time);
-
         tsk_fprintf(hFile, "%.4d-%.2d-%.2d 00:00:00 (%s)",
             (int) tmTime->tm_year + 1900,
             (int) tmTime->tm_mon + 1, (int) tmTime->tm_mday,


### PR DESCRIPTION
Hello,

during fuzzing commit [9bd64eb](https://github.com/sleuthkit/sleuthkit/commit/9bd64ebbae196611aa3f28b64a6e859b206bf609), i came across [this](https://github.com/sleuthkit/sleuthkit/files/4510580/crash_tsk_fs_time_to_str.tar.gz) test case.

The backtrace and register values can be seen below:
```
gdb -q --args ~/fuzzing/sleuthkit_clean/tools/fstools/fls -lr crash-8b75de88cbcb872bc127cc936963498a594c6043 
Reading symbols from /home/cuk/fuzzing/sleuthkit_clean/tools/fstools/fls...done.
(gdb) r
Starting program: /home/cuk/fuzzing/sleuthkit_clean/tools/fstools/fls -lr crash-8b75de88cbcb872bc127cc936963498a594c6043
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
bV/V 16:	$OrphanFiles	0000-00-00 00:00:00 (UTC)	0000-00-00 00:00:00 (UTC)	0000-00-00 00:00:00 (UTC)	0000-00-00 00:00:00 (UTC)	0	0	0
+ -/- * 9:	OrphanFile-9	0000-00-00 00:00:00 (UTC)	0000-00-00 00:00:00 (UTC)	0000-00-00 00:00:00 (UTC)	0000-00-00 00:00:00 (UTC)	-2211830366992310628	24220	3779985408

Program received signal SIGSEGV, Segmentation fault.
0x000000000042b8dd in tsk_fs_time_to_str (time=2012264612782669824, buf=0x7fffffffcba0 "") at fs_name.c:308
308	            (int) tmTime->tm_year + 1900,
(gdb) bt
#0  0x000000000042b8dd in tsk_fs_time_to_str (time=2012264612782669824, buf=0x7fffffffcba0 "") at fs_name.c:308
#1  0x000000000042c0a6 in tsk_fs_print_time (hFile=0x7ffff7c76760 <_IO_2_1_stdout_>, time=2012264612782669824) at fs_name.c:351
#2  0x000000000042bf92 in tsk_fs_name_print_long (hFile=0x7ffff7c76760 <_IO_2_1_stdout_>, fs_file=0x547080, a_path=0x7fffffffd2b8 "$OrphanFiles/", fs=0x53dca0, fs_attr=0x0, 
    print_path=0 '\000', sec_skew=0) at fs_name.c:526
#3  0x0000000000423b45 in printit (fs_file=0x547080, a_path=0x7fffffffd2b8 "$OrphanFiles/", fs_attr=0x0, fls_data=0x7fffffffe318) at fls_lib.c:97
#4  0x00000000004238c4 in print_dent_act (fs_file=0x547080, a_path=0x7fffffffd2b8 "$OrphanFiles/", ptr=0x7fffffffe318) at fls_lib.c:200
#5  0x0000000000427e83 in tsk_fs_dir_walk_lcl (a_fs=0x53dca0, a_dinfo=0x7fffffffceb0, a_addr=16, 
    a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x423440 <print_dent_act>, a_ptr=0x7fffffffe318) at fs_dir.c:593
#6  0x00000000004283b2 in tsk_fs_dir_walk_lcl (a_fs=0x53dca0, a_dinfo=0x7fffffffceb0, a_addr=2, 
    a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x423440 <print_dent_act>, a_ptr=0x7fffffffe318) at fs_dir.c:712
#7  0x0000000000427c9f in tsk_fs_dir_walk (a_fs=0x53dca0, a_addr=2, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), 
    a_action=0x423440 <print_dent_act>, a_ptr=0x7fffffffe318) at fs_dir.c:817
#8  0x000000000042342d in tsk_fs_fls (fs=0x53dca0, lclflags=(TSK_FS_FLS_LONG | TSK_FS_FLS_FILE | TSK_FS_FLS_DIR), inode=2, 
    flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), tpre=0x0, skew=0) at fls_lib.c:262
#9  0x0000000000404e81 in main (argc=3, argv1=0x7fffffffe568) at fls.cpp:394
(gdb) i r
rax            0x0                 0
rbx            0x0                 0
rcx            0x7ffff7c764f0      140737350427888
rdx            0x0                 0
rsi            0x2                 2
rdi            0x7fffffffcba0      140737488341920
rbp            0x7fffffffcb80      0x7fffffffcb80
rsp            0x7fffffffcb30      0x7fffffffcb30
r8             0xed8c1e9c2         63766129090
r9             0xa3d70a3d70a3d70b  -6640827866535438581
r10            0x2ce33e6c02ce33e7  3234497591006606311
r11            0x7ffff7c7a4a0      140737350444192
r12            0x403f10            4210448
r13            0x7fffffffe560      140737488348512
r14            0x0                 0
r15            0x0                 0
rip            0x42b8dd            0x42b8dd <tsk_fs_time_to_str+93>
eflags         0x10246             [ PF ZF IF RF ]
cs             0x33                51
ss             0x2b                43
ds             0x0                 0
es             0x0                 0
fs             0x0                 0
gs             0x0                 0
(gdb) p/x 2012264612782669824
$1 = 0x1bed0000ff000000
(gdb) 
```

The first parameter to tsk_fs_time_to_str is read directly from the file offset 0x15a30 (8bytes) and is fully controlled by the attacker. The only check performed by the code is if this value is less than 0 at [fs_name.c:305](https://github.com/sleuthkit/sleuthkit/blob/9bd64ebbae196611aa3f28b64a6e859b206bf609/tsk/fs/fs_name.c#L305). However, the return value of localtime is never checked and it's not guaranteed that localtime will never return with an error. In the former case, localtime returns NULL and then the address 0x14 is accessed resulting in a segfault.