### PR TITLE
Fixes MSVC C5208 Compile Error

### DIFF
--- a/tsk/fs/apfs.cpp
+++ b/tsk/fs/apfs.cpp
@@ -590,7 +590,7 @@ const std::vector<APFSFileSystem::snapshot_t> APFSFileSystem::snapshots()
 
   const APFSSnapshotMetaBtreeNode snap_tree{_pool, fs()->snap_meta_tree_oid};
 
-  using key_type = struct {
+  struct key_type {
     uint64_t xid_and_type;
 
     inline uint64_t snap_xid() const noexcept {

--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -979,7 +979,7 @@ class APFSFileSystem : public APFSObject {
     }
   };
 
-  using crypto_info_t = struct {
+  struct crypto_info_t {
     apfs_block_num recs_block_num{};
     std::string password_hint{};
     std::string password{};


### PR DESCRIPTION
No longer uses a typedef for an unnamed struct