### PR TITLE
Security Descriptor Offset Bug

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -3397,7 +3397,7 @@ ntfs_get_sds(TSK_FS_INFO * fs, uint32_t secid)
     sii_sds_ent_size = tsk_getu32(fs->endian, sii->sec_desc_size);
 
     // Check that we do not go out of bounds.
-    if ((uint32_t) sii_sds_file_off > ntfs->sds_data.size) {
+    if (sii_sds_file_off > ntfs->sds_data.size) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_FS_GENFS);
         tsk_error_set_errstr("ntfs_get_sds: SII offset too large (%" PRIu64


### PR DESCRIPTION
Fixed bad cast in security descriptor bounds check comparison that could cause failures if offset larger than 32-bits.
I experienced crashes running TSK.  The crashes were caused by a bad sii_sds_file_off resulting in an invalid sds pointer.  The check failed because the cast to 32-bits discarded upper bits resulting in a potentially bad comparison to ntfs->sds_data.size, which is also a 64-bit value.  There should not be a cast.  Once it was eliminated, the crash went away.