### PR TITLE
fix of possible memory overflow.

### DIFF
--- a/tools/autotools/tsk_comparedir.cpp
+++ b/tools/autotools/tsk_comparedir.cpp
@@ -161,18 +161,18 @@ uint8_t
     struct stat status;
 
     strncpy(fullPath, m_lclDir, TSK_CD_BUFSIZE);
-    strncat(fullPath, a_dir, TSK_CD_BUFSIZE-strlen(fullPath));
+    strncat(fullPath, a_dir, TSK_CD_BUFSIZE-strlen(fullPath)-1);
     if ((dp = opendir(fullPath)) == NULL) {
         fprintf(stderr, "Error opening directory");
         return 1;
     }
     while ((dirp = readdir(dp)) != NULL) {
         strncpy(file, a_dir, TSK_CD_BUFSIZE);
-        strncat(file, "/", TSK_CD_BUFSIZE-strlen(file));
-        strncat(file, dirp->d_name, TSK_CD_BUFSIZE-strlen(file));
+        strncat(file, "/", TSK_CD_BUFSIZE-strlen(file)-1);
+        strncat(file, dirp->d_name, TSK_CD_BUFSIZE-strlen(file)-1);
 
         strncpy(fullPath, m_lclDir, TSK_CD_BUFSIZE);
-        strncat(fullPath, file, TSK_CD_BUFSIZE-strlen(fullPath));
+        strncat(fullPath, file, TSK_CD_BUFSIZE-strlen(fullPath)-1);
 
         stat(fullPath, &status);
         if (S_ISDIR(status.st_mode)) {


### PR DESCRIPTION
according to the standard, the third parameter of the strncat function is not the size of the buffer, but the number of bytes that can be placed in the buffer without a terminating character.
https://en.cppreference.com/w/c/string/byte/strncat
```
 Appends at most count characters from the character array pointed to by src, stopping if the null character is found, to the end of the null-terminated byte string pointed to by dest. The character src [0] replaces the null terminator at the end of dest. The terminating null character is always appended in the end (so the maximum number of bytes the function may write is count + 1).
```
in your project file tsk_comparedir.cpp, there are places of unsafe use of the strncat function. if the source buffer is completely filled, zero writing may occur outside the buffer boundaries on the stack.