### PR TITLE
API updates newBlackboardArtifact

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
@@ -456,58 +456,59 @@ public final class Blackboard {
 
 
 	/**
-	 * Add a set of blackboard artifacts within a transaction context
-	 *
-	 * @param attributes	 A set of blackboard attribute.
-	 * @param artifactTypeId type of artifact associated with the attributes
-	 * @param artifactId     The artifact id of the blackboard artifact
-	 * @param transaction	 the transaction in the scope of which the operation
-	 *		                 is to be performed, managed by the caller
-	 *
-	 * @throws TskCoreException  thrown if a critical error occurs.
-	 */
-	public void addBlackboardAttributes(Collection<BlackboardAttribute> attributes, int artifactTypeId, long artifactId, SleuthkitCase.CaseDbTransaction transaction) throws TskCoreException {
-		if (attributes.isEmpty()) {
-			return;
-		}
-		if (transaction == null) {
-			throw new TskCoreException("Passed null CaseDbTransaction");
-		}
-		try {
-			SleuthkitCase.CaseDbConnection connection = transaction.getConnection();
-			for (final BlackboardAttribute attr : attributes) {
-				attr.setArtifactId(artifactId);
-				caseDb.addBlackBoardAttribute(attr, artifactTypeId, connection);
-			}
-		} catch (SQLException ex) {
-			throw new TskCoreException("Error adding blackboard attributes", ex);
-		}
-	}
-
-
-	/**
 	 * Add a new blackboard artifact with the given type.
 	 *
-	 * This api executes in the context of a transaction.
+	 * This api executes in the context of a transaction if one is provided.
 	 *
-	 * @param artifactType the type the given artifact should have
-	 * @param objId	   the content object id associated with this artifact
-	 * @param dataSourceObjId the data source object.
-	 * @param transaction  the transaction in the scope of which the operation
-	 *                     is to be performed, managed by the caller
+	 * @param artifactType    The type of the artifact.
+	 * @param sourceObjId     The content that is the source of this artifact.
+	 * @param dataSourceObjId The data source the artifact source content
+	 *                        belongs to, may be the same as the sourceObjId.
+	 * @param attributes      The attributes.
+	 * @param allowDuplicates Whether or not a duplicate artifact should be
+	 *                        created if the artifact already exists.
+	 * @param transaction     the transaction in the scope of which the
+	 *                        operation is to be performed. Null may be
+	 *                        provided, if one is not available. 
 	 *
 	 * @return a new blackboard artifact
 	 *
 	 * @throws TskCoreException exception thrown if a critical error occurs
 	 *                          within tsk core
 	 */
-	public BlackboardArtifact newBlackboardArtifact(BlackboardArtifact.Type artifactType, long objId, long dataSourceObjId, CaseDbTransaction transaction) throws TskCoreException {
+	public BlackboardArtifact newBlackboardArtifact(BlackboardArtifact.Type artifactType, long sourceObjId, long dataSourceObjId,
+			Collection<BlackboardAttribute> attributes, boolean allowDuplicates, final CaseDbTransaction transaction) throws TskCoreException {
+
+	    CaseDbTransaction localTrans = null;
+		boolean isNewLocalTx = false;
 		if (transaction == null) {
-			throw new TskCoreException("Passed null CaseDbTransaction");
+			localTrans = caseDb.beginTransaction();
+			isNewLocalTx = true;
+		}else {
+			localTrans = transaction;
 		}
-		return caseDb.newBlackboardArtifact(artifactType.getTypeID(), objId,
+
+		try {
+			// TODO: Perform duplicate checks if requested.
+			BlackboardArtifact blackboardArtifact = caseDb.newBlackboardArtifact(artifactType.getTypeID(), sourceObjId,
 					artifactType.getTypeName(), artifactType.getDisplayName(),
-					dataSourceObjId, transaction.getConnection());
+					dataSourceObjId, localTrans.getConnection());
+
+			if (Objects.nonNull(attributes)) {
+				blackboardArtifact.addAttributes(attributes, localTrans);
+			}
+
+			if (isNewLocalTx) {
+				localTrans.commit();
+			}
+			return blackboardArtifact;
+
+		} catch (TskCoreException ex) {
+			if (isNewLocalTx) {
+				localTrans.rollback(); // An exception here is not caught. This can cause confusion 
+			}
+			throw ex;
+		}
 	}
 
 

--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
@@ -20,6 +20,7 @@ package org.sleuthkit.datamodel;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -383,6 +384,41 @@ public class BlackboardArtifact implements Content {
 		getSleuthkitCase().addBlackboardAttributes(attributes, artifactTypeId);
 		attrsCache.addAll(attributes);
 	}
+
+	/**
+	 * Adds a collection of attributes to this artifact in a single operation
+	 * (faster than adding each attribute individually). This function also
+	 * executes in the inserts within the transaction context.
+	 *
+	 * @param attributes		      The collection of attributes.
+	 * @param caseDbTransaction the transaction in the scope of which the
+	 *                          operation is to be performed, managed by the
+	 *                          caller
+	 *
+	 * @throws TskCoreException If an error occurs and the attributes were not
+	 *                          added to the artifact.
+	 */
+	public void addAttributes(Collection<BlackboardAttribute> attributes, final SleuthkitCase.CaseDbTransaction caseDbTransaction) throws TskCoreException {
+
+		if (attributes.isEmpty()) {
+			return;
+		}
+		if (caseDbTransaction == null) {
+			addAttributes(attributes);
+			return;
+		}
+		try {
+			for (final BlackboardAttribute attribute : attributes) {
+				attribute.setArtifactId(artifactId);
+				attribute.setCaseDatabase(getSleuthkitCase());
+				getSleuthkitCase().addBlackBoardAttribute(attribute, artifactTypeId, caseDbTransaction.getConnection());
+			}
+			attrsCache.addAll(attributes);
+		} catch (SQLException ex) {
+			throw new TskCoreException("Error adding blackboard attributes", ex);
+		}
+	}
+
 
 	/**
 	 * This overiding implementation returns the unique path of the parent. It

--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
@@ -387,25 +387,24 @@ public class BlackboardArtifact implements Content {
 
 	/**
 	 * Adds a collection of attributes to this artifact in a single operation
-	 * (faster than adding each attribute individually). This function also
-	 * executes in the inserts within the transaction context.
+	 * (faster than adding each attribute individually) within a transaction
+	 * supplied by the caller.
 	 *
-	 * @param attributes		      The collection of attributes.
-	 * @param caseDbTransaction the transaction in the scope of which the
+	 * @param attributes        The collection of attributes.
+	 * @param caseDbTransaction The transaction in the scope of which the
 	 *                          operation is to be performed, managed by the
-	 *                          caller
+	 *                          caller. Null is not permitted.
 	 *
 	 * @throws TskCoreException If an error occurs and the attributes were not
 	 *                          added to the artifact.
 	 */
 	public void addAttributes(Collection<BlackboardAttribute> attributes, final SleuthkitCase.CaseDbTransaction caseDbTransaction) throws TskCoreException {
 
-		if (attributes.isEmpty()) {
-			return;
+		if (Objects.isNull(attributes) || attributes.isEmpty()) {
+			throw new TskCoreException("Passed null or empty attributes");
 		}
-		if (caseDbTransaction == null) {
-			addAttributes(attributes);
-			return;
+		if (Objects.isNull(caseDbTransaction) ) {
+			throw new TskCoreException("Passed null CaseDbTransaction");
 		}
 		try {
 			for (final BlackboardAttribute attribute : attributes) {


### PR DESCRIPTION
- newBlackboardArtifact takes a collection of attributes and a boolean allowDuplicates flag transaction may be null. if it is null a new transaction will be created and used
- Removed Blackboard#addBlackboardAttributes method. This function does not update the Artifact object cache and can potentially cause issues if the caller is not aware of this.
- Added BlackboardArtifact#addAttributes method that does update its cache. The downside of this change is that the caller needs to load an Artifact into memory if it does not have it.  
This API is however safer 
 a) One cannot add arbitrarily add attributes to a nonexistent Artifact  
 b) The caller will have the opportunity to validate or duplicate check the attribute list etc.
