### PR TITLE
Fixed issues in analysis result apis found during testing ingest of C…

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
@@ -177,7 +177,9 @@ public final class Blackboard {
 			AnalysisResult analysisResult =  caseDb.newAnalysisResult(artifactType, obj_id, datasource_obj_id, score, conclusion, configuration, justification, transaction.getConnection());
 			
 			// add the given attributes
-			analysisResult.addAttributes(attributesList, transaction);
+			if (attributesList != null && !attributesList.isEmpty()) {
+				analysisResult.addAttributes(attributesList, transaction);
+			}
 			
 			return analysisResult;
 		}  catch (TskCoreException ex) {

--- a/bindings/java/src/org/sleuthkit/datamodel/Score.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Score.java
@@ -49,7 +49,7 @@ public class Score {
 
 		public static Significance fromString(String name) {
 			return Arrays.stream(values())
-					.filter(val -> val.getName().equalsIgnoreCase(name))
+					.filter(val -> val.getName().equals(name))
 					.findFirst().orElse(NONE);
 		}
 
@@ -97,7 +97,7 @@ public class Score {
 
 		public static Confidence fromString(String name) {
 			return Arrays.stream(values())
-					.filter(val -> val.getName().equalsIgnoreCase(name))
+					.filter(val -> val.getName().equals(name))
 					.findFirst().orElse(NONE);
 		}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/Score.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Score.java
@@ -49,7 +49,7 @@ public class Score {
 
 		public static Significance fromString(String name) {
 			return Arrays.stream(values())
-					.filter(val -> val.name.equals(name))
+					.filter(val -> val.getName().equalsIgnoreCase(name))
 					.findFirst().orElse(NONE);
 		}
 
@@ -97,7 +97,7 @@ public class Score {
 
 		public static Confidence fromString(String name) {
 			return Arrays.stream(values())
-					.filter(val -> val.getName().equals(name))
+					.filter(val -> val.getName().equalsIgnoreCase(name))
 					.findFirst().orElse(NONE);
 		}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -4671,35 +4671,42 @@ public class SleuthkitCase {
 		try {
 			// add a row in tsk_objects
 			long artifact_obj_id = addObject(obj_id, TskData.ObjectType.ARTIFACT.getObjectType(), connection);
-			
+
 			// add a row in blackboard_artifacts table
-			try (PreparedStatement insertArtifactstatement = createInsertArtifactStatement(artifactType.getTypeID(), obj_id, artifact_obj_id, data_source_obj_id, connection)) {
+			PreparedStatement insertArtifactstatement;
+			ResultSet resultSet = null;
+			try {
+				insertArtifactstatement = createInsertArtifactStatement(artifactType.getTypeID(), obj_id, artifact_obj_id, data_source_obj_id, connection);
 				connection.executeUpdate(insertArtifactstatement);
-				ResultSet resultSet = insertArtifactstatement.getGeneratedKeys();
+				resultSet = insertArtifactstatement.getGeneratedKeys();
 				resultSet.next();
 				artifactID = resultSet.getLong(1); //last_insert_rowid()
-			}
-			
-			// add a row in tsk_analysis_results table
-			try (PreparedStatement analysisResultsStatement = connection.getPreparedStatement(PREPARED_STATEMENT.INSERT_ANALYSIS_RESULT)) {
+
+				// add a row in tsk_analysis_results table
+				PreparedStatement analysisResultsStatement;
+
+				analysisResultsStatement = connection.getPreparedStatement(PREPARED_STATEMENT.INSERT_ANALYSIS_RESULT);
 				analysisResultsStatement.clearParameters();
-				
+
 				analysisResultsStatement.setLong(1, artifact_obj_id);
-				analysisResultsStatement.setString(2, (conclusion != null) ? conclusion : "" );
+				analysisResultsStatement.setString(2, (conclusion != null) ? conclusion : "");
 				analysisResultsStatement.setInt(3, score.getSignificance().getId());
 				analysisResultsStatement.setInt(4, score.getConfidence().getId());
-				analysisResultsStatement.setString(5, (configuration != null) ? configuration : "" );
-				analysisResultsStatement.setString(6, (justification != null) ? justification : "" );
-				
+				analysisResultsStatement.setString(5, (configuration != null) ? configuration : "");
+				analysisResultsStatement.setString(6, (justification != null) ? justification : "");
+
 				connection.executeUpdate(analysisResultsStatement);
+
+				return new AnalysisResult(this, artifactID, obj_id, artifact_obj_id, data_source_obj_id, artifactType.getTypeID(),
+						artifactType.getTypeName(), artifactType.getDisplayName(),
+						BlackboardArtifact.ReviewStatus.UNDECIDED, true,
+						score, (conclusion != null) ? conclusion : "",
+						(configuration != null) ? configuration : "", (justification != null) ? justification : "");
+
+			} finally {
+				closeResultSet(resultSet);
 			}
-			
-			return new AnalysisResult( this, artifactID, obj_id, artifact_obj_id, data_source_obj_id, artifactType.getTypeID(), 
-										artifactType.getTypeName(), artifactType.getDisplayName(), 
-										BlackboardArtifact.ReviewStatus.UNDECIDED, true,
-										score, (conclusion != null) ? conclusion : "", 
-										(configuration != null) ? configuration : "", (justification != null) ? justification : "");
-			
+		
 		} catch (SQLException ex) {
 			throw new TskCoreException("Error creating a analysis result", ex);
 		} finally {


### PR DESCRIPTION
…yberTriage json files:

 - Prepared statements (as we have them) can't be used in a try-with-resources block, they close automatically.
 - Ignore case when instantiating Score/Confidence enums from string
 - Do not attempt to add a null or empty attribute list to an artifact.