### PR TITLE
Data source updates 

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDatabaseFactory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDatabaseFactory.java
@@ -184,7 +184,7 @@ class CaseDatabaseFactory {
 
 		stmt.execute("CREATE TABLE data_source_info (obj_id " + dbQueryHelper.getBigIntType() + " PRIMARY KEY, device_id TEXT NOT NULL, "
 				+ "time_zone TEXT NOT NULL, acquisition_details TEXT, added_date_time "+ dbQueryHelper.getBigIntType() + ", "
-				+ "acquisition_settings TEXT, module_name TEXT, module_version TEXT, "
+				+ "acquisition_tool_settings TEXT, acquisition_tool_name TEXT, acquisition_tool_version TEXT, "
 				+ "FOREIGN KEY(obj_id) REFERENCES tsk_objects(obj_id) ON DELETE CASCADE)");
 
 		stmt.execute("CREATE TABLE tsk_fs_info (obj_id " + dbQueryHelper.getPrimaryKey() + " PRIMARY KEY, "

--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDatabaseFactory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDatabaseFactory.java
@@ -183,7 +183,9 @@ class CaseDatabaseFactory {
 				+ "pool_type INTEGER NOT NULL, FOREIGN KEY(obj_id) REFERENCES tsk_objects(obj_id) ON DELETE CASCADE);");
 
 		stmt.execute("CREATE TABLE data_source_info (obj_id " + dbQueryHelper.getBigIntType() + " PRIMARY KEY, device_id TEXT NOT NULL, "
-				+ "time_zone TEXT NOT NULL, acquisition_details TEXT, FOREIGN KEY(obj_id) REFERENCES tsk_objects(obj_id) ON DELETE CASCADE)");
+				+ "time_zone TEXT NOT NULL, acquisition_details TEXT, added_date_time "+ dbQueryHelper.getBigIntType() + ", "
+				+ "acquisition_settings TEXT, module_name TEXT, module_version TEXT, "
+				+ "FOREIGN KEY(obj_id) REFERENCES tsk_objects(obj_id) ON DELETE CASCADE)");
 
 		stmt.execute("CREATE TABLE tsk_fs_info (obj_id " + dbQueryHelper.getPrimaryKey() + " PRIMARY KEY, "
 				+ "data_source_obj_id " + dbQueryHelper.getBigIntType() + " NOT NULL, "

--- a/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
@@ -73,15 +73,11 @@ public interface DataSource extends Content {
 	 * 
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
-	default void setAcquisitionDetails(String details) throws TskCoreException {
-		setAcquisitionDetails(details, null, null, null);
-	}
+	void setAcquisitionDetails(String details) throws TskCoreException;
 
 	/**
-	 * Sets the acquisition details along with any settings used as well as
-	 * module name and module version.
-	 *
-	 * @param details             The acquisition details
+	 * Sets the acquisition settings used as well as module name and module version.
+	 * 
 	 * @param acquisitionSettings Any settings specific to the acquisition. May
 	 *                            be Null.
 	 * @param moduleName          The module name. May be Null
@@ -89,7 +85,7 @@ public interface DataSource extends Content {
 	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
-	public void setAcquisitionDetails(String details, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException;
+	public void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException;
 	
 	/**
 	 * Gets the acquisition details field from the case database.

--- a/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
@@ -85,7 +85,7 @@ public interface DataSource extends Content {
 	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
-	public void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException;
+	void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException;
 	
 	/**
 	 * Gets the acquisition details field from the case database.
@@ -95,4 +95,40 @@ public interface DataSource extends Content {
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
 	String getAcquisitionDetails() throws TskCoreException;
+
+	/**
+	 * Gets the acquisition settings field from the case database.
+	 *
+	 * @return The acquisition settings
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	String getAcquisitionSettings() throws TskCoreException;
+
+	/**
+	 * Gets the module name field from the case database.
+	 *
+	 * @return The module name
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	String getModuleName() throws TskCoreException;
+
+	/**
+	 * Gets the module version field from the case database.
+	 *
+	 * @return The module version details
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	String getModuleVersion() throws TskCoreException;
+
+	/**
+	 * Gets the added date field from the case database.
+	 *
+	 * @return The date time when the image was added in epoch seconds.
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	Long getDateAdded() throws TskCoreException;
 }

--- a/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
@@ -73,7 +73,23 @@ public interface DataSource extends Content {
 	 * 
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
-	void setAcquisitionDetails(String details) throws TskCoreException;
+	default void setAcquisitionDetails(String details) throws TskCoreException {
+		setAcquisitionDetails(details, null, null, null);
+	}
+
+	/**
+	 * Sets the acquisition details along with any settings used as well as
+	 * module name and module version.
+	 *
+	 * @param details             The acquisition details
+	 * @param acquisitionSettings Any settings specific to the acquisition. May
+	 *                            be Null.
+	 * @param moduleName          The module name. May be Null
+	 * @param moduleVersion       The module's version number. May be Null.
+	 *
+	 * @throws TskCoreException Thrown if the data can not be written
+	 */
+	public void setAcquisitionDetails(String details, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException;
 	
 	/**
 	 * Gets the acquisition details field from the case database.

--- a/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/DataSource.java
@@ -76,16 +76,16 @@ public interface DataSource extends Content {
 	void setAcquisitionDetails(String details) throws TskCoreException;
 
 	/**
-	 * Sets the acquisition settings used as well as module name and module version.
-	 * 
-	 * @param acquisitionSettings Any settings specific to the acquisition. May
-	 *                            be Null.
-	 * @param moduleName          The module name. May be Null
-	 * @param moduleVersion       The module's version number. May be Null.
+	 * Sets the acquisition tool details such as its name, version number and 
+	 * any settings used during the acquisition tool to acquire data.
+	 *
+	 * @param name     The name of the acquisition tool. May be NULL.
+	 * @param version  The acquisition tool version number. May be NULL.
+	 * @param settings The settings used by the acquisition tool. May be NULL.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
-	void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException;
+	void setAcquisitionToolDetails(String name, String version, String settings) throws TskCoreException;
 	
 	/**
 	 * Gets the acquisition details field from the case database.
@@ -97,31 +97,31 @@ public interface DataSource extends Content {
 	String getAcquisitionDetails() throws TskCoreException;
 
 	/**
-	 * Gets the acquisition settings field from the case database.
+	 * Gets the acquisition tool settings field from the case database.
 	 *
-	 * @return The acquisition settings
+	 * @return The acquisition tool settings. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	String getAcquisitionSettings() throws TskCoreException;
+	String getAcquisitionToolSettings() throws TskCoreException;
 
 	/**
-	 * Gets the module name field from the case database.
+	 * Gets the acquisition tool name field from the case database.
 	 *
-	 * @return The module name
+	 * @return The acquisition tool name. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	String getModuleName() throws TskCoreException;
+	String getAcquisitionToolName() throws TskCoreException;
 
 	/**
-	 * Gets the module version field from the case database.
+	 * Gets the acquisition tool version field from the case database.
 	 *
-	 * @return The module version details
+	 * @return The acquisition tool version. May be Null if not set. 
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	String getModuleVersion() throws TskCoreException;
+	String getAcquisitionToolVersion() throws TskCoreException;
 
 	/**
 	 * Gets the added date field from the case database.

--- a/bindings/java/src/org/sleuthkit/datamodel/Image.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Image.java
@@ -528,51 +528,51 @@ public class Image extends AbstractContent implements DataSource {
 	}
 
 	/**
-	 * Sets the acquisition settings used as well as module name and module version.
+	 * Sets the acquisition tool details such as its name, version number and
+	 * any settings used during the acquisition tool to acquire data.
 	 *
-	 * @param acquisitionSettings Any settings specific to the acquisition. May
-	 *                            be Null.
-	 * @param moduleName          The module name. May be Null
-	 * @param moduleVersion       The module's version number. May be Null.
+	 * @param name     The name of the acquisition tool. May be NULL.
+	 * @param version  The acquisition tool version number. May be NULL.
+	 * @param settings The settings used by the acquisition tool. May be NULL.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override
-	public void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
-		getSleuthkitCase().setAcquisitionSettings(this, acquisitionSettings, moduleName, moduleVersion);
+	public void setAcquisitionToolDetails(String name, String version, String settings) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionToolDetails(this, name, version, settings);
 	}
 
 	/**
-	 * Gets the acquisition settings field from the case database.
+	 * Gets the acquisition tool settings field from the case database.
 	 *
-	 * @return The acquisition settings
+	 * @return The acquisition tool settings. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	public String getAcquisitionSettings() throws TskCoreException {
-		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_settings");
+	public String getAcquisitionToolSettings() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_tool_settings");
 	}
 
 	/**
-	 * Gets the module name field from the case database.
+	 * Gets the acquisition tool name field from the case database.
 	 *
-	 * @return The module name
+	 * @return The acquisition tool name. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	public String getModuleName() throws TskCoreException {
-		return getSleuthkitCase().getDataSourceInfoString(this, "module_name");
+	public String getAcquisitionToolName() throws TskCoreException{
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_tool_name");
 	}
 
 	/**
-	 * Gets the module version field from the case database.
+	 * Gets the acquisition tool version field from the case database.
 	 *
-	 * @return The module version details
+	 * @return The acquisition tool version. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	public String getModuleVersion() throws TskCoreException {
-		return getSleuthkitCase().getDataSourceInfoString(this, "module_version");
+	public String getAcquisitionToolVersion() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_tool_version");
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/Image.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Image.java
@@ -514,12 +514,22 @@ public class Image extends AbstractContent implements DataSource {
 
 		return contentSize;
 	}
-	
+
 	/**
-	 * Sets the acquisition details along with any settings used as well as
-	 * module name and module version.
+	 * Sets the acquisition details field in the case database.
 	 *
-	 * @param details             The acquisition details
+	 * @param details The acquisition details
+	 *
+	 * @throws TskCoreException Thrown if the data can not be written
+	 */
+	@Override
+	public void setAcquisitionDetails(String details) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionDetails(this, details);
+	}
+
+	/**
+	 * Sets the acquisition settings used as well as module name and module version.
+	 *
 	 * @param acquisitionSettings Any settings specific to the acquisition. May
 	 *                            be Null.
 	 * @param moduleName          The module name. May be Null
@@ -528,10 +538,54 @@ public class Image extends AbstractContent implements DataSource {
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override
-	public void setAcquisitionDetails(String details, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
-		getSleuthkitCase().setAcquisitionDetails(this, details, acquisitionSettings, moduleName, moduleVersion);
+	public void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionSettings(this, acquisitionSettings, moduleName, moduleVersion);
 	}
-	
+
+	/**
+	 * Gets the acquisition settings field from the case database.
+	 *
+	 * @return The acquisition settings
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public String getAcquisitionSettings() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_settings");
+	}
+
+	/**
+	 * Gets the module name field from the case database.
+	 *
+	 * @return The module name
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public String getModuleName() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "module_name");
+	}
+
+	/**
+	 * Gets the module version field from the case database.
+	 *
+	 * @return The module version details
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public String getModuleVersion() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "module_version");
+	}
+
+	/**
+	 * Gets the added date field from the case database.
+	 *
+	 * @return The date time when the image was added in epoch seconds.
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public Long getDateAdded() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoLong(this, "added_date_time");
+	}
+
 	/**
 	 * Gets the acquisition details field from the case database.
 	 * 

--- a/bindings/java/src/org/sleuthkit/datamodel/Image.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Image.java
@@ -516,15 +516,20 @@ public class Image extends AbstractContent implements DataSource {
 	}
 	
 	/**
-	 * Sets the acquisition details field in the case database.
-	 * 
-	 * @param details The acquisition details
-	 * 
+	 * Sets the acquisition details along with any settings used as well as
+	 * module name and module version.
+	 *
+	 * @param details             The acquisition details
+	 * @param acquisitionSettings Any settings specific to the acquisition. May
+	 *                            be Null.
+	 * @param moduleName          The module name. May be Null
+	 * @param moduleVersion       The module's version number. May be Null.
+	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override
-	public void setAcquisitionDetails(String details) throws TskCoreException {
-		getSleuthkitCase().setAcquisitionDetails(this, details);
+	public void setAcquisitionDetails(String details, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionDetails(this, details, acquisitionSettings, moduleName, moduleVersion);
 	}
 	
 	/**
@@ -538,6 +543,23 @@ public class Image extends AbstractContent implements DataSource {
 	public String getAcquisitionDetails() throws TskCoreException {
 		return getSleuthkitCase().getAcquisitionDetails(this);
 	}	
+
+	/**
+	 * Updates the image's total size and sector size.This function may be used
+	 * to update the sizes after the image was created.
+	 *
+	 * Can only update the sizes if they were not set before. Will throw
+	 * TskCoreException if the values in the db are not 0 prior to this call.
+	 *
+	 * @param totalSize  The total size
+	 * @param sectorSize The sector size
+	 *
+	 * @throws TskCoreException Thrown if the values were not 0 in DB
+	 *
+	 */
+	public void setSizes(long totalSize, long sectorSize) throws TskCoreException {
+		getSleuthkitCase().setImageSizes(this, totalSize, sectorSize);
+	}
 
 	/**
 	 * Close a ResultSet.

--- a/bindings/java/src/org/sleuthkit/datamodel/Image.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Image.java
@@ -519,7 +519,7 @@ public class Image extends AbstractContent implements DataSource {
 	 * Sets the acquisition details field in the case database.
 	 *
 	 * @param details The acquisition details
-	 *
+	 * 
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override

--- a/bindings/java/src/org/sleuthkit/datamodel/Image.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Image.java
@@ -608,7 +608,7 @@ public class Image extends AbstractContent implements DataSource {
 	 * @param totalSize  The total size
 	 * @param sectorSize The sector size
 	 *
-	 * @throws TskCoreException Thrown if the values were not 0 in DB
+	 * @throws TskCoreException If there is an error updating the case database.
 	 *
 	 */
 	public void setSizes(long totalSize, long sectorSize) throws TskCoreException {

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
@@ -182,10 +182,20 @@ public class LocalFilesDataSource extends VirtualDirectory implements DataSource
 	}
 
 	/**
-	 * Sets the acquisition details along with any settings used as well as
-	 * module name and module version.
+	 * Sets the acquisition details field in the case database.
 	 *
-	 * @param details             The acquisition details
+	 * @param details The acquisition details
+	 *
+	 * @throws TskCoreException Thrown if the data can not be written
+	 */
+	@Override
+	public void setAcquisitionDetails(String details) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionDetails(this, details);
+	}
+
+	/**
+	 * Sets the acquisition settings used as well as module name and module version.
+	 *
 	 * @param acquisitionSettings Any settings specific to the acquisition. May
 	 *                            be Null.
 	 * @param moduleName          The module name. May be Null
@@ -194,10 +204,10 @@ public class LocalFilesDataSource extends VirtualDirectory implements DataSource
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override
-	public void setAcquisitionDetails(String details, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
-		getSleuthkitCase().setAcquisitionDetails(this, details, acquisitionSettings, moduleName, moduleVersion);
+	public void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionSettings(this, acquisitionSettings, moduleName, moduleVersion);
 	}
-
+  
 	/**
 	 * Gets the acquisition details field from the case database.
 	 * 

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
@@ -194,18 +194,18 @@ public class LocalFilesDataSource extends VirtualDirectory implements DataSource
 	}
 
 	/**
-	 * Sets the acquisition settings used as well as module name and module version.
+	 * Sets the acquisition tool details such as its name, version number and
+	 * any settings used during the acquisition tool to acquire data.
 	 *
-	 * @param acquisitionSettings Any settings specific to the acquisition. May
-	 *                            be Null.
-	 * @param moduleName          The module name. May be Null
-	 * @param moduleVersion       The module's version number. May be Null.
+	 * @param name     The name of the acquisition tool. May be NULL.
+	 * @param version  The acquisition tool version number. May be NULL.
+	 * @param settings The settings used by the acquisition tool. May be NULL.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override
-	public void setAcquisitionSettings(String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
-		getSleuthkitCase().setAcquisitionSettings(this, acquisitionSettings, moduleName, moduleVersion);
+	public void setAcquisitionToolDetails(String name, String version, String settings) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionToolDetails(this, name, version, settings);
 	}
   
 	/**
@@ -222,36 +222,37 @@ public class LocalFilesDataSource extends VirtualDirectory implements DataSource
 
 
 	/**
-	 * Gets the acquisition settings field from the case database.
+	 * Gets the acquisition tool settings field from the case database.
 	 *
-	 * @return The acquisition settings
+	 * @return The acquisition tool settings. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	public String getAcquisitionSettings() throws TskCoreException {
-		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_settings");
+	@Override
+	public String getAcquisitionToolSettings() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_tool_settings");
 	}
 
 	/**
-	 * Gets the module name field from the case database.
+	 * Gets the acquisition tool name field from the case database.
 	 *
-	 * @return The module name
+	 * @return The acquisition tool name. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	public String getModuleName() throws TskCoreException {
-		return getSleuthkitCase().getDataSourceInfoString(this, "module_name");
+	public String getAcquisitionToolName() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_tool_name");
 	}
 
 	/**
-	 * Gets the module version field from the case database.
+	 * Gets the acquisition tool version field from the case database.
 	 *
-	 * @return The module version details
+	 * @return The acquisition tool version. May be Null if not set.
 	 *
 	 * @throws TskCoreException Thrown if the data can not be read
 	 */
-	public String getModuleVersion() throws TskCoreException {
-		return getSleuthkitCase().getDataSourceInfoString(this, "module_version");
+	public String getAcquisitionToolVersion() throws TskCoreException{
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_tool_version");
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
@@ -180,19 +180,24 @@ public class LocalFilesDataSource extends VirtualDirectory implements DataSource
 
 		return contentSize;
 	}
-	
+
 	/**
-	 * Sets the acquisition details field in the case database.
-	 * 
-	 * @param details The acquisition details
-	 * 
+	 * Sets the acquisition details along with any settings used as well as
+	 * module name and module version.
+	 *
+	 * @param details             The acquisition details
+	 * @param acquisitionSettings Any settings specific to the acquisition. May
+	 *                            be Null.
+	 * @param moduleName          The module name. May be Null
+	 * @param moduleVersion       The module's version number. May be Null.
+	 *
 	 * @throws TskCoreException Thrown if the data can not be written
 	 */
 	@Override
-	public void setAcquisitionDetails(String details) throws TskCoreException {
-		getSleuthkitCase().setAcquisitionDetails(this, details);
+	public void setAcquisitionDetails(String details, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
+		getSleuthkitCase().setAcquisitionDetails(this, details, acquisitionSettings, moduleName, moduleVersion);
 	}
-	
+
 	/**
 	 * Gets the acquisition details field from the case database.
 	 * 

--- a/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LocalFilesDataSource.java
@@ -220,6 +220,51 @@ public class LocalFilesDataSource extends VirtualDirectory implements DataSource
 		return getSleuthkitCase().getAcquisitionDetails(this);
 	}
 
+
+	/**
+	 * Gets the acquisition settings field from the case database.
+	 *
+	 * @return The acquisition settings
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public String getAcquisitionSettings() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "acquisition_settings");
+	}
+
+	/**
+	 * Gets the module name field from the case database.
+	 *
+	 * @return The module name
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public String getModuleName() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "module_name");
+	}
+
+	/**
+	 * Gets the module version field from the case database.
+	 *
+	 * @return The module version details
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public String getModuleVersion() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoString(this, "module_version");
+	}
+
+	/**
+	 * Gets the added date field from the case database.
+	 *
+	 * @return The date time when the image was added in epoch seconds.
+	 *
+	 * @throws TskCoreException Thrown if the data can not be read
+	 */
+	public Long getDateAdded() throws TskCoreException {
+		return getSleuthkitCase().getDataSourceInfoLong(this, "added_date_time");
+	}
+
 	/**
 	 * Close a ResultSet.
 	 *

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -2232,9 +2232,9 @@ public class SleuthkitCase {
 				dateDataType = "INTEGER";
 			}
 			statement.execute("ALTER TABLE data_source_info ADD COLUMN added_date_time "+ dateDataType);
-			statement.execute("ALTER TABLE data_source_info ADD COLUMN acquisition_settings TEXT");
-			statement.execute("ALTER TABLE data_source_info ADD COLUMN module_name TEXT");
-			statement.execute("ALTER TABLE data_source_info ADD COLUMN module_version TEXT");
+			statement.execute("ALTER TABLE data_source_info ADD COLUMN acquisition_tool_settings TEXT");
+			statement.execute("ALTER TABLE data_source_info ADD COLUMN acquisition_tool_name TEXT");
+			statement.execute("ALTER TABLE data_source_info ADD COLUMN acquisition_tool_version TEXT");
 
 			return new CaseDbSchemaVersionNumber(8, 7);
 
@@ -9632,29 +9632,29 @@ public class SleuthkitCase {
 		}
 	}
 
+
 	/**
-	 * Set the acquisition settings used as well as module name and
-	 * module version in the data_source_info table
+	 * Sets the acquisition tool details such as its name, version number and
+	 * any settings used during the acquisition tool to acquire data.
 	 *
-	 * @param details             The acquisition details
-	 * @param acquisitionSettings Any settings specific to the acquisition. May
-	 *                            be Null.
-	 * @param moduleName          The module name. May be Null
-	 * @param moduleVersion       The module's version number. May be Null.
+	 * @param datasource The datasource object
+	 * @param name       The name of the acquisition tool. May be NULL.
+	 * @param version    The acquisition tool version number. May be NULL.
+	 * @param settings   The settings used by the acquisition tool. May be NULL.
 	 *
 	 * @throws TskCoreException Thrown if the database write fails
 	 */
-	void setAcquisitionSettings(DataSource datasource, String acquisitionSettings, String moduleName, String moduleVersion) throws TskCoreException {
+	void setAcquisitionToolDetails(DataSource datasource, String name, String version, String settings) throws TskCoreException {
 
 		long id = datasource.getId();
 		CaseDbConnection connection = connections.getConnection();
 		acquireSingleUserCaseWriteLock();
 		try {
-			PreparedStatement statement = connection.getPreparedStatement(PREPARED_STATEMENT.UPDATE_ACQUISITION_SETTINGS);
+			PreparedStatement statement = connection.getPreparedStatement(PREPARED_STATEMENT.UPDATE_ACQUISITION_TOOL_SETTINGS);
 			statement.clearParameters();
-			statement.setString(1, acquisitionSettings);
-			statement.setString(2, moduleName);
-			statement.setString(3, moduleVersion);
+			statement.setString(1, settings);
+			statement.setString(2, name);
+			statement.setString(3, version);
 			statement.setLong(4, id);
 			connection.executeUpdate(statement);
 		} catch (SQLException ex) {
@@ -9738,7 +9738,7 @@ public class SleuthkitCase {
 		ResultSet rs = null;
 		String returnValue = "";
 		try {
-			PreparedStatement statement = connection.getPreparedStatement(PREPARED_STATEMENT.SELECT_DATASOURCE_INFO_DETAILS);
+			PreparedStatement statement = connection.getPreparedStatement(PREPARED_STATEMENT.SELECT_ACQUISITION_TOOL_SETTINGS);
 			statement.clearParameters();
 			statement.setLong(1, id);
 			rs = connection.executeQuery(statement);
@@ -9771,7 +9771,7 @@ public class SleuthkitCase {
 		ResultSet rs = null;
 		Long returnValue = null;
 		try {
-			PreparedStatement statement = connection.getPreparedStatement(PREPARED_STATEMENT.SELECT_DATASOURCE_INFO_DETAILS);
+			PreparedStatement statement = connection.getPreparedStatement(PREPARED_STATEMENT.SELECT_ACQUISITION_TOOL_SETTINGS);
 			statement.clearParameters();
 			statement.setLong(1, id);
 			rs = connection.executeQuery(statement);
@@ -11459,9 +11459,9 @@ public class SleuthkitCase {
 		SELECT_IMAGE_SHA1("SELECT sha1 FROM tsk_image_info WHERE obj_id = ?"), //NON-NLS
 		SELECT_IMAGE_SHA256("SELECT sha256 FROM tsk_image_info WHERE obj_id = ?"), //NON-NLS
 		UPDATE_ACQUISITION_DETAILS("UPDATE data_source_info SET acquisition_details = ? WHERE obj_id = ?"), //NON-NLS
-		UPDATE_ACQUISITION_SETTINGS("UPDATE data_source_info SET acquisition_settings = ?, module_name = ?, module_version = ? WHERE obj_id = ?"), //NON-NLS
+		UPDATE_ACQUISITION_TOOL_SETTINGS("UPDATE data_source_info SET acquisition_tool_settings = ?, acquisition_tool_name = ?, acquisition_tool_version = ? WHERE obj_id = ?"), //NON-NLS
 		SELECT_ACQUISITION_DETAILS("SELECT acquisition_details FROM data_source_info WHERE obj_id = ?"), //NON-NLS
-		SELECT_DATASOURCE_INFO_DETAILS("SELECT acquisition_settings, module_name, module_version, added_date_time FROM data_source_info WHERE obj_id = ?"), //NON-NLS
+		SELECT_ACQUISITION_TOOL_SETTINGS("SELECT acquisition_tool_settings, acquisition_tool_name, acquisition_tool_version, added_date_time FROM data_source_info WHERE obj_id = ?"), //NON-NLS
 		SELECT_LOCAL_PATH_FOR_FILE("SELECT path FROM tsk_files_path WHERE obj_id = ?"), //NON-NLS
 		SELECT_ENCODING_FOR_FILE("SELECT encoding_type FROM tsk_files_path WHERE obj_id = ?"), // NON-NLS
 		SELECT_LOCAL_PATH_AND_ENCODING_FOR_FILE("SELECT path, encoding_type FROM tsk_files_path WHERE obj_id = ?"), // NON_NLS

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -9327,14 +9327,11 @@ public class SleuthkitCase {
 	 * @param totalSize  The total size
 	 * @param sectorSize The sector size
 	 *
-	 * @throws TskCoreException Thrown if the values were not 0 in DB
+	 * @throws TskCoreException If there is an error updating the case database.
 	 *
 	 */
 	void setImageSizes(Image image, long totalSize, long sectorSize) throws TskCoreException {
 
-		if (image.getSize() > 0 || image.getSsize() > 0) {
-			throw new TskCoreException(String.format("Error updating image sizes for object ID %d. Cannot update non-zero total size (%d) or sector size (%d)",image.getId(), image.getSize(), image.getSsize()));
-		}
 		acquireSingleUserCaseWriteLock();
 		try (CaseDbConnection connection = connections.getConnection();) {
 			PreparedStatement preparedStatement = connection.getPreparedStatement(SleuthkitCase.PREPARED_STATEMENT.UPDATE_IMAGE_SIZES);

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -9719,6 +9719,14 @@ public class SleuthkitCase {
 		}
 	}
 
+	/**
+	 * Get String value from the provided column from data_source_info table. 
+	 * 
+	 * @param datasource The datasource
+	 * @param columnName The column from which the data should be returned 
+	 * @return String value from the column 
+	 * @throws TskCoreException 
+	 */
 	String getDataSourceInfoString(DataSource datasource, String columnName) throws TskCoreException {
 		long id = datasource.getId();
 		CaseDbConnection connection = connections.getConnection();
@@ -9743,6 +9751,15 @@ public class SleuthkitCase {
 		}
 	}
 
+
+	/**
+	 * Get Long value from the provided column from data_source_info table.
+	 *
+	 * @param datasource The datasource
+	 * @param columnName The column from which the data should be returned
+	 * @return Long value from the column
+	 * @throws TskCoreException
+	 */
 	Long getDataSourceInfoLong(DataSource datasource, String columnName) throws TskCoreException {
 		long id = datasource.getId();
 		CaseDbConnection connection = connections.getConnection();


### PR DESCRIPTION
Following new APIs have been introduced in **`DataSource`** 
- `void setAcquisitionToolDetails(DataSource datasource, String name, String version, String settings) throws TskCoreException `
- `String getAcquisitionToolSettings() throws TskCoreException;`
- `String getAcquisitionToolName() throws TskCoreException;`
- `String getAcquisitionToolVersion() throws TskCoreException;` 
- `Long getDateAdded() throws TskCoreException;`

**`Image`** and **`LocalFilesDataSource`** both have the same implementation that calls the API in **`SleuthkitCase`**

**`SleuthkitCase`**
- `Long getDataSourceInfoLong(DataSource datasource, String columnName) throws TskCoreException`
- `String getDataSourceInfoString(DataSource datasource, String columnName) throws TskCoreException `
I am not thrilled about these two new functions. I created them to reduce the code duplication and several new getters in SleuthkitCase class. Ideally, we'd want to update the Image constructor. However, `g/setAcquisitionDetails` apis follow a similar load/set on-demand model. 

@rcordovano @bcarrier Can you guys please review

