### PR TITLE
fix memoryleak error found by oss-fuzz

### DIFF
--- a/tsk/vs/dos.c
+++ b/tsk/vs/dos.c
@@ -769,6 +769,7 @@ dos_load_ext_table(TSK_VS_INFO * vs, TSK_DADDR_T sect_cur,
                     tsk_error_set_errno(TSK_ERR_VS_BLK_NUM);
                     tsk_error_set_errstr
                         ("dos_load_ext_table: Loop in partition table detected");
+                    free(sect_buf);
                     return 1;
                 }
                 part_info = part_info->next;


### PR DESCRIPTION
issue #2096
/tsk/vs/dos.c line772
exit function dos_load_ext_table() without free sect_buf

This issue has been fixed in openEuler community， welcome to join us
【fuzz】内存泄漏 
https://gitee.com/open_euler/dashboard/issues?id=I27WZN
https://gitee.com/src-openeuler/sleuthkit/pulls/5