### PR TITLE
7063 - Discovery Bug Fix

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardAttribute.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardAttribute.java
@@ -555,11 +555,10 @@ public class BlackboardAttribute {
 					}
 				} catch (TskException ex) {
 					LOGGER.log(Level.WARNING, "Could not get timezone for image", ex); //NON-NLS
-					// return time string in default timezone
-					return TimeUtilities.epochToTime(getValueLong());
 				}
+				// return time string in default timezone
+				return TimeUtilities.epochToTime(getValueLong());
 			}
-			break;
 			case JSON: {
 				return getValueString();
 			}


### PR DESCRIPTION
The attribute `getDisplayString()` switch for type DATETIME does not return a value when the parent data source has no timezone. Given that the default timezone is used when a TskCoreException is encountered (trying to access the parent), I believe the correct behavior should be to format the DATETIME value with the default timezone for both the error case and for when the parent data source does not have a timezone. 