### PR TITLE
fix Memory leak in ext2fs_inode_walk() and unix_make_data_run_indirect()

### DIFF
--- a/tsk/fs/unix_misc.c
+++ b/tsk/fs/unix_misc.c
@@ -180,6 +180,7 @@ unix_make_data_run_indirect(TSK_FS_INFO * fs, TSK_FS_ATTR * fs_attr,
             }
             tsk_error_set_errstr2("unix_make_data_run_indir: Block %"
                 PRIuDADDR, addr);
+            free(data_run);
             return -1;
         }
     }


### PR DESCRIPTION
i find that code exit the ext2fs_inode_walk() without cleanup fs_file,
exit unix_make_data_run_indirect() without cleanup data_run.