### PR TITLE
7206-Negative-seek-offset-exception-hashing-large-.tar-file

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/HashUtility.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HashUtility.java
@@ -62,7 +62,7 @@ public class HashUtility {
 		byte[] data = new byte[BUFFER_SIZE];
 		int totalChunks = (int) Math.ceil((double) content.getSize() / (double) BUFFER_SIZE);
 		int read;
-		for (int i = 0; i < totalChunks; i++) {
+		for (long i = 0; i < totalChunks; i++) {
 			try {
 				read = content.read(data, i * BUFFER_SIZE, BUFFER_SIZE);
 			} catch (TskCoreException ex) {


### PR DESCRIPTION
Change from int to long so when math is done a few lines down it will convert the result to long instead of int as the number happens to be bigger then the maximum value of an integer and going negative.