### PR TITLE
fix of possible memory overflow. 

### DIFF
--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -290,7 +290,7 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     if (fbuf[strlen(fbuf) - 1] != '/')
         strncat(fbuf, "/", PATH_MAX - strlen(fbuf)-1);
 
-    strncat(fbuf, a_fs_file->name->name, PATH_MAX - strlen(fbuf));
+    strncat(fbuf, a_fs_file->name->name, PATH_MAX - strlen(fbuf)-1);
     
     //do name mangling of the file name that was just added
     for (int i = strlen(fbuf)-1; fbuf[i] != '/'; i--) {

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -288,7 +288,7 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     }
 
     if (fbuf[strlen(fbuf) - 1] != '/')
-        strncat(fbuf, "/", PATH_MAX - strlen(fbuf));
+        strncat(fbuf, "/", PATH_MAX - strlen(fbuf)-1);
 
     strncat(fbuf, a_fs_file->name->name, PATH_MAX - strlen(fbuf));
     

--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -801,7 +801,7 @@ tsk_fs_dir_walk_lcl(TSK_FS_INFO * a_fs, DENT_DINFO * a_dinfo,
                 strncpy(a_dinfo->didx[a_dinfo->depth],
                     fs_file->name->name,
                     DIR_STRSZ - strlen(a_dinfo->dirs));
-                strncat(a_dinfo->dirs, "/", DIR_STRSZ);
+                strncat(a_dinfo->dirs, "/", DIR_STRSZ-1);
                 depth_added = 1;
                 a_dinfo->depth++;
 


### PR DESCRIPTION
according to the standard, the third parameter of the strncat function is not the size of the buffer, but the number of bytes that can be placed in the buffer without a terminating character.
https://en.cppreference.com/w/c/string/byte/strncat
```
 Appends at most count characters from the character array pointed to by src, stopping if the null character is found, to the end of the null-terminated byte string pointed to by dest. The character src [0] replaces the null terminator at the end of dest. The terminating null character is always appended in the end (so the maximum number of bytes the function may write is count + 1).
```