### PR TITLE
HostAddress api updates 

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
@@ -360,7 +360,7 @@ public class HostAddressManager {
 	public void addHostNameAndIpMapping(HostAddress dnsNameAddress, HostAddress ipAddress, Long time, Content source, final SleuthkitCase.CaseDbTransaction caseDbTransaction) throws TskCoreException {
 
 		if (Objects.isNull(caseDbTransaction)) {
-			throw new IllegalArgumentException("null caseDbTransaction passed to addAttributes");
+			throw new IllegalArgumentException("null caseDbTransaction passed to addHostNameAndIpMapping");
 		}
 		try {
 			addHostNameAndIpMapping(dnsNameAddress, ipAddress, time, source, caseDbTransaction.getConnection());
@@ -470,7 +470,7 @@ public class HostAddressManager {
 	 */
 	public Optional<Long> existsHostAddress(HostAddress.HostAddressType type, String address) throws TskCoreException {
 		
-		long id = recenHostAddresstCache.getIfPresent(type.getId()+"#"+address.toLowerCase());
+		Long id = recenHostAddresstCache.getIfPresent(type.getId()+"#"+address.toLowerCase());
 		if(Objects.nonNull(id)){
 			return Optional.of(id);
 		}

--- a/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/HostAddressManager.java
@@ -389,7 +389,7 @@ public class HostAddressManager {
 			throw new IllegalArgumentException("An IPv4/IPv6 address is expected.");
 		}
 		if (Objects.isNull(connection)) {
-			throw new IllegalArgumentException("null caseDbTransaction passed to addHostNameToIpMapping");
+			throw new IllegalArgumentException("null connection passed to addHostNameAndIpMapping");
 		}
 
 		String insertSQL = db.getInsertOrIgnoreSQL(" INTO tsk_host_address_dns_ip_map(dns_address_id, ip_address_id, source_obj_id, time) "

--- a/bindings/java/test/org/sleuthkit/datamodel/OsAccountTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/OsAccountTest.java
@@ -202,8 +202,8 @@ public class OsAccountTest {
 		assertEquals(hostAddrs.size() == 1, true);
 		
 		// Test IP mapping
-		caseDB.getHostAddressManager().addHostNameToIpMapping(hostAddr, ipv4addr, (long) 0, ds);
-		List<HostAddress> ipForHostSet = caseDB.getHostAddressManager().getIp(hostAddr.getAddress());
+		caseDB.getHostAddressManager().addHostNameAndIpMapping(hostAddr, ipv4addr, (long) 0, ds);
+		List<HostAddress> ipForHostSet = caseDB.getHostAddressManager().getIpAddress(hostAddr.getAddress());
 		assertEquals(ipForHostSet.size() == 1, true);
 		List<HostAddress> hostForIpSet = caseDB.getHostAddressManager().getHostNameByIp(ipv4addr.getAddress());
 		assertEquals(hostForIpSet.size() == 1, true);


### PR DESCRIPTION
## New API 
`Optional<long> existsHostAddress(HostAddress.HostAddressType type, String address) throws TskCoreException `

Returns ObjId of HostAddress if it exists. 

`boolean existsHostNameAndIpMapping(long addr) throws TskCoreException `

Returns true if addr is used as either IP or host name

## Rename API 
`addHostNameToIpMapping` to `addHostNameAndIpMapping` because 'To' seems to imply too much directionality  


## Performance 
Both exists methods could have a Guava cache that is populated by:
- Calls to exists
- Calls to 'add' or 'get' methods