### PR TITLE
Fix OOB read in raw.c

### DIFF
--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -239,7 +239,7 @@ raw_read_segment(IMG_RAW_INFO * raw_info, int idx, char *buf,
         // the number of bytes read
         if (sector_aligned_buf != NULL) {
             memcpy(buf, sector_aligned_buf + rel_offset % raw_info->img_info.sector_size, len);
-            cnt = cnt - offset_to_read % raw_info->img_info.sector_size;
+            cnt = cnt - rel_offset % raw_info->img_info.sector_size;
             if (cnt < 0) {
                 cnt = -1;
             }


### PR DESCRIPTION
In raw.c, the return value of raw_read_segment in calculated incorrectly if the offset is not aligned and TSK is reading from a windows device, causing the cache to be corrupted (it contains the wrong sizes for the cache), which leads to an out-of-bound read later
The fix it to calculate the return value correctly in this case