### PR TITLE
4279: Out of memory error when adding/updating accounts

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -1044,8 +1044,8 @@ public final class OsAccountManager {
 			} finally {
 				db.releaseSingleUserCaseWriteLock();
 			}
+			// set the atrribute list in account to the most current list from the database
 			List<OsAccountAttribute> currentAttribsList = getOsAccountAttributes(account);
-			currentAttribsList.addAll(accountAttributes);
 			account.setAttributesInternal(currentAttribsList);
 		}
 		fireChangeEvent(account);


### PR DESCRIPTION
Since we switched to replacing the entire attributes list in OsAccount with the most current list from the database, there's no need to append the recently added attributes to that list, they are already in there.