### PR TITLE
Assign correct device block size in HFS

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -6532,14 +6532,8 @@ hfs_open(TSK_IMG_INFO * img_info, TSK_OFF_T offset,
     fs->block_count = tsk_getu32(fs->endian, hfs->fs->blk_cnt);
     fs->first_block = 0;
     fs->last_block = fs->last_block_act = fs->block_count - 1;
-
-    /* this isn't really accurate; fs->block_size reports only the size
-       of the allocation block; the size of the device block has to be
-       found from the device (allocation block size should always be
-       larger than device block size and an even multiple of the device
-       block size) */
-    fs->dev_bsize = fs->block_size =
-        tsk_getu32(fs->endian, hfs->fs->blk_sz);
+	fs->block_size = tsk_getu32(fs->endian, hfs->fs->blk_sz);
+	fs->dev_bsize = fs->img_info->sector_size;
 
     // determine the last block we have in this image
     if (fs->block_size <= 1) {


### PR DESCRIPTION
Use TSK_IMG_INFO::sector_size, as this may differ from block_size.
All other filesystems use this value 

Closes #2436 