### PR TITLE
Put image type cases in the order defined by their enum

### DIFF
--- a/tsk/img/img_open.cpp
+++ b/tsk/img/img_open.cpp
@@ -230,18 +230,6 @@ tsk_img_open(int num_img,
         return NULL;
     }
 
-#if HAVE_LIBVHDI
-    case TSK_IMG_TYPE_VHD_VHD:
-        img_info = vhdi_open(num_img, images, a_ssize);
-        break;
-#endif
-
-#if HAVE_LIBVMDK
-    case TSK_IMG_TYPE_VMDK_VMDK:
-        img_info = vmdk_open(num_img, images, a_ssize);
-        break;
-#endif
-
     case TSK_IMG_TYPE_RAW:
         img_info = raw_open(num_img, images, a_ssize);
         break;
@@ -258,6 +246,18 @@ tsk_img_open(int num_img,
 #if HAVE_LIBEWF
     case TSK_IMG_TYPE_EWF_EWF:
         img_info = ewf_open(num_img, images, a_ssize);
+        break;
+#endif
+
+#if HAVE_LIBVMDK
+    case TSK_IMG_TYPE_VMDK_VMDK:
+        img_info = vmdk_open(num_img, images, a_ssize);
+        break;
+#endif
+
+#if HAVE_LIBVHDI
+    case TSK_IMG_TYPE_VHD_VHD:
+        img_info = vhdi_open(num_img, images, a_ssize);
         break;
 #endif
 


### PR DESCRIPTION
Type cases should be in the same order as defined in the enum, for best efficiency.