### PR TITLE
Fix leaks of EWF, VMDK, VHD handles; leak of EWF image array; free image filename array uniformly

### DIFF
--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -217,11 +217,6 @@ aff_close(TSK_IMG_INFO * img_info)
     int i;
     IMG_AFF_INFO *aff_info = (IMG_AFF_INFO *) img_info;
     af_close(aff_info->af_file);
-	for (i = 0; i < img_info->num_img; i++) {
-		if (img_info->images[i])
-			free(img_info->images[i]);
-	}
-	free(img_info->images);
     tsk_img_free(aff_info);
 }
 
@@ -290,24 +285,15 @@ aff_open(const TSK_TCHAR * const images[], unsigned int a_ssize)
     img_info->close = aff_close;
     img_info->imgstat = aff_imgstat;
 
-    // Save the image path in TSK_IMG_INFO - this is mostly for consistency with the other
-    // image types and is not currently used
-    img_info->num_img = 1;
-    img_info->images =
-        (TSK_TCHAR **)tsk_malloc(sizeof(TSK_TCHAR *) * img_info->num_img);
-    if (img_info->images == NULL) {
+    // Save the image path in TSK_IMG_INFO - this is mostly for consistency
+    // with the other image types and is not currently used
+
+    // a_num_img should be 1
+    if (!tsk_img_copy_image_names(img_info, a_images, a_num_img)) {
+        tsk_img_free(aff_info);
         free(image);
         return NULL;
     }
-    size_t len = TSTRLEN(images[0]);
-    img_info->images[0] =
-        (TSK_TCHAR *)tsk_malloc(sizeof(TSK_TCHAR) * (len + 1));
-    if (img_info->images[0] == NULL) {
-        free(img_info->images);
-        free(image);
-        return NULL;
-    }
-    TSTRNCPY(img_info->images[0], images[0], len + 1);
 
     img_info->sector_size = 512;
     if (a_ssize)

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -222,8 +222,18 @@ aff_close(TSK_IMG_INFO * img_info)
 
 
 TSK_IMG_INFO *
-aff_open(const TSK_TCHAR * const images[], unsigned int a_ssize)
+aff_open(int a_num_img, const TSK_TCHAR * const images[], unsigned int a_ssize)
 {
+    if (a_num_img != 1) {
+        tsk_error_set_errstr("aff_open file: %" PRIttocTSK
+            ": expected one image filename, was given %d", a_images[0], a_num_img);
+
+        if (tsk_verbose != 0) {
+            tsk_fprintf(stderr, "aff requires exactly 1 image filename for opening\n");
+        }
+        return NULL;
+    }
+
     IMG_AFF_INFO *aff_info;
     TSK_IMG_INFO *img_info;
     int type;

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -278,6 +278,7 @@ aff_open(const TSK_TCHAR * const images[], unsigned int a_ssize)
         NULL) {
         goto on_error;
     }
+    aff_info->af_file = NULL;
 
     img_info = (TSK_IMG_INFO *) aff_info;
     img_info->read = aff_read;
@@ -359,6 +360,9 @@ aff_open(const TSK_TCHAR * const images[], unsigned int a_ssize)
 
 on_error:
     free(image);
+    if (af_file) {
+        af_close(aff_info->af_file);
+    }
     tsk_img_free(aff_info);
     return NULL;
 }

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -228,7 +228,7 @@ aff_open(int a_num_img, const TSK_TCHAR * const images[], unsigned int a_ssize)
         tsk_error_set_errstr("aff_open file: %" PRIttocTSK
             ": expected one image filename, was given %d", a_images[0], a_num_img);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "aff requires exactly 1 image filename for opening\n");
         }
         return NULL;

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -126,13 +126,11 @@ ewf_glob_free(IMG_EWF_INFO* ewf_info) {
     // @@@ Probably a memory leak in v1 unless libewf_close deals with it
     if (ewf_info->used_ewf_glob != 0) {
 #if defined ( HAVE_LIBEWF_V2_API)
-        libewf_error_t *error = NULL;
 #ifdef TSK_WIN32
-        libewf_glob_wide_free(ewf_info->img_info.images, ewf_info->img_info.num_img, &error);
+        libewf_glob_wide_free(ewf_info->img_info.images, ewf_info->img_info.num_img, NULL);
 #else
-        libewf_glob_free(ewf_info->img_info.images, ewf_info->img_info.num_img, &error);
+        libewf_glob_free(ewf_info->img_info.images, ewf_info->img_info.num_img, NULL);
 #endif
-        libewf_error_free(&error);
 #endif
         // ensure that tsk_img_free() does not double free images
         ewf_info->img_info.images = NULL;

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -343,6 +343,7 @@ ewf_open(int a_num_img,
         tsk_error_set_errstr("ewf_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
 
+        libewf_handle_free(&(ewf_info->handle), NULL);
         tsk_img_free(ewf_info);
 
         if (tsk_verbose != 0) {
@@ -360,6 +361,7 @@ ewf_open(int a_num_img,
             ": Error getting size of image (%s)", a_images[0],
             error_string);
 
+        libewf_handle_free(&(ewf_info->handle), NULL);
         tsk_img_free(ewf_info);
 
         if (tsk_verbose != 0) {
@@ -379,6 +381,7 @@ ewf_open(int a_num_img,
             ": Error getting MD5 of image (%s)", a_images[0],
             error_string);
 
+        libewf_handle_free(&(ewf_info->handle), NULL);
         tsk_img_free(ewf_info);
 
         if (tsk_verbose != 0) {

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -115,7 +115,6 @@ ewf_image_imgstat(TSK_IMG_INFO * img_info, FILE * hFile)
     if (ewf_info->md5hash_isset == 1) {
         tsk_fprintf(hFile, "MD5 hash of data:\t%s\n", ewf_info->md5hash);
     }
-    return;
 }
 
 static void

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -302,7 +302,7 @@ ewf_open(int a_num_img,
         tsk_error_set_errstr("ewf_open: Not an EWF file (%s)",
             error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Not an EWF file\n");
         }
         goto on_error;
@@ -316,7 +316,7 @@ ewf_open(int a_num_img,
         tsk_error_set_errstr("ewf_open file: %" PRIttocTSK
             ": Error initializing handle (%s)", a_images[0], error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Unable to create EWF handle\n");
         }
         goto on_error;
@@ -339,7 +339,7 @@ ewf_open(int a_num_img,
         tsk_error_set_errstr("ewf_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error opening EWF file\n");
         }
         goto on_error;
@@ -356,7 +356,7 @@ ewf_open(int a_num_img,
 
         libewf_handle_close(ewf_info->handle, NULL);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error getting size of EWF file\n");
         }
         goto on_error;
@@ -375,7 +375,7 @@ ewf_open(int a_num_img,
 
         libewf_handle_close(ewf_info->handle, NULL);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error getting MD5 of EWF file\n");
         }
         goto on_error;
@@ -397,7 +397,7 @@ ewf_open(int a_num_img,
 
         tsk_img_free(ewf_info);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error getting SHA1 of EWF file\n");
         }
         return NULL;
@@ -439,7 +439,7 @@ ewf_open(int a_num_img,
         tsk_error_set_errstr("ewf_open file: %" PRIttocTSK
             ": Error opening", ewf_info->img_info.images[0]);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error opening EWF file\n");
         }
         goto on_error;

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -324,7 +324,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Not an EWF file\n");
         }
-        return (NULL);
+        return NULL;
     }
 
     if (libewf_handle_initialize(&(ewf_info->handle), &ewf_error) != 1) {
@@ -341,7 +341,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Unable to create EWF handle\n");
         }
-        return (NULL);
+        return NULL;
     }
 #if defined( TSK_WIN32 )
     is_error = (libewf_handle_open_wide(ewf_info->handle,
@@ -367,7 +367,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error opening EWF file\n");
         }
-        return (NULL);
+        return NULL;
     }
     if (libewf_handle_get_media_size(ewf_info->handle,
             (size64_t *) & (img_info->size), &ewf_error) != 1) {
@@ -385,7 +385,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error getting size of EWF file\n");
         }
-        return (NULL);
+        return NULL;
     }
     result = libewf_handle_get_utf8_hash_value_md5(ewf_info->handle,
         (uint8_t *) ewf_info->md5hash, 33, &ewf_error);
@@ -405,7 +405,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error getting MD5 of EWF file\n");
         }
-        return (NULL);
+        return NULL;
     }
     ewf_info->md5hash_isset = result;
 
@@ -471,7 +471,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error opening EWF file\n");
         }
-        return (NULL);
+        return NULL;
     }
 #if defined( LIBEWF_STRING_DIGEST_HASH_LENGTH_MD5 )
     // 2007 version
@@ -491,7 +491,7 @@ ewf_open(int a_num_img,
         if (tsk_verbose) {
             tsk_fprintf(stderr, "Error getting size of EWF file\n");
         }
-        return (NULL);
+        return NULL;
     }
     if (libewf_get_md5_hash(ewf_info->handle, md5_hash, 16) == 1) {
         int md5_string_iterator = 0;
@@ -565,7 +565,7 @@ ewf_open(int a_num_img,
     // initialize the read lock
     tsk_init_lock(&(ewf_info->read_lock));
 
-    return (img_info);
+    return img_info;
 }
 
 

--- a/tsk/img/img_open.cpp
+++ b/tsk/img/img_open.cpp
@@ -560,8 +560,32 @@ tsk_img_open_utf16(int num_img,
 }
 #endif
 
+void tsk_img_free_image_names(TSK_IMG_INFO* img_info) {
+    for (int i = img_info->num_img - 1; i >= 0; --i) {
+        free(img_info->images[i]);
+    }
+    free(img_info->images);
+    img_info->images = NULL;
+    img_info->num_img = 0;
+}
 
+int tsk_img_copy_image_names(TSK_IMG_INFO* img_info, const TSK_TCHAR* const images[], int num) {
+    if (!(img_info->images = (TSK_TCHAR**) tsk_malloc(num * sizeof(TSK_TCHAR*)))) {
+        return 0;
+    }
+    img_info->num_img = num;
+    memset(img_info->images, 0, sizeof(num * sizeof(TSK_TCHAR*)));
 
+    for (int i = 0; i < num; ++i) {
+        const size_t len = TSTRLEN(images[i]);
+        if (!(img_info->images[i] = (TSK_TCHAR*) tsk_malloc((len+1)*sizeof(TSK_TCHAR)))) {
+            tsk_img_free_image_names(img_info);
+            return 0;
+        }
+        TSTRNCPY(img_info->images[i], images[i], len + 1);
+    }
+    return 1;
+}
 
 /**
  * \ingroup imglib
@@ -576,4 +600,30 @@ tsk_img_close(TSK_IMG_INFO * a_img_info)
     }
     tsk_deinit_lock(&(a_img_info->cache_lock));
     a_img_info->close(a_img_info);
+}
+
+/* tsk_img_malloc - tsk_malloc, then set image tag
+ * This is for img module and all its inheritances
+ */
+void *
+tsk_img_malloc(size_t a_len)
+{
+    TSK_IMG_INFO *imgInfo;
+    if ((imgInfo = (TSK_IMG_INFO *) tsk_malloc(a_len)) == NULL)
+        return NULL;
+    imgInfo->tag = TSK_IMG_INFO_TAG;
+    return (void *) imgInfo;
+}
+
+
+/* tsk_img_free - unset image tag, then free memory
+ * This is for img module and all its inheritances
+ */
+void
+tsk_img_free(void *a_ptr)
+{
+    TSK_IMG_INFO *imgInfo = (TSK_IMG_INFO *) a_ptr;
+    imgInfo->tag = 0;
+    tsk_img_free_image_names(imgInfo);
+    free(imgInfo);
 }

--- a/tsk/img/img_open.cpp
+++ b/tsk/img/img_open.cpp
@@ -92,6 +92,13 @@ tsk_img_open(int num_img,
         return NULL;
     }
 
+    if (num_img < 0) {
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_IMG_ARG);
+        tsk_error_set_errstr("number of images is negative (%d)", num_img);
+        return NULL;
+    }
+
     if ((a_ssize > 0) && (a_ssize < 512)) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_ARG);
@@ -131,7 +138,7 @@ tsk_img_open(int num_img,
 
         /* Try the non-raw formats first */
 #if HAVE_LIBAFFLIB
-        if ((img_info = aff_open(images, a_ssize)) != NULL) {
+        if ((img_info = aff_open(num_img, images, a_ssize)) != NULL) {
             /* we don't allow the "ANY" when autodetect is used because
              * we only want to detect the tested formats. */
             if (img_info->itype == TSK_IMG_TYPE_AFF_ANY) {
@@ -244,7 +251,7 @@ tsk_img_open(int num_img,
     case TSK_IMG_TYPE_AFF_AFD:
     case TSK_IMG_TYPE_AFF_AFM:
     case TSK_IMG_TYPE_AFF_ANY:
-        img_info = aff_open(images, a_ssize);
+        img_info = aff_open(num_img, images, a_ssize);
         break;
 #endif
 

--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -656,28 +656,9 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
         }
     }
     else {
-        raw_info->img_info.num_img = a_num_img;
-        raw_info->img_info.images =
-            (TSK_TCHAR **) tsk_malloc(sizeof(TSK_TCHAR *) * a_num_img);
-        if (raw_info->img_info.images == NULL) {
+        if (!tsk_img_copy_image_names(img_info, a_images, a_num_img)) {
             tsk_img_free(raw_info);
             return NULL;
-        }
-
-        for (i = 0; i < raw_info->img_info.num_img; i++) {
-            size_t len = TSTRLEN(a_images[i]);
-            raw_info->img_info.images[i] =
-                (TSK_TCHAR *) tsk_malloc(sizeof(TSK_TCHAR) * (len + 1));
-            if (raw_info->img_info.images[i] == NULL) {
-                int j;
-                for (j = 0; j < i; j++) {
-                    free(raw_info->img_info.images[j]);
-                }
-                free(raw_info->img_info.images);
-                tsk_img_free(raw_info);
-                return NULL;
-            }
-            TSTRNCPY(raw_info->img_info.images[i], a_images[i], len + 1);
         }
     }
 
@@ -689,10 +670,6 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
                 "raw_open: file size is unknown in a segmented raw image\n");
         }
 
-        for (i = 0; i < raw_info->img_info.num_img; i++) {
-            free(raw_info->img_info.images[i]);
-        }
-        free(raw_info->img_info.images);
         tsk_img_free(raw_info);
         return NULL;
     }
@@ -700,10 +677,6 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
     /* initialize the split cache */
     raw_info->cptr = (int *) tsk_malloc(raw_info->img_info.num_img * sizeof(int));
     if (raw_info->cptr == NULL) {
-        for (i = 0; i < raw_info->img_info.num_img; i++) {
-            free(raw_info->img_info.images[i]);
-        }
-        free(raw_info->img_info.images);
         tsk_img_free(raw_info);
         return NULL;
     }
@@ -717,10 +690,6 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
         (TSK_OFF_T *) tsk_malloc(raw_info->img_info.num_img * sizeof(TSK_OFF_T));
     if (raw_info->max_off == NULL) {
         free(raw_info->cptr);
-        for (i = 0; i < raw_info->img_info.num_img; i++) {
-            free(raw_info->img_info.images[i]);
-        }
-        free(raw_info->img_info.images);
         tsk_img_free(raw_info);
         return NULL;
     }
@@ -749,10 +718,6 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
                 }
             }
             free(raw_info->cptr);
-            for (i = 0; i < raw_info->img_info.num_img; i++) {
-                free(raw_info->img_info.images[i]);
-            }
-            free(raw_info->img_info.images);
             tsk_img_free(raw_info);
             return NULL;
         }
@@ -770,30 +735,4 @@ raw_open(int a_num_img, const TSK_TCHAR * const a_images[],
     }
 
     return img_info;
-}
-
-
-/* tsk_img_malloc - tsk_malloc, then set image tag
- * This is for img module and all its inheritances
- */
-void *
-tsk_img_malloc(size_t a_len)
-{
-    TSK_IMG_INFO *imgInfo;
-    if ((imgInfo = (TSK_IMG_INFO *) tsk_malloc(a_len)) == NULL)
-        return NULL;
-    imgInfo->tag = TSK_IMG_INFO_TAG;
-    return (void *) imgInfo;
-}
-
-
-/* tsk_img_free - unset image tag, then free memory
- * This is for img module and all its inheritances
- */
-void
-tsk_img_free(void *a_ptr)
-{
-    TSK_IMG_INFO *imgInfo = (TSK_IMG_INFO *) a_ptr;
-    imgInfo->tag = 0;
-    free(imgInfo);
 }

--- a/tsk/img/raw.c
+++ b/tsk/img/raw.c
@@ -451,11 +451,8 @@ raw_close(TSK_IMG_INFO * img_info)
             close(raw_info->cache[i].fd);
 #endif
     }
-    for (i = 0; i < raw_info->img_info.num_img; i++) {
-        free(raw_info->img_info.images[i]);
-    }
+
     free(raw_info->max_off);
-    free(raw_info->img_info.images);
     free(raw_info->cptr);
 
     tsk_img_free(raw_info);

--- a/tsk/img/tsk_img_i.h
+++ b/tsk/img/tsk_img_i.h
@@ -37,6 +37,9 @@ extern "C" {
 #endif
 extern void *tsk_img_malloc(size_t);
 extern void tsk_img_free(void *);
+
+extern int tsk_img_copy_image_names(TSK_IMG_INFO* img_info, const TSK_TCHAR* const images[], int num);
+extern void tsk_img_free_image_names(TSK_IMG_INFO* img_info);
 extern TSK_TCHAR **tsk_img_findFiles(const TSK_TCHAR * a_startingName,
     int *a_numFound);
 

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -127,11 +127,6 @@ static void
         tsk_error_set_errstr("vhdi_image_close: unable to free handle - %s", errmsg);
     }
 
-    for (i = 0; i < vhdi_info->img_info.num_img; i++) {
-        free(vhdi_info->img_info.images[i]);
-    }
-    free(vhdi_info->img_info.images);
-
     tsk_deinit_lock(&(vhdi_info->read_lock));
     tsk_img_free(img_info);
 }
@@ -159,23 +154,11 @@ vhdi_open(int a_num_img,
     }
     vhdi_info->handle = NULL;
     img_info = (TSK_IMG_INFO *) vhdi_info;
- 
-    vhdi_info->img_info.num_img = a_num_img;
-    if ((vhdi_info->img_info.images =
-        (TSK_TCHAR **) tsk_malloc(a_num_img *
-        sizeof(TSK_TCHAR *))) == NULL) {
-            tsk_img_free(vhdi_info);
-            return NULL;
-    }
-    for (i = 0; i < a_num_img; i++) {
-        if ((vhdi_info->img_info.images[i] =
-            (TSK_TCHAR *) tsk_malloc((TSTRLEN(a_images[i]) +
-            1) * sizeof(TSK_TCHAR))) == NULL) {
-                tsk_img_free(vhdi_info);
-                return NULL;
-        }
-        TSTRNCPY(vhdi_info->img_info.images[i], a_images[i],
-            TSTRLEN(a_images[i]) + 1);
+
+    // a_num_img should be 1
+    if (!tsk_img_copy_image_names(img_info, a_images, a_num_img)) {
+        tsk_img_free(vhdi_info);
+        return NULL;
     }
 
     if (libvhdi_file_initialize(&(vhdi_info->handle), &vhdi_error) != 1) {

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -31,9 +31,8 @@ getError(libvhdi_error_t * vhdi_error,
     error_string[0] = '\0';
     retval = libvhdi_error_backtrace_sprint(vhdi_error,
         error_string, TSK_VHDI_ERROR_STRING_SIZE);
-    if (retval)
-        return 1;
-    return 0;
+    libvhdi_error_free(&vhdi_error);
+    return retval ? 1 : 0;
 } 
 
 
@@ -168,7 +167,6 @@ vhdi_open(int a_num_img,
         getError(vhdi_error, error_string);
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error initializing handle (%s)", a_images[0], error_string);
-        libvhdi_error_free(&vhdi_error);
 
         tsk_img_free(vhdi_info);
 
@@ -191,7 +189,6 @@ vhdi_open(int a_num_img,
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error checking file signature for image (%s)", a_images[0],
             error_string);
-        libvhdi_error_free(&vhdi_error);
 
         tsk_img_free(vhdi_info);
 
@@ -216,7 +213,6 @@ vhdi_open(int a_num_img,
         getError(vhdi_error, error_string);
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
-        libvhdi_error_free(&vhdi_error);
 
         tsk_img_free(vhdi_info);
 
@@ -234,7 +230,6 @@ vhdi_open(int a_num_img,
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error getting size of image (%s)", a_images[0],
             error_string);
-        libvhdi_error_free(&vhdi_error);
 
         tsk_img_free(vhdi_info);
 

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -137,7 +137,7 @@ vhdi_open(int a_num_img,
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": expected one image filename, was given %d", a_images[0], a_num_img);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "vhd requires exactly 1 image filename for opening\n");
         }
         return NULL;
@@ -175,7 +175,7 @@ vhdi_open(int a_num_img,
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error initializing handle (%s)", a_images[0], error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Unable to create vhdi handle\n");
         }
         goto on_error;
@@ -195,7 +195,7 @@ vhdi_open(int a_num_img,
             ": Error checking file signature for image (%s)", a_images[0],
             error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error checking file signature for vhd file\n");
         }
         goto on_error;
@@ -217,7 +217,7 @@ vhdi_open(int a_num_img,
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error opening vhdi file\n");
         }
         goto on_error;
@@ -232,7 +232,7 @@ vhdi_open(int a_num_img,
             ": Error getting size of image (%s)", a_images[0],
             error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error getting size of vhdi file\n");
         }
         goto on_error;

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -106,8 +106,7 @@ static void
     char *errmsg = NULL;
     IMG_VHDI_INFO *vhdi_info = (IMG_VHDI_INFO *) img_info;
 
-    if( libvhdi_file_close(vhdi_info->handle, &vhdi_error ) != 0 )
-    {
+    if (libvhdi_file_close(vhdi_info->handle, &vhdi_error ) != 0) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vhdi_error, error_string))
@@ -119,8 +118,7 @@ static void
     }
 
     libvhdi_file_free(&(vhdi_info->handle), NULL);
-    if( libvhdi_file_free(&(vhdi_info->handle), &vhdi_error ) != 1 )
-    {
+    if (libvhdi_file_free(&(vhdi_info->handle), &vhdi_error ) != 1) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vhdi_error, error_string))

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -114,8 +114,7 @@ static void
         tsk_error_set_errstr("vhdi_image_close: unable to close handle - %s", errmsg);
     }
 
-    libvhdi_file_free(&(vhdi_info->handle), NULL);
-    if (libvhdi_file_free(&(vhdi_info->handle), &vhdi_error ) != 1) {
+    if (libvhdi_file_free(&(vhdi_info->handle), &vhdi_error) != 1) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vhdi_error, error_string))

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -196,7 +196,7 @@ vhdi_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Unable to create vhdi handle\n");
         }
-        return (NULL);
+        return NULL;
     }
     // Check the file signature before we call the library open
 #if defined( TSK_WIN32 )
@@ -219,7 +219,7 @@ vhdi_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error checking file signature for vhd file\n");
         }
-        return (NULL);
+        return NULL;
     }
 #if defined( TSK_WIN32 )
     if (libvhdi_file_open_wide(vhdi_info->handle,
@@ -244,7 +244,7 @@ vhdi_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error opening vhdi file\n");
         }
-        return (NULL);
+        return NULL;
     }
     if (libvhdi_file_get_media_size(vhdi_info->handle,
             (size64_t *) & (img_info->size), &vhdi_error) != 1) {
@@ -262,7 +262,7 @@ vhdi_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error getting size of vhdi file\n");
         }
-        return (NULL);
+        return NULL;
     }
 
     if (a_ssize != 0) {
@@ -279,7 +279,7 @@ vhdi_open(int a_num_img,
     // initialize the read lock
     tsk_init_lock(&(vhdi_info->read_lock));
 
-    return (img_info);
+    return img_info;
 }
 
 #endif /* HAVE_LIBVHDI */

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -92,8 +92,6 @@ vhdi_image_imgstat(TSK_IMG_INFO * img_info, FILE * hFile)
     tsk_fprintf(hFile, "\nSize of data in bytes:\t%" PRIdOFF "\n",
         img_info->size);
     tsk_fprintf(hFile, "Sector size:\t%d\n", img_info->sector_size);
-
-    return;
 }
 
 

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -133,6 +133,16 @@ TSK_IMG_INFO *
 vhdi_open(int a_num_img,
     const TSK_TCHAR * const a_images[], unsigned int a_ssize)
 {
+    if (a_num_img != 1) {
+        tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
+            ": expected one image filename, was given %d", a_images[0], a_num_img);
+
+        if (tsk_verbose != 0) {
+            tsk_fprintf(stderr, "vhd requires exactly 1 image filename for opening\n");
+        }
+        return NULL;
+    }
+
     char error_string[TSK_VHDI_ERROR_STRING_SIZE];
     libvhdi_error_t *vhdi_error = NULL;
     int i;
@@ -153,7 +163,6 @@ vhdi_open(int a_num_img,
     vhdi_info->handle = NULL;
     img_info = (TSK_IMG_INFO *) vhdi_info;
 
-    // a_num_img should be 1
     if (!tsk_img_copy_image_names(img_info, a_images, a_num_img)) {
         goto on_error;
     }

--- a/tsk/img/vhd.c
+++ b/tsk/img/vhd.c
@@ -103,7 +103,7 @@ static void
     char *errmsg = NULL;
     IMG_VHDI_INFO *vhdi_info = (IMG_VHDI_INFO *) img_info;
 
-    if (libvhdi_file_close(vhdi_info->handle, &vhdi_error ) != 0) {
+    if (libvhdi_file_close(vhdi_info->handle, &vhdi_error) != 0) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vhdi_error, error_string))
@@ -189,6 +189,7 @@ vhdi_open(int a_num_img,
             ": Error checking file signature for image (%s)", a_images[0],
             error_string);
 
+        libvhdi_file_free(&(vhdi_info->handle), NULL);
         tsk_img_free(vhdi_info);
 
         if (tsk_verbose != 0) {
@@ -213,6 +214,7 @@ vhdi_open(int a_num_img,
         tsk_error_set_errstr("vhdi_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
 
+        libvhdi_file_free(&(vhdi_info->handle), NULL);
         tsk_img_free(vhdi_info);
 
         if (tsk_verbose != 0) {
@@ -230,6 +232,7 @@ vhdi_open(int a_num_img,
             ": Error getting size of image (%s)", a_images[0],
             error_string);
 
+        libvhdi_file_free(&(vhdi_info->handle), NULL);
         tsk_img_free(vhdi_info);
 
         if (tsk_verbose != 0) {

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -139,7 +139,7 @@ vmdk_open(int a_num_img,
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": expected one image filename, was given %d", a_images[0], a_num_img);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "vmdk requires exactly 1 image filename for opening\n");
         }
         return NULL;
@@ -177,7 +177,7 @@ vmdk_open(int a_num_img,
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error initializing handle (%s)", a_images[0], error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Unable to create vmdk handle\n");
         }
         goto on_error;
@@ -199,7 +199,7 @@ vmdk_open(int a_num_img,
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error opening vmdk file\n");
         }
         goto on_error;
@@ -214,7 +214,7 @@ vmdk_open(int a_num_img,
             ": Error opening extent data files for image (%s)", a_images[0],
             error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error opening vmdk extent data files\n");
         }
         goto on_error;
@@ -229,7 +229,7 @@ vmdk_open(int a_num_img,
             ": Error getting size of image (%s)", a_images[0],
             error_string);
 
-        if (tsk_verbose != 0) {
+        if (tsk_verbose) {
             tsk_fprintf(stderr, "Error getting size of vmdk file\n");
         }
         goto on_error;

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -196,7 +196,7 @@ vmdk_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Unable to create vmdk handle\n");
         }
-        return (NULL);
+        return NULL;
     }
 #if defined( TSK_WIN32 )
     if (libvmdk_handle_open_wide(vmdk_info->handle,
@@ -221,7 +221,7 @@ vmdk_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error opening vmdk file\n");
         }
-        return (NULL);
+        return NULL;
     }
     if( libvmdk_handle_open_extent_data_files(vmdk_info->handle, &vmdk_error ) != 1 )
 	{
@@ -239,7 +239,7 @@ vmdk_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error opening vmdk extent data files\n");
         }
-        return (NULL);
+        return NULL;
     }
     if (libvmdk_handle_get_media_size(vmdk_info->handle,
             (size64_t *) & (img_info->size), &vmdk_error) != 1) {
@@ -257,7 +257,7 @@ vmdk_open(int a_num_img,
         if (tsk_verbose != 0) {
             tsk_fprintf(stderr, "Error getting size of vmdk file\n");
         }
-        return (NULL);
+        return NULL;
     }
 
     if (a_ssize != 0) {
@@ -274,7 +274,7 @@ vmdk_open(int a_num_img,
     // initialize the read lock
     tsk_init_lock(&(vmdk_info->read_lock));
 
-    return (img_info);
+    return img_info;
 }
 
 #endif /* HAVE_LIBVMDK */

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -105,7 +105,7 @@ static void
     char *errmsg = NULL;
     IMG_VMDK_INFO *vmdk_info = (IMG_VMDK_INFO *) img_info;
 
-    if (libvmdk_handle_close(vmdk_info->handle, &vmdk_error ) != 0) {
+    if (libvmdk_handle_close(vmdk_info->handle, &vmdk_error) != 0) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vmdk_error, error_string))
@@ -193,6 +193,7 @@ vmdk_open(int a_num_img,
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
 
+        libvmdk_handle_free(&(vmdk_info->handle), NULL);
         tsk_img_free(vmdk_info);
 
         if (tsk_verbose != 0) {
@@ -210,6 +211,7 @@ vmdk_open(int a_num_img,
             ": Error opening extent data files for image (%s)", a_images[0],
             error_string);
 
+        libvmdk_handle_free(&(vmdk_info->handle), NULL);
         tsk_img_free(vmdk_info);
 
         if (tsk_verbose != 0) {
@@ -227,6 +229,7 @@ vmdk_open(int a_num_img,
             ": Error getting size of image (%s)", a_images[0],
             error_string);
 
+        libvmdk_handle_free(&(vmdk_info->handle), NULL);
         tsk_img_free(vmdk_info);
 
         if (tsk_verbose != 0) {

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -31,9 +31,8 @@ getError(libvmdk_error_t * vmdk_error,
     error_string[0] = '\0';
     retval = libvmdk_error_backtrace_sprint(vmdk_error,
         error_string, TSK_VMDK_ERROR_STRING_SIZE);
-    if (retval)
-        return 1;
-    return 0;
+    libvmdk_error_free(&vmdk_error);
+    return retval ? 1 : 0;
 } 
 
 
@@ -170,7 +169,6 @@ vmdk_open(int a_num_img,
         getError(vmdk_error, error_string);
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error initializing handle (%s)", a_images[0], error_string);
-        libvmdk_error_free(&vmdk_error);
 
         tsk_img_free(vmdk_info);
 
@@ -195,7 +193,6 @@ vmdk_open(int a_num_img,
         getError(vmdk_error, error_string);
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error opening (%s)", a_images[0], error_string);
-        libvmdk_error_free(&vmdk_error);
 
         tsk_img_free(vmdk_info);
 
@@ -213,7 +210,6 @@ vmdk_open(int a_num_img,
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error opening extent data files for image (%s)", a_images[0],
             error_string);
-        libvmdk_error_free(&vmdk_error);
 
         tsk_img_free(vmdk_info);
 
@@ -231,7 +227,6 @@ vmdk_open(int a_num_img,
         tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
             ": Error getting size of image (%s)", a_images[0],
             error_string);
-        libvmdk_error_free(&vmdk_error);
 
         tsk_img_free(vmdk_info);
 

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -116,8 +116,7 @@ static void
         tsk_error_set_errstr("vmdk_image_close: unable to close handle - %s", errmsg);
     }
 
-    libvmdk_handle_free(&(vmdk_info->handle), NULL);
-    if (libvmdk_handle_free(&(vmdk_info->handle), &vmdk_error ) != 1) {
+    if (libvmdk_handle_free(&(vmdk_info->handle), &vmdk_error) != 1) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vmdk_error, error_string))

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -106,8 +106,7 @@ static void
     char *errmsg = NULL;
     IMG_VMDK_INFO *vmdk_info = (IMG_VMDK_INFO *) img_info;
 
-    if( libvmdk_handle_close(vmdk_info->handle, &vmdk_error ) != 0 )
-    {
+    if (libvmdk_handle_close(vmdk_info->handle, &vmdk_error ) != 0) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vmdk_error, error_string))
@@ -119,8 +118,7 @@ static void
     }
 
     libvmdk_handle_free(&(vmdk_info->handle), NULL);
-    if( libvmdk_handle_free(&(vmdk_info->handle), &vmdk_error ) != 1 )
-    {
+    if (libvmdk_handle_free(&(vmdk_info->handle), &vmdk_error ) != 1) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_GENERIC);
         if (getError(vmdk_error, error_string))
@@ -223,8 +221,8 @@ vmdk_open(int a_num_img,
         }
         return NULL;
     }
-    if( libvmdk_handle_open_extent_data_files(vmdk_info->handle, &vmdk_error ) != 1 )
-	{
+
+    if (libvmdk_handle_open_extent_data_files(vmdk_info->handle, &vmdk_error) != 1) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_OPEN);
 

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -135,6 +135,16 @@ TSK_IMG_INFO *
 vmdk_open(int a_num_img,
     const TSK_TCHAR * const a_images[], unsigned int a_ssize)
 {
+    if (a_num_img != 1) {
+        tsk_error_set_errstr("vmdk_open file: %" PRIttocTSK
+            ": expected one image filename, was given %d", a_images[0], a_num_img);
+
+        if (tsk_verbose != 0) {
+            tsk_fprintf(stderr, "vmdk requires exactly 1 image filename for opening\n");
+        }
+        return NULL;
+    }
+
     char error_string[TSK_VMDK_ERROR_STRING_SIZE];
     libvmdk_error_t *vmdk_error = NULL;
     int i;
@@ -155,7 +165,6 @@ vmdk_open(int a_num_img,
     vmdk_info->handle = NULL;
     img_info = (TSK_IMG_INFO *) vmdk_info;
 
-    // a_num_img should be 1
     if (!tsk_img_copy_image_names(img_info, a_images, a_num_img)) {
         goto on_error;
     }

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -32,7 +32,7 @@ getError(libvmdk_error_t * vmdk_error,
     retval = libvmdk_error_backtrace_sprint(vmdk_error,
         error_string, TSK_VMDK_ERROR_STRING_SIZE);
     libvmdk_error_free(&vmdk_error);
-    return retval ? 1 : 0;
+    return retval != 0;
 } 
 
 

--- a/tsk/img/vmdk.c
+++ b/tsk/img/vmdk.c
@@ -99,7 +99,6 @@ vmdk_image_imgstat(TSK_IMG_INFO * img_info, FILE * hFile)
 static void
     vmdk_image_close(TSK_IMG_INFO * img_info)
 {
-    int i;
     char error_string[TSK_VMDK_ERROR_STRING_SIZE];
     libvmdk_error_t *vmdk_error = NULL;
     char *errmsg = NULL;
@@ -147,7 +146,6 @@ vmdk_open(int a_num_img,
 
     char error_string[TSK_VMDK_ERROR_STRING_SIZE];
     libvmdk_error_t *vmdk_error = NULL;
-    int i;
 
     IMG_VMDK_INFO *vmdk_info = NULL;
     TSK_IMG_INFO *img_info = NULL;


### PR DESCRIPTION
This PR fixes:

* leaks of EWF, VMDK, VHD handles when opening the images fails after the handles are initialized
* leak of the libewf image array and incorect nesting of an `#ifdef`

This PR also:

* adds sanity checks on the number of images passed to `tsk_img_open` 
* consolidates allocating and freeing the image filename array to prevent future leaks