### PR TITLE
Use calloc instead of malloc and memset in tsk_malloc

### DIFF
--- a/tsk/base/mymalloc.c
+++ b/tsk/base/mymalloc.c
@@ -34,9 +34,7 @@ tsk_malloc(size_t len)
         tsk_error_set_errno(TSK_ERR_AUX_MALLOC);
         tsk_error_set_errstr("tsk_malloc: %s (%" PRIuSIZE" requested)", strerror(errno), len);
     }
-    /*else {
-        memset(ptr, 0, len);
-    }*/
+
     return ptr;
 }
 

--- a/tsk/base/mymalloc.c
+++ b/tsk/base/mymalloc.c
@@ -29,14 +29,14 @@ tsk_malloc(size_t len)
 {
     void *ptr;
 
-    if ((ptr = malloc(len)) == 0) {
+    if ((ptr = calloc(len, 1)) == 0) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_AUX_MALLOC);
         tsk_error_set_errstr("tsk_malloc: %s (%" PRIuSIZE" requested)", strerror(errno), len);
     }
-    else {
+    /*else {
         memset(ptr, 0, len);
-    }
+    }*/
     return ptr;
 }
 


### PR DESCRIPTION
This is should be faster, as it allows the OS to optimize the allocation