### PR TITLE
Add support for identifying EFS-encrypted files on FAT volumes

### DIFF
--- a/tsk/fs/fatxxfs_dent.c
+++ b/tsk/fs/fatxxfs_dent.c
@@ -293,7 +293,7 @@ fatxxfs_dent_parse_buf(FATFS_INFO *fatfs, TSK_FS_DIR *a_fs_dir, char *buf,
                                 && (dir->name[0] == FATXXFS_SLOT_DELETED)) {
                                     name_ptr[a++] = '_';
                             }
-                            else if ((dir->lowercase & FATXXFS_CASE_LOWER_BASE)
+                            else if ((dir->ntbyte & FATXXFS_CASE_LOWER_BASE)
                                 && (dir->name[b] >= 'A')
                                 && (dir->name[b] <= 'Z')) {
                                     name_ptr[a++] = dir->name[b] + 32;
@@ -309,7 +309,7 @@ fatxxfs_dent_parse_buf(FATFS_INFO *fatfs, TSK_FS_DIR *a_fs_dir, char *buf,
                         (dir->ext[b] != 0x20)) {
                             if (b == 0)
                                 name_ptr[a++] = '.';
-                            if ((dir->lowercase & FATXXFS_CASE_LOWER_EXT) &&
+                            if ((dir->ntbyte & FATXXFS_CASE_LOWER_EXT) &&
                                 (dir->ext[b] >= 'A') && (dir->ext[b] <= 'Z'))
                                 name_ptr[a++] = dir->ext[b] + 32;
                             else

--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -177,7 +177,7 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
     else {
         // the basic test is only for the 'essential data'.
         if (a_do_basic_tests_only == 0) {
-            if (dentry->lowercase & ~(FATXXFS_CASE_LOWER_ALL)) {
+            if (dentry->ntbyte & ~(FATXXFS_CASE_LOWER_ALL)) {
                 if (tsk_verbose)
                     fprintf(stderr, "%s: lower case all\n", func_name);
                 return 0;
@@ -553,7 +553,7 @@ fatxxfs_dinode_copy(FATFS_INFO *a_fatfs, TSK_INUM_T a_inum,
             i++) {
             if ((i == 0) && (dentry->name[0] == FATXXFS_SLOT_DELETED))
                 fs_meta->name2->name[0] = '_';
-            else if ((dentry->lowercase & FATXXFS_CASE_LOWER_BASE) &&
+            else if ((dentry->ntbyte & FATXXFS_CASE_LOWER_BASE) &&
                 (dentry->name[i] >= 'A') && (dentry->name[i] <= 'Z'))
                 fs_meta->name2->name[i] = dentry->name[i] + 32;
             else
@@ -566,7 +566,7 @@ fatxxfs_dinode_copy(FATFS_INFO *a_fatfs, TSK_INUM_T a_inum,
             for (a = 0;
                 (a < 3) && (dentry->ext[a] != 0) && (dentry->ext[a] != ' ');
                 a++, i++) {
-                if ((dentry->lowercase & FATXXFS_CASE_LOWER_EXT)
+                if ((dentry->ntbyte & FATXXFS_CASE_LOWER_EXT)
                     && (dentry->ext[a] >= 'A') && (dentry->ext[a] <= 'Z'))
                     fs_meta->name2->name[i] = dentry->ext[a] + 32;
                 else
@@ -788,6 +788,12 @@ fatxxfs_istat_attr_flags(FATFS_INFO *a_fatfs, TSK_INUM_T a_inum, FILE *a_hFile)
             tsk_fprintf(a_hFile, ", System");
         if (dentry.attrib & FATFS_ATTR_ARCHIVE)
             tsk_fprintf(a_hFile, ", Archive");
+        if (dentry.ntbyte & FATXXFS_ENCRYPTED_DATA) {
+            tsk_fprintf(a_hFile, ", Encrypted");
+
+            if (dentry.ntbyte & FATXXFS_LARGE_EFS_HEADER)
+                tsk_fprintf(a_hFile, ", Large EFS Header");
+        }
 
         tsk_fprintf(a_hFile, "\n");
     }

--- a/tsk/fs/tsk_fatxxfs.h
+++ b/tsk/fs/tsk_fatxxfs.h
@@ -68,6 +68,7 @@
 #define FATXXFS_CASE_LOWER_ALL	 0x18    /* both are lower */
 #define FATXXFS_ENCRYPTED_DATA	 0x01    /* data is EFS-encrypted */
 #define FATXXFS_LARGE_EFS_HEADER 0x02    /* data has large EFS header (if not set, its size is 4096 bytes) */
+/* other bits are used to store the padding size */
 
 /* flags for seq field */
 #define FATXXFS_LFN_SEQ_FIRST	0x40    /* This bit is set for the first lfn entry */

--- a/tsk/fs/tsk_fatxxfs.h
+++ b/tsk/fs/tsk_fatxxfs.h
@@ -62,10 +62,12 @@
 #define FATXXFS_IS_83_EXT(c)		\
     (FATXXFS_IS_83_NAME((c)) && ((c) < 0x7f))
 
-/* flags for lowercase field */
-#define FATXXFS_CASE_LOWER_BASE	0x08    /* base is lower case */
-#define FATXXFS_CASE_LOWER_EXT	0x10    /* extension is lower case */
-#define FATXXFS_CASE_LOWER_ALL	0x18    /* both are lower */
+/* flags for ntbyte field */
+#define FATXXFS_CASE_LOWER_BASE	 0x08    /* base is lower case */
+#define FATXXFS_CASE_LOWER_EXT	 0x10    /* extension is lower case */
+#define FATXXFS_CASE_LOWER_ALL	 0x18    /* both are lower */
+#define FATXXFS_ENCRYPTED_DATA	 0x01    /* data is EFS-encrypted */
+#define FATXXFS_LARGE_EFS_HEADER 0x02    /* data has large EFS header (if not set, its size is 4096 bytes) */
 
 /* flags for seq field */
 #define FATXXFS_LFN_SEQ_FIRST	0x40    /* This bit is set for the first lfn entry */
@@ -139,7 +141,7 @@ extern "C" {
         uint8_t name[8];
         uint8_t ext[3];
         uint8_t attrib;
-        uint8_t lowercase;
+        uint8_t ntbyte;
         uint8_t ctimeten;       /* create times (ctimeten is 0-199) */
         uint8_t ctime[2];
         uint8_t cdate[2];


### PR DESCRIPTION
This will fix: https://github.com/sleuthkit/sleuthkit/issues/2615