### PR TITLE
CT-4851 (fix UTF-16 conversion)

### DIFF
--- a/rejistry++/msvcpp/Rejistry/Rejistry.vcxproj
+++ b/rejistry++/msvcpp/Rejistry/Rejistry.vcxproj
@@ -45,7 +45,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -66,14 +66,14 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_NoLibs|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>Windows7.1SDK</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -105,7 +105,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>rejistry++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -116,7 +116,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>rejistry++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -131,7 +131,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>rejistry++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -147,7 +147,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>rejistry++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -162,7 +162,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>rejistry++.lib;</AdditionalDependencies>
+      <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -177,7 +177,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>rejistry++.lib;</AdditionalDependencies>
+      <AdditionalDependencies>rejistry++.lib;$(TSK_HOME)\win32\x64\$(Configuration)\libtsk.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\$(Platform)\$(ConfigurationName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -580,18 +580,16 @@ tsk_cleanupUTF8(char *source, const char replacement)
  * @param replacement Character to insert into source as needed.
  */
 void
-tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, const wchar_t replacement) {
+tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, size_t wstrlen, const wchar_t replacement) {
 
-    size_t total_len = wcslen(source);
     size_t cur_idx = 0;
-    
-    while (cur_idx < total_len) {
+    while (cur_idx < wstrlen) {
         UTF32 ch = tsk_getu16(endian, (uint8_t *) &source[cur_idx]);
 
         /* If we have a surrogate pair, check out the high part. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-            if (cur_idx + 1 < total_len) {
+            if (cur_idx + 1 < wstrlen) {
                 UTF32 ch2 = tsk_getu16(endian, (uint8_t *) &source[cur_idx+1]);
                 
                 /* If it's a low surrogate, we're good. */

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -577,19 +577,20 @@ tsk_cleanupUTF8(char *source, const char replacement)
  * UTF-16 values with the passed in character.
  * @param endian Ordering that data is stored in
  * @param source String to be cleaned up
+ * @param source_len Number of wchar_t characters in source
  * @param replacement Character to insert into source as needed.
  */
 void
-tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, size_t wstrlen, const wchar_t replacement) {
+tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, size_t source_len, const wchar_t replacement) {
 
     size_t cur_idx = 0;
-    while (cur_idx < wstrlen) {
+    while (cur_idx < source_len) {
         UTF32 ch = tsk_getu16(endian, (uint8_t *) &source[cur_idx]);
 
         /* If we have a surrogate pair, check out the high part. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-            if (cur_idx + 1 < wstrlen) {
+            if (cur_idx + 1 < source_len) {
                 UTF32 ch2 = tsk_getu16(endian, (uint8_t *) &source[cur_idx+1]);
                 
                 /* If it's a low surrogate, we're good. */

--- a/tsk/base/tsk_unicode.h
+++ b/tsk/base/tsk_unicode.h
@@ -156,7 +156,7 @@ extern "C" {
         tsk_cleanupUTF8(char *source, const char replacement);
 
     extern void
-        tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, const wchar_t replacement);
+        tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, size_t wstrlen, const wchar_t replacement);
 #endif
 //@}
 

--- a/tsk/base/tsk_unicode.h
+++ b/tsk/base/tsk_unicode.h
@@ -156,7 +156,7 @@ extern "C" {
         tsk_cleanupUTF8(char *source, const char replacement);
 
     extern void
-        tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, size_t wstrlen, const wchar_t replacement);
+        tsk_cleanupUTF16(TSK_ENDIAN_ENUM endian, wchar_t *source, size_t source_len, const wchar_t replacement);
 #endif
 //@}
 


### PR DESCRIPTION
 - Sanatize UTF-16 data and replace invalid characters with the UTF-16 replace char
 - Cast data to wstring instead of using from_bytes()