### PR TITLE
Fixed OOB read in ntfs_make_data_run

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -630,7 +630,7 @@ ntfs_make_data_run(NTFS_INFO * ntfs, TSK_OFF_T start_vcn,
          * A length of more than eight bytes will not fit in the
          * 64-bit length field (and is likely corrupt)
          */
-        if (NTFS_RUNL_LENSZ(run) > 8) {
+        if (NTFS_RUNL_LENSZ(run) > 8 || NTFS_RUNL_LENSZ(run) > runlist_size - runlist_offset - 1) {
             tsk_error_reset();
             tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
             tsk_error_set_errstr


### PR DESCRIPTION
Merged changes into https://github.com/sleuthkit/sleuthkit/pull/2346