### PR TITLE
CT-4969: Incorrect Process user

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -1062,7 +1062,11 @@ public final class OsAccountManager {
 		}
 
 		// search by login name
-		return this.getOsAccountByLoginName(loginName, realm.get());
+		if (!Strings.isNullOrEmpty(loginName)) {
+			return this.getOsAccountByLoginName(loginName, realm.get());
+		} else {
+			return Optional.empty();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Incorrect user is matched/returned if loginName is empty.