### PR TITLE
Fix #2700: continue loop over next volumes if first volumes fail to open

### DIFF
--- a/tsk/auto/auto.cpp
+++ b/tsk/auto/auto.cpp
@@ -491,10 +491,6 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
                                 "findFilesInPool: Error opening APFS file system");
                             registerError();
                         }
-
-                        tsk_img_close(pool_img);
-                        tsk_pool_close(pool);
-                        return TSK_ERR;
                     }
 
                     tsk_img_close(pool_img);


### PR DESCRIPTION
Fix #2700: continue loop over next volumes if first volumes fail to open