### PR TITLE
Fix string format specifier warnings

### DIFF
--- a/tests/fs_thread_test.cpp
+++ b/tests/fs_thread_test.cpp
@@ -154,7 +154,7 @@ static const TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr, _TSK_T("Usage: %s [-f fstype ] [-o imgoffset ] [-v] image nthreads niters\n"), progname);
+    TFPRINTF(stderr, _TSK_T("Usage: " PRIttocTSK " [-f fstype ] [-o imgoffset ] [-v] image nthreads niters\n"), progname);
 
     exit(1);
 }
@@ -188,7 +188,7 @@ main(int argc, char** argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                         _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                         _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;

--- a/tools/autotools/tsk_comparedir.cpp
+++ b/tools/autotools/tsk_comparedir.cpp
@@ -37,7 +37,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-n start_inum] [-vV] image [image] comparison_directory\n"),
+        ("usage: " PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-n start_inum] [-vV] image [image] comparison_directory\n"),
         progname);
 
     tsk_fprintf(stderr,
@@ -371,7 +371,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
 
@@ -380,7 +380,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                          _TSK_T
-                         ("invalid argument: sector size must be positive: %s\n"),
+                         ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                          OPTARG);
                 usage();
             }
@@ -394,7 +394,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                         _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                         _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -407,7 +407,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                          OPTARG);
                 usage();
             }

--- a/tools/autotools/tsk_comparedir.cpp
+++ b/tools/autotools/tsk_comparedir.cpp
@@ -99,13 +99,13 @@ uint8_t
     hFind = FindFirstFile((LPCWSTR) fullpath, &ffd);
     DWORD err = GetLastError();
     if (hFind == INVALID_HANDLE_VALUE) {
-        fprintf(stderr, "Error opening directory: %S\n", fullpath);
+        fprintf(stderr, "Error opening directory: %ls\n", fullpath);
 
         wchar_t message[64];
         FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
             FORMAT_MESSAGE_IGNORE_INSERTS, NULL, err, 0,
             (LPWSTR) & message, 64, NULL);
-        fprintf(stderr, "error: %S", message);
+        fprintf(stderr, "error: %ls", message);
         return 1;
     }
 

--- a/tools/autotools/tsk_gettimes.cpp
+++ b/tools/autotools/tsk_gettimes.cpp
@@ -21,7 +21,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-vVm] [-i imgtype] [-b dev_sector_size] [-z zone] [-s seconds] image [image]\n"),
+        ("usage: " PRIttocTSK " [-vVm] [-i imgtype] [-b dev_sector_size] [-z zone] [-s seconds] image [image]\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
@@ -172,7 +172,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
 
@@ -182,7 +182,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -197,7 +197,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/autotools/tsk_loaddb.cpp
+++ b/tools/autotools/tsk_loaddb.cpp
@@ -20,7 +20,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-ahkvV] [-i imgtype] [-b dev_sector_size] [-d database] [-z ZONE] image [image]\n"),
+        ("usage: " PRIttocTSK " [-ahkvV] [-i imgtype] [-b dev_sector_size] [-d database] [-z ZONE] image [image]\n"),
         progname);
     tsk_fprintf(stderr, "\t-a: Add image to existing database, instead of creating a new one (requires -d to specify database)\n");
     tsk_fprintf(stderr, "\t-k: Don't create block data table\n");
@@ -72,7 +72,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
 
@@ -85,7 +85,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -98,7 +98,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -184,7 +184,7 @@ main(int argc, char **argv1)
         tsk_error_print(stderr);
         exit(1);
     }
-    TFPRINTF(stdout, _TSK_T("Database stored at: %s\n"), database);
+    TFPRINTF(stdout, _TSK_T("Database stored at: " PRIttocTSK "\n"), database);
 
     autoDb->closeImage();
     delete tskCase;

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -181,7 +181,7 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
                 result = CreateDirectoryW((LPCTSTR) path16full, NULL);
             if (result == FALSE) {
                 if (GetLastError() == ERROR_PATH_NOT_FOUND) {
-                    fprintf(stderr, "Error Creating Directory (%S)", path16full);
+                    fprintf(stderr, "Error Creating Directory (%ls)", path16full);
                     return 1;
                 }
             }
@@ -227,14 +227,14 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
         CreateFileW((LPCTSTR) path16full, GENERIC_WRITE, 0, NULL, OPEN_ALWAYS,
         FILE_ATTRIBUTE_NORMAL, NULL);
     if (handle == INVALID_HANDLE_VALUE) {
-        fprintf(stderr, "Error Creating File (%S)", path16full);
+        fprintf(stderr, "Error Creating File (%ls)", path16full);
         return 1;
     }
 
     //try to write to the file
     if (tsk_fs_file_walk(a_fs_file, (TSK_FS_FILE_WALK_FLAG_ENUM) 0,
             file_walk_cb, handle)) {
-        fprintf(stderr, "Error writing file %S\n", path16full);
+        fprintf(stderr, "Error writing file %ls\n", path16full);
         tsk_error_print(stderr);
         CloseHandle(handle);
         return 1;

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -21,7 +21,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-vVae] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-d dir_inum] image [image] output_dir\n"),
+        ("usage: " PRIttocTSK " [-vVae] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-d dir_inum] image [image] output_dir\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
@@ -442,7 +442,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
 
@@ -455,7 +455,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -464,7 +464,7 @@ main(int argc, char **argv1)
         case _TSK_T('d'):
             if (tsk_fs_parse_inum(OPTARG, &dirInum, NULL, NULL, NULL, NULL)) {
                 TFPRINTF(stderr,
-                        _TSK_T("invalid argument for directory inode: %s\n"),
+                        _TSK_T("invalid argument for directory inode: " PRIttocTSK "\n"),
                         OPTARG);
                 usage();
             }
@@ -484,7 +484,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                         _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                         _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -497,7 +497,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/blkcalc.cpp
+++ b/tools/fstools/blkcalc.cpp
@@ -31,7 +31,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-dsu unit_addr] [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images]\n"),
+        ("usage: " PRIttocTSK " [-dsu unit_addr] [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images]\n"),
         progname);
     tsk_fprintf(stderr, "Slowly calculates the opposite block number\n");
     tsk_fprintf(stderr, "\tOne of the following must be given:\n");

--- a/tools/fstools/blkcalc.cpp
+++ b/tools/fstools/blkcalc.cpp
@@ -103,7 +103,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
 
@@ -112,7 +112,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -122,7 +122,7 @@ main(int argc, char **argv1)
             type |= TSK_FS_BLKCALC_DD;
             count = TSTRTOULL(OPTARG, &cp, 0);
             if (*cp || *cp == *OPTARG) {
-                TFPRINTF(stderr, _TSK_T("Invalid address: %s\n"), OPTARG);
+                TFPRINTF(stderr, _TSK_T("Invalid address: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             set = 1;
@@ -136,7 +136,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -148,7 +148,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -185,7 +185,7 @@ main(int argc, char **argv1)
             type |= TSK_FS_BLKCALC_SLACK;
             count = TSTRTOULL(OPTARG, &cp, 0);
             if (*cp || *cp == *OPTARG) {
-                TFPRINTF(stderr, _TSK_T("Invalid address: %s\n"), OPTARG);
+                TFPRINTF(stderr, _TSK_T("Invalid address: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             set = 1;
@@ -195,7 +195,7 @@ main(int argc, char **argv1)
             type |= TSK_FS_BLKCALC_BLKLS;
             count = TSTRTOULL(OPTARG, &cp, 0);
             if (*cp || *cp == *OPTARG) {
-                TFPRINTF(stderr, _TSK_T("Invalid address: %s\n"), OPTARG);
+                TFPRINTF(stderr, _TSK_T("Invalid address: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             set = 1;

--- a/tools/fstools/blkcat.cpp
+++ b/tools/fstools/blkcat.cpp
@@ -32,7 +32,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-ahsvVw] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-u usize] image [images] unit_addr [num]\n"),
+        ("usage: " PRIttocTSK " [-ahsvVw] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-u usize] image [images] unit_addr [num]\n"),
         progname);
     tsk_fprintf(stderr, "\t-a: displays in all ASCII \n");
     tsk_fprintf(stderr, "\t-h: displays in hexdump-like fashion\n");

--- a/tools/fstools/blkcat.cpp
+++ b/tools/fstools/blkcat.cpp
@@ -111,7 +111,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -131,7 +131,7 @@ main(int argc, char **argv1)
             }
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -145,7 +145,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -180,7 +180,7 @@ main(int argc, char **argv1)
         case _TSK_T('u'):
             usize = TSTRTOUL(OPTARG, &cp, 0);
             if (*cp || cp == OPTARG) {
-                TFPRINTF(stderr, _TSK_T("Invalid block size: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Invalid block size: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -197,7 +197,7 @@ main(int argc, char **argv1)
             break;
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         }
@@ -254,7 +254,7 @@ main(int argc, char **argv1)
             /* Not a number, so it is the image name and we do not have a length */
             addr = TSTRTOULL(argv[argc - 1], &cp, 0);
             if (*cp || *cp == *argv[argc - 1]) {
-                TFPRINTF(stderr, _TSK_T("Invalid block address: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Invalid block address: " PRIttocTSK "\n"),
                     argv[argc - 1]);
                 usage();
             }
@@ -277,7 +277,7 @@ main(int argc, char **argv1)
             /* We got a number, so take the length as well while we are at it */
             read_num_units = TSTRTOULL(argv[argc - 1], &cp, 0);
             if (*cp || *cp == *argv[argc - 1]) {
-                TFPRINTF(stderr, _TSK_T("Invalid size: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Invalid size: " PRIttocTSK "\n"),
                     argv[argc - 1]);
                 usage();
             }

--- a/tools/fstools/blkls.cpp
+++ b/tools/fstools/blkls.cpp
@@ -35,7 +35,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-aAelvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] [start-stop]\n"),
+        ("usage: " PRIttocTSK " [-aAelvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] [start-stop]\n"),
         progname);
     tsk_fprintf(stderr, "\t-e: every block (including file system metadata blocks)\n");
     tsk_fprintf(stderr,
@@ -112,7 +112,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('a'):
@@ -128,7 +128,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -144,7 +144,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -155,7 +155,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/blkstat.cpp
+++ b/tools/fstools/blkstat.cpp
@@ -24,7 +24,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] addr\n"),
+        ("usage: " PRIttocTSK " [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] addr\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-f fstype: File system type (use '-f list' for supported types)\n");
@@ -88,7 +88,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -101,7 +101,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -112,7 +112,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -149,7 +149,7 @@ main(int argc, char **argv1)
             exit(0);
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         }

--- a/tools/fstools/fcat.cpp
+++ b/tools/fstools/fcat.cpp
@@ -20,7 +20,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-hRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] file_path image [images]\n"),
+        ("usage: " PRIttocTSK " [-hRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] file_path image [images]\n"),
         progname);
     tsk_fprintf(stderr, "\t-h: Do not display holes in sparse files\n");
     tsk_fprintf(stderr,
@@ -87,7 +87,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -95,7 +95,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -108,7 +108,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -122,7 +122,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/ffind.cpp
+++ b/tools/fstools/ffind.cpp
@@ -28,7 +28,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-aduvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] inode\n"),
+        ("usage: " PRIttocTSK " [-aduvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] inode\n"),
         progname);
     tsk_fprintf(stderr, "\t-a: Find all occurrences\n");
     tsk_fprintf(stderr, "\t-d: Find deleted entries ONLY\n");
@@ -102,7 +102,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -118,7 +118,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -129,7 +129,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -169,7 +169,7 @@ main(int argc, char **argv1)
             exit(0);
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         }
@@ -193,7 +193,7 @@ main(int argc, char **argv1)
     /* Get the inode */
     if (tsk_fs_parse_inum(argv[argc - 1], &inode, &type, &type_used, &id,
             &id_used)) {
-        TFPRINTF(stderr, _TSK_T("Invalid inode: %s\n"), argv[argc - 1]);
+        TFPRINTF(stderr, _TSK_T("Invalid inode: " PRIttocTSK "\n"), argv[argc - 1]);
         usage();
     }
 

--- a/tools/fstools/fls.cpp
+++ b/tools/fstools/fls.cpp
@@ -31,7 +31,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-adDFlhpruvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-m dir/] [-o imgoffset] [-z ZONE] [-s seconds] image [images] [inode]\n"),
+        ("usage: " PRIttocTSK " [-adDFlhpruvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-m dir/] [-o imgoffset] [-z ZONE] [-s seconds] image [images] [inode]\n"),
         progname);
     tsk_fprintf(stderr,
         "\tIf [inode] is not given, the root directory is used\n");
@@ -122,7 +122,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('a'):
@@ -133,7 +133,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -153,7 +153,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -168,7 +168,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -197,7 +197,7 @@ main(int argc, char **argv1)
             pooltype = tsk_pool_type_toid(OPTARG);
             if (pooltype == TSK_POOL_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported pool container type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported pool container type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;

--- a/tools/fstools/fscheck.cpp
+++ b/tools/fstools/fscheck.cpp
@@ -70,7 +70,7 @@ main(int argc, char **argv)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -83,7 +83,7 @@ main(int argc, char **argv)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -95,7 +95,7 @@ main(int argc, char **argv)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/fsstat.cpp
+++ b/tools/fstools/fsstat.cpp
@@ -22,7 +22,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-tvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n"),
+        ("usage: " PRIttocTSK " [-tvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n"),
         progname);
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,
@@ -83,7 +83,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -91,7 +91,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -104,7 +104,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -116,7 +116,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -141,7 +141,7 @@ main(int argc, char **argv1)
             pooltype = tsk_pool_type_toid(OPTARG);
             if (pooltype == TSK_POOL_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported pool container type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported pool container type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;

--- a/tools/fstools/icat.cpp
+++ b/tools/fstools/icat.cpp
@@ -34,7 +34,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-hrRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image [images] inum[-typ[-id]]\n"),
+        ("usage: " PRIttocTSK " [-hrRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image [images] inum[-typ[-id]]\n"),
         progname);
     tsk_fprintf(stderr, "\t-h: Do not display holes in sparse files\n");
     tsk_fprintf(stderr, "\t-r: Recover deleted file\n");
@@ -106,7 +106,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -114,7 +114,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -127,7 +127,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -141,7 +141,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -163,7 +163,7 @@ main(int argc, char **argv1)
             pooltype = tsk_pool_type_toid(OPTARG);
             if (pooltype == TSK_POOL_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported pool container type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported pool container type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -212,7 +212,7 @@ main(int argc, char **argv1)
     /* Get the inode address */
     if (tsk_fs_parse_inum(argv[argc - 1], &inum, &type, &type_used, &id,
             &id_used)) {
-        TFPRINTF(stderr, _TSK_T("Invalid inode address: %s\n"),
+        TFPRINTF(stderr, _TSK_T("Invalid inode address: " PRIttocTSK "\n"),
             argv[argc - 1]);
         usage();
     }

--- a/tools/fstools/ifind.cpp
+++ b/tools/fstools/ifind.cpp
@@ -31,7 +31,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-alvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-d unit_addr] [-n file] [-p par_addr] [-z ZONE] image [images]\n"),
+        ("usage: " PRIttocTSK " [-alvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-d unit_addr] [-n file] [-p par_addr] [-z ZONE] image [images]\n"),
         progname);
     tsk_fprintf(stderr, "\t-a: find all inodes\n");
     tsk_fprintf(stderr,
@@ -115,7 +115,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -129,7 +129,7 @@ main(int argc, char **argv1)
             type = IFIND_DATA;
             block = TSTRTOULL(OPTARG, &cp, 0);
             if (*cp || *cp == *OPTARG) {
-                TFPRINTF(stderr, _TSK_T("Invalid block address: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Invalid block address: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -142,7 +142,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -153,7 +153,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -211,7 +211,7 @@ main(int argc, char **argv1)
             type = IFIND_PARENT;
             if (tsk_fs_parse_inum(OPTARG, &parinode, NULL, NULL, NULL,
                     NULL)) {
-                TFPRINTF(stderr, _TSK_T("Invalid inode address: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Invalid inode address: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/ils.cpp
+++ b/tools/fstools/ils.cpp
@@ -34,7 +34,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-emOpvV] [-aAlLzZ] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-s seconds] image [images] [inum[-end]]\n"),
+        ("usage: " PRIttocTSK " [-emOpvV] [-aAlLzZ] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-s seconds] image [images] [inum[-end]]\n"),
         progname);
     tsk_fprintf(stderr, "\t-e: Display all inodes\n");
     tsk_fprintf(stderr, "\t-m: Display output in the mactime format\n");
@@ -118,7 +118,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -126,7 +126,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -139,7 +139,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -150,7 +150,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/istat.cpp
+++ b/tools/fstools/istat.cpp
@@ -31,7 +31,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-N num] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-z zone] [-s seconds] [-rvV] image inum\n"),
+        ("usage: " PRIttocTSK " [-N num] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-z zone] [-s seconds] [-rvV] image inum\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-N num: force the display of NUM address of block pointers\n");
@@ -104,7 +104,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('N'):
@@ -112,7 +112,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || numblock < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: block count must be positive: %s\n"),
+                    ("invalid argument: block count must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -122,7 +122,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -135,7 +135,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -149,7 +149,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -168,7 +168,7 @@ main(int argc, char **argv1)
             pooltype = tsk_pool_type_toid(OPTARG);
             if (pooltype == TSK_POOL_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported pool container type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported pool container type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -228,7 +228,7 @@ main(int argc, char **argv1)
      * This will make scripting easier
      */
     if (tsk_fs_parse_inum(argv[argc - 1], &inum, NULL, NULL, NULL, NULL)) {
-        TFPRINTF(stderr, _TSK_T("Invalid inode number: %s"),
+        TFPRINTF(stderr, _TSK_T("Invalid inode number: " PRIttocTSK),
             argv[argc - 1]);
         usage();
     }

--- a/tools/fstools/jcat.cpp
+++ b/tools/fstools/jcat.cpp
@@ -24,7 +24,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [images] [inode] blk\n"),
+        ("usage: " PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [images] [inode] blk\n"),
         progname);
     tsk_fprintf(stderr, "\tblk: The journal block to view\n");
     tsk_fprintf(stderr,
@@ -78,7 +78,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -86,7 +86,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -99,7 +99,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -110,7 +110,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -138,7 +138,7 @@ main(int argc, char **argv1)
 
     blk = TSTRTOULL(argv[argc - 1], &cp, 0);
     if (*cp || *cp == *argv[argc - 1]) {
-        TFPRINTF(stderr, _TSK_T("bad block number: %s"), argv[argc - 1]);
+        TFPRINTF(stderr, _TSK_T("bad block number: " PRIttocTSK), argv[argc - 1]);
         exit(1);
     }
 

--- a/tools/fstools/jls.cpp
+++ b/tools/fstools/jls.cpp
@@ -20,7 +20,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [inode]\n"),
+        ("usage: " PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [inode]\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
@@ -70,7 +70,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -78,7 +78,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -91,7 +91,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -102,7 +102,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/fstools/usnjls.cpp
+++ b/tools/fstools/usnjls.cpp
@@ -26,7 +26,7 @@ usage()
 {
     TFPRINTF(stderr,
              _TSK_T
-             ("usage: %s [-f fstype] [-i imgtype] [-b dev_sector_size]"
+             ("usage: " PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size]"
               " [-o imgoffset] [-lmvV] image [inode]\n"),
              progname);
     tsk_fprintf(stderr,
@@ -86,7 +86,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'): {
             default:
-                TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                          argv[OPTIND]);
                 usage();
         }
@@ -95,7 +95,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                          _TSK_T("invalid argument: sector size "
-                                "must be positive: %s\n"),
+                                "must be positive: " PRIttocTSK "\n"),
                          OPTARG);
                 usage();
             }
@@ -108,7 +108,7 @@ main(int argc, char **argv1)
             fstype = tsk_fs_type_toid(OPTARG);
             if (fstype == TSK_FS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                         _TSK_T("Unsupported file system type: %s\n"), OPTARG);
+                         _TSK_T("Unsupported file system type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -119,7 +119,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                          OPTARG);
                 usage();
             }

--- a/tools/hashtools/hfind.cpp
+++ b/tools/hashtools/hfind.cpp
@@ -24,7 +24,7 @@ usage()
 {
     TFPRINTF(stderr,
              _TSK_T
-             ("usage: %s [-eqVa] [-c] [-f lookup_file] [-i db_type] db_file [hashes]\n"),
+             ("usage: " PRIttocTSK " [-eqVa] [-c] [-f lookup_file] [-i db_type] db_file [hashes]\n"),
              progname);
     tsk_fprintf(stderr,
                 "\t-e: Extended mode - where values other than just the name are printed\n");
@@ -292,7 +292,7 @@ main(int argc, char ** argv1)
             if ((handle = CreateFile(lookup_file, GENERIC_READ,
                                      FILE_SHARE_READ, 0, OPEN_EXISTING, 0,
                                      0)) == INVALID_HANDLE_VALUE) {
-                TFPRINTF(stderr, _TSK_T("Error opening hash file: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Error opening hash file: " PRIttocTSK "\n"),
                          lookup_file);
                 exit(1);
             }

--- a/tools/imgtools/img_cat.cpp
+++ b/tools/imgtools/img_cat.cpp
@@ -21,7 +21,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-vV] [-i imgtype] [-b dev_sector_size] [-s start_sector] [-e stop_sector] image\n"),
+        ("usage: " PRIttocTSK " [-vV] [-i imgtype] [-b dev_sector_size] [-s start_sector] [-e stop_sector] image\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use 'i list' for supported types)\n");
@@ -68,7 +68,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -76,7 +76,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -88,7 +88,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -99,7 +99,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || start_sector < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: start sector must be positive: %s\n"),
+                    ("invalid argument: start sector must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -110,7 +110,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || end_sector < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: end sector must be positive: %s\n"),
+                    ("invalid argument: end sector must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -17,7 +17,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-tvV] [-i imgtype] [-b dev_sector_size] image\n"),
+        ("usage: " PRIttocTSK " [-tvV] [-i imgtype] [-b dev_sector_size] image\n"),
         progname);
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,

--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -59,7 +59,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -67,7 +67,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -79,7 +79,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/logicalimager/tsk_logical_imager.cpp
+++ b/tools/logicalimager/tsk_logical_imager.cpp
@@ -398,7 +398,7 @@ static void reportUsers(const std::string &sessionDir, const std::string &driveN
 static void usage() {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-c configPath]\n"),
+        ("usage: " PRIttocTSK " [-c configPath]\n"),
         progname);
     tsk_fprintf(stderr, "\t-c configPath: The configuration file. Default is logical-imager-config.json\n");
     tsk_fprintf(stderr, "\t-v: verbose output to stderr\n");
@@ -440,7 +440,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND-1]);
             usage();
 

--- a/tools/pooltools/pstat.cpp
+++ b/tools/pooltools/pstat.cpp
@@ -8,7 +8,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %s [-tvV] [-p pooltype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n"),
+        ("usage: " PRIttocTSK " [-tvV] [-p pooltype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n"),
         progname);
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,
@@ -57,7 +57,7 @@ main(int argc, char **argv1)
         switch (ch) {
         case _TSK_T('?'):
         default:
-            TFPRINTF(stderr, _TSK_T("Invalid argument: %s\n"),
+            TFPRINTF(stderr, _TSK_T("Invalid argument: " PRIttocTSK "\n"),
                 argv[OPTIND]);
             usage();
         case _TSK_T('b'):
@@ -65,7 +65,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -78,7 +78,7 @@ main(int argc, char **argv1)
             pooltype = tsk_pool_type_toid(OPTARG);
             if (pooltype == TSK_POOL_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported pool container type: %s\n"), OPTARG);
+                    _TSK_T("Unsupported pool container type: " PRIttocTSK "\n"), OPTARG);
                 usage();
             }
             break;
@@ -89,7 +89,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/vstools/mmcat.cpp
+++ b/tools/vstools/mmcat.cpp
@@ -22,7 +22,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("%s [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images] part_num\n"),
+        ("usage: " PRIttocTSK " [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images] part_num\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-t vstype: The type of partition system (use '-t list' for list of supported types)\n");
@@ -76,7 +76,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -88,7 +88,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -108,7 +108,7 @@ main(int argc, char **argv1)
             vstype = tsk_vs_type_toid(OPTARG);
             if (vstype == TSK_VS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported volume system type: %s\n"),
+                    _TSK_T("Unsupported volume system type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/vstools/mmls.cpp
+++ b/tools/vstools/mmls.cpp
@@ -24,7 +24,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("%s [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-BrvV] [-aAmM] [-t vstype] image [images]\n"),
+        ("usage: " PRIttocTSK " [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-BrvV] [-aAmM] [-t vstype] image [images]\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-t vstype: The type of volume system (use '-t list' for list of supported types)\n");
@@ -187,7 +187,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -199,7 +199,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -228,7 +228,7 @@ main(int argc, char **argv1)
             vstype = tsk_vs_type_toid(OPTARG);
             if (vstype == TSK_VS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported volume system type: %s\n"),
+                    _TSK_T("Unsupported volume system type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tools/vstools/mmstat.cpp
+++ b/tools/vstools/mmstat.cpp
@@ -19,7 +19,7 @@ usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("%s [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images]\n"),
+        ("usage: " PRIttocTSK " [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images]\n"),
         progname);
     tsk_fprintf(stderr,
         "\t-t vstype: The volume system type (use '-t list' for list of supported types)\n");
@@ -74,7 +74,7 @@ main(int argc, char **argv1)
             if (*cp || *cp == *OPTARG || ssize < 1) {
                 TFPRINTF(stderr,
                     _TSK_T
-                    ("invalid argument: sector size must be positive: %s\n"),
+                    ("invalid argument: sector size must be positive: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -86,7 +86,7 @@ main(int argc, char **argv1)
             }
             imgtype = tsk_img_type_toid(OPTARG);
             if (imgtype == TSK_IMG_TYPE_UNSUPP) {
-                TFPRINTF(stderr, _TSK_T("Unsupported image type: %s\n"),
+                TFPRINTF(stderr, _TSK_T("Unsupported image type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }
@@ -106,7 +106,7 @@ main(int argc, char **argv1)
             vstype = tsk_vs_type_toid(OPTARG);
             if (vstype == TSK_VS_TYPE_UNSUPP) {
                 TFPRINTF(stderr,
-                    _TSK_T("Unsupported volume system type: %s\n"),
+                    _TSK_T("Unsupported volume system type: " PRIttocTSK "\n"),
                     OPTARG);
                 usage();
             }

--- a/tsk/base/tsk_os.h
+++ b/tsk/base/tsk_os.h
@@ -160,9 +160,9 @@ typedef WCHAR TSK_TCHAR;        ///< Character data type that is UTF-16 (wchar_t
 #endif
 
 
-#define PRIcTSK _TSK_T("S")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
-#define PRIwTSK _TSK_T("s")     ///< sprintf macro to print a UTF-16 wchar_t string to TSK_TCHAR buffer
-#define PRIttocTSK  "S"         ///< printf macro to print a TSK_TCHAR string to stderr or other char device
+#define PRIcTSK _TSK_T("s")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
+#define PRIwTSK _TSK_T("ls")     ///< sprintf macro to print a UTF-16 wchar_t string to TSK_TCHAR buffer
+#define PRIttocTSK  "ls"         ///< printf macro to print a TSK_TCHAR string to stderr or other char device
 #define PRIuSIZE "Iu"           ///< printf macro to print a size_t value in Windows printf codes
 
 #define unlink _unlink
@@ -202,7 +202,7 @@ typedef char TSK_TCHAR;         ///< Character data type that is UTF-16 (wchar_t
 #define TZNAME	tzname
 
 #define PRIcTSK _TSK_T("s")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
-#define PRIwTSK _TSK_T("S")     ///< sprintf macro to print a UTF-16 wchar_t string to TSK_TCHAR buffer
+#define PRIwTSK _TSK_T("ls")     ///< sprintf macro to print a UTF-16 wchar_t string to TSK_TCHAR buffer
 #define PRIttocTSK  "s"         ///< printf macro to print a TSK_TCHAR string to stderr or other char device
 #define PRIuSIZE "zu"           ///< printf macro to print a size_t value in non-Windows printf codes
 

--- a/tsk/base/tsk_printf.c
+++ b/tsk/base/tsk_printf.c
@@ -92,7 +92,7 @@ tsk_fprintf(FILE * fd, const char *msg, ...)
     {
         WCHAR wbuf[2048];
         tsk_printf_conv(wbuf, 2048, msg, &args);
-        fwprintf(fd, _TSK_T("%s"), wbuf);
+        fwprintf(fd, _TSK_T("%ls"), wbuf);
     }
 #else
     vfprintf(fd, msg, args);
@@ -119,7 +119,7 @@ tsk_printf(const char *msg, ...)
     {
         WCHAR wbuf[2048];
         tsk_printf_conv(wbuf, 2048, msg, &args);
-        wprintf(_TSK_T("%s"), wbuf);
+        wprintf(_TSK_T("%ls"), wbuf);
     }
 #else
     vprintf(msg, args);

--- a/tsk/fs/ils_lib.c
+++ b/tsk/fs/ils_lib.c
@@ -181,7 +181,7 @@ ils_mac_act(TSK_FS_FILE * fs_file, void *ptr)
     }
 
     /* ADD image and file name (if we have one) */
-    TFPRINTF(stdout, _TSK_T("0|<%s-"), data->image);
+    TFPRINTF(stdout, _TSK_T("0|<" PRIttocTSK "-"), data->image);
     tsk_printf("%s%s%s-%" PRIuINUM ">|%" PRIuINUM "|",
         (fs_file->meta->name2) ? fs_file->meta->name2->name : "",
         (fs_file->meta->name2) ? "-" : "",

--- a/tsk/hashdb/encase.c
+++ b/tsk/hashdb/encase.c
@@ -129,7 +129,7 @@ uint8_t
 
     /* Status */
     if (tsk_verbose)
-        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (%s)\n"),
+        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (" PRIttocTSK ")\n"),
         hdb_binsrch_info->base.db_fname);
 
     memset(phash, '0', sizeof(phash));

--- a/tsk/hashdb/hashkeeper.c
+++ b/tsk/hashdb/hashkeeper.c
@@ -280,7 +280,7 @@ uint8_t
 
     /* Status */
     if (tsk_verbose)
-        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (%s)\n"),
+        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (" PRIttocTSK ")\n"),
         hdb_binsrch_info->base.db_fname);
 
     /* Allocate a buffer to hold the previous hash values */

--- a/tsk/hashdb/md5sum.c
+++ b/tsk/hashdb/md5sum.c
@@ -218,7 +218,7 @@ uint8_t
 
     /* Status */
     if (tsk_verbose)
-        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (%s)\n"),
+        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (" PRIttocTSK ")\n"),
         hdb_info->base.db_fname);
 
     /* Allocate a buffer for the previous hash value */

--- a/tsk/hashdb/nsrl.c
+++ b/tsk/hashdb/nsrl.c
@@ -401,7 +401,7 @@ uint8_t
 
     /* Status */
     if (tsk_verbose)
-        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (%s)\n"),
+        TFPRINTF(stderr, _TSK_T("Extracting Data from Database (" PRIttocTSK ")\n"),
         hdb_info_base->db_fname);
 
     /* Allocate a buffer for the previous hash value */

--- a/tsk/img/img_open.cpp
+++ b/tsk/img/img_open.cpp
@@ -110,7 +110,7 @@ tsk_img_open(int num_img,
 
     if (tsk_verbose)
         TFPRINTF(stderr,
-            _TSK_T("tsk_img_open: Type: %d   NumImg: %d  Img1: %s\n"),
+            _TSK_T("tsk_img_open: Type: %d   NumImg: %d  Img1: " PRIttocTSK "\n"),
             type, num_img, images[0]);
 
 


### PR DESCRIPTION
* Use the correct string format specifiers in calls to TFPRINTF.
* Use standards-compliant %ls instead of legacy MSVC %S.