### PR TITLE
Fixes Heap-buffer-overflow READ in tsk_UTF16toUTF8

### DIFF
--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -238,7 +238,7 @@ ntfs_parent_act(TSK_FS_FILE * fs_file, void * /*ptr*/)
 /****************/
 
 static uint8_t
-ntfs_dent_copy(NTFS_INFO * ntfs, ntfs_idxentry * idxe,
+ntfs_dent_copy(NTFS_INFO * ntfs, ntfs_idxentry * idxe, uintptr_t endaddr,
     TSK_FS_NAME * fs_name)
 {
     ntfs_attr_fname *fname = (ntfs_attr_fname *) & idxe->stream;
@@ -254,10 +254,18 @@ ntfs_dent_copy(NTFS_INFO * ntfs, ntfs_idxentry * idxe,
 
     name16 = (UTF16 *) & fname->name;
     name8 = (UTF8 *) fs_name->name;
+    
+    const UTF16 * sourceEnd = (UTF16 *) ((uintptr_t) name16 + fname->nlen * 2);
+    if (((uintptr_t) sourceEnd) >= endaddr) {
+        if (tsk_verbose)
+            tsk_fprintf(stderr,
+                "sourceEnd: %" PRIuINUM " is out of endaddr bounds: %" PRIuINUM,
+                sourceEnd, endaddr);
+        return 1;
+    }
 
     retVal = tsk_UTF16toUTF8(fs->endian, (const UTF16 **) &name16,
-        (UTF16 *) ((uintptr_t) name16 +
-            fname->nlen * 2), &name8,
+        sourceEnd, &name8,
         (UTF8 *) ((uintptr_t) name8 +
             fs_name->name_size), TSKlenientConversion);
 
@@ -549,7 +557,7 @@ ntfs_proc_idxentry(NTFS_INFO * a_ntfs, TSK_FS_DIR * a_fs_dir,
         }
 
         /* Copy it into the generic form */
-        if (ntfs_dent_copy(a_ntfs, a_idxe, fs_name)) {
+        if (ntfs_dent_copy(a_ntfs, a_idxe, endaddr, fs_name)) {
             if (tsk_verbose)
                 tsk_fprintf(stderr,
                     "ntfs_proc_idxentry: Skipping because error copying dent_entry\n");


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43923

The `sourceEnd` in `tsk_UTF16toUTF8` is calculated as `(UTF16 *) ((uintptr_t) name16 + fname->nlen * 2)` in `ntfs_dent_copy` points past the `endaddr` calculated in `ntfs_proc_idxentry`.