### PR TITLE
Fixes Heap-buffer-overflow READ in tsk_stack_pop

### DIFF
--- a/tsk/fs/fs_dir.c
+++ b/tsk/fs/fs_dir.c
@@ -829,7 +829,7 @@ tsk_fs_dir_walk_recursive(TSK_FS_INFO * a_fs, DENT_DINFO * a_dinfo,
                 strncpy(a_dinfo->didx[a_dinfo->depth],
                     fs_file->name->name,
                     DIR_STRSZ - strlen(a_dinfo->dirs));
-                strncat(a_dinfo->dirs, "/", DIR_STRSZ-1);
+                strncat(a_dinfo->dirs, "/", DIR_STRSZ - strlen(a_dinfo->dirs) - 1);
                 depth_added = 1;
                 a_dinfo->depth++;
 


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36955

The `stack_seen` pointer gets corrupted because of `strncat(a_dinfo->dirs, "/", DIR_STRSZ-1);` in `tsk_fs_dir_walk_recursive`.
When the `a_dinfo->dirs` buffer is full (4095 chars are filled with data and the last 4096's char (index 4095) is '\0')
the `strncat(a_dinfo->dirs, "/", DIR_STRSZ-1);` copies '/' to the last char in the buffer and terminating '\0' out of the buffer bounds.
`strncat` does not check for sufficient space in `a_dinfo->dirs`, the last parameter `DIR_STRSZ-1` tells the max characters to copy from the source.
Since the buffer is a field in the `DENT_DINFO` structure, it overwrites a single byte in the next member - `stack_seen` pointer.