### PR TITLE
Fixes Crash Unknown Read in std::__1::enable_if<true, memory_view>::type

### DIFF
--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -440,8 +440,17 @@ class APFSBtreeNode : public APFSObject, public APFSOmap::node_tag {
     }
 
     _table_data.toc = {_storage.data() + toffset()};
+    if ((uintptr_t)_table_data.toc.v - (uintptr_t)_storage.data() > _storage.size()) {
+      throw std::runtime_error("APFSBtreeNode: invalid toffset");
+    }
     _table_data.voff = _storage.data() + voffset();
+    if (_table_data.voff - _storage.data() > _storage.size()) {
+      throw std::runtime_error("APFSBtreeNode: invalid voffset");
+    }
     _table_data.koff = _storage.data() + koffset();
+    if (_table_data.koff - _storage.data() > _storage.size()) {
+      throw std::runtime_error("APFSBtreeNode: invalid koffset");
+    }
   }
 
   inline bool is_root() const noexcept {


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36027 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36025

The `_table_data.toc` points to invalid memory because of the wrong offset set in `APFSBtreeNode` constructor.