### PR TITLE
Fixes heap use after free read

### DIFF
--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -142,6 +142,12 @@ class APFSBtreeNodeIterator {
     const auto &t = _node->_table_data.toc.variable[_index];
     const auto key_data = _node->_table_data.koff + t.key_offset;
     const auto val_data = _node->_table_data.voff - t.val_offset;
+    if (key_data > _node->_storage.data()) {
+      throw std::runtime_error("init_value: invalid key_offset");
+    }
+    if (val_data < _node->_storage.data()) {
+      throw std::runtime_error("init_value: invalid val_offset");
+    }
 
     memory_view key{key_data, t.key_length};
 
@@ -168,6 +174,12 @@ class APFSBtreeNodeIterator {
     const auto &t = _node->_table_data.toc.fixed[_index];
     const auto key_data = _node->_table_data.koff + t.key_offset;
     const auto val_data = _node->_table_data.voff - t.val_offset;
+    if (key_data > _node->_storage.data()) {
+      throw std::runtime_error("init_value: invalid key_offset");
+    }
+    if (val_data < _node->_storage.data()) {
+      throw std::runtime_error("init_value: invalid val_offset");
+    }
 
     if (_node->is_leaf()) {
       _val = {(typename Node::key_type)key_data,
@@ -1145,6 +1157,12 @@ inline void APFSBtreeNodeIterator<APFSJObjBtreeNode>::init_value<void>(int recur
   const auto &t = _node->_table_data.toc.variable[_index];
   const auto key_data = _node->_table_data.koff + t.key_offset;
   const auto val_data = _node->_table_data.voff - t.val_offset;
+  if (key_data > _node->_storage.data()) {
+    throw std::runtime_error("APFSBtreeNodeIterator<APFSJObjBtreeNode>::init_value: invalid key_offset");
+  }
+  if (val_data < _node->_storage.data()) {
+    throw std::runtime_error("APFSBtreeNodeIterator<APFSJObjBtreeNode>::init_value: invalid val_offset");
+  }
 
   memory_view key{key_data, t.key_length};
 


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36024 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36098 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36021 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36122 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38365

The `val_data` points to invalid memory because of invalid `t.val_offset`.