### PR TITLE
Fixes Heap-buffer-overflow read in inode_walk_file_act

### DIFF
--- a/tsk/fs/fatfs_meta.c
+++ b/tsk/fs/fatfs_meta.c
@@ -1224,8 +1224,7 @@ fatfs_inode_walk(TSK_FS_INFO *a_fs, TSK_INUM_T a_start_inum,
     /* Allocate a bitmap to keep track of which sectors are allocated to
      * directories. */
     if ((dir_sectors_bitmap =
-            (uint8_t*)tsk_malloc((size_t) ((a_fs->block_count +
-                        7) / 8))) == NULL) {
+            (uint8_t*)tsk_malloc((size_t) (a_fs->block_count / 8 + 1))) == NULL) {
         tsk_fs_file_close(fs_file);
         return 1;
     }

--- a/tsk/fs/fatfs_meta.c
+++ b/tsk/fs/fatfs_meta.c
@@ -1224,7 +1224,7 @@ fatfs_inode_walk(TSK_FS_INFO *a_fs, TSK_INUM_T a_start_inum,
     /* Allocate a bitmap to keep track of which sectors are allocated to
      * directories. */
     if ((dir_sectors_bitmap =
-            (uint8_t*)tsk_malloc((size_t) (a_fs->block_count / 8 + 1))) == NULL) {
+            (uint8_t*)tsk_malloc((size_t) (a_fs->block_count / 8 + (a_fs->block_count % 8 > 0) ? 1 : 0))) == NULL) {
         tsk_fs_file_close(fs_file);
         return 1;
     }


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35648

The root cause is in call to in `(size_t) ((a_fs->block_count + 7) / 8))` `fatfs_inode_walk`. When `a_fs->block_count` is max 64bit int it leads to integer overflow and allocation of a small buffer.