### PR TITLE
Fixes Crash unknown read in ntfs_dir_open_meta

### DIFF
--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -1002,7 +1002,7 @@ ntfs_dir_open_meta(TSK_FS_INFO * a_fs, TSK_FS_DIR ** a_fs_dir,
         }
     }
     else {
-        int off;
+        unsigned int off;
 
         if (fs_attr_idx->flags & TSK_FS_ATTR_RES) {
             tsk_error_reset();


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34415

The root cause is in `for (off = 0; off < idxalloc_len; off += ntfs->csize_b)` - the `int off` overflows and becomes negative which later is used in `idxalloc[off]`