### PR TITLE
Changes to fix build

### DIFF
--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -456,11 +456,11 @@ class APFSBtreeNode : public APFSObject, public APFSOmap::node_tag {
       throw std::runtime_error("APFSBtreeNode: invalid toffset");
     }
     _table_data.voff = _storage.data() + voffset();
-    if (_table_data.voff - _storage.data() > _storage.size()) {
+    if ((uintptr_t)_table_data.voff - (uintptr_t)_storage.data() > _storage.size()) {
       throw std::runtime_error("APFSBtreeNode: invalid voffset");
     }
     _table_data.koff = _storage.data() + koffset();
-    if (_table_data.koff - _storage.data() > _storage.size()) {
+    if ((uintptr_t)_table_data.koff - (uintptr_t)_storage.data() > _storage.size()) {
       throw std::runtime_error("APFSBtreeNode: invalid koffset");
     }
   }


### PR DESCRIPTION
Fixes:

```
../fs/tsk_apfs.hpp:459:44: error: comparison of integer expressions of different signedness: 'long int' and 'std::array<char, 4096>::size_type' {aka 'long unsigned int'} [-Werror=sign-compare]
  459 |     if (_table_data.voff - _storage.data() > _storage.size()) {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
../fs/tsk_apfs.hpp:463:44: error: comparison of integer expressions of different signedness: 'long int' and 'std::array<char, 4096>::size_type' {aka 'long unsigned int'} [-Werror=sign-compare]
  463 |     if (_table_data.koff - _storage.data() > _storage.size()) {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[3]: *** [Makefile:435: pool_open.lo] Error 1
make[2]: *** [Makefile:565: all-recursive] Error 1
make[1]: *** [Makefile:439: all] Error 2
make: *** [Makefile:581: all-recursive] Error 1
```