### PR TITLE
Statically link tools for static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,15 @@ case "$host" in
   ;;
 esac
 
+dnl ensure static linkage of tools during static builds
+if test "x$enable_shared" != "xyes"; then
+  CXXLD="$CXX -all-static"
+else
+  CXXLD="$CXX"
+fi
+
+AC_SUBST([CXXLD])
+
 dnl Dependencies for fiwalk
 AC_CHECK_FUNCS([getline])
 AC_SEARCH_LIBS(regexec, [regex], , AC_MSG_ERROR([missing regex]))

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I.. -I$(srcdir)/..
 AM_CXXFLAGS += -Wno-unused-command-line-argument
 LDADD = ../tsk/libtsk.la
-AM_LDFLAGS = -static
 EXTRA_DIST = .indent.pro 
 
 noinst_PROGRAMS = posix_style callback_style posix_cpp_style callback_cpp_style

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,8 +2,8 @@ AM_CPPFLAGS = -I.. -I$(srcdir)/..
 AM_CFLAGS += $(PTHREAD_CFLAGS)
 AM_CXXFLAGS += -Wno-unused-command-line-argument $(PTHREAD_CFLAGS)
 LDADD = ../tsk/libtsk.la
-LDFLAGS += -static $(PTHREAD_LIBS)
-EXTRA_DIST = .indent.pro runtests.sh test_libraries.sh
+LDFLAGS += $(PTHREAD_LIBS)
+EXTRA_DIST = .indent.pro runtests.sh
 
 check_SCRIPTS = runtests.sh test_libraries.sh test_imgs.sh
 

--- a/tools/autotools/Makefile.am
+++ b/tools/autotools/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. 
 AM_CXXFLAGS += -Wno-overloaded-virtual -Wno-unused-command-line-argument
 LDADD = ../../tsk/libtsk.la
-LDFLAGS += -static
 EXTRA_DIST = .indent.pro
 
 bin_PROGRAMS = tsk_recover tsk_loaddb tsk_comparedir tsk_gettimes tsk_imageinfo

--- a/tools/fstools/Makefile.am
+++ b/tools/fstools/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 AM_CXXFLAGS += -Wno-unused-command-line-argument
 LDADD = ../../tsk/libtsk.la
-LDFLAGS += -static
 EXTRA_DIST = .indent.pro fscheck.cpp
 
 bin_PROGRAMS = blkcalc blkcat blkls blkstat ffind fls fcat fsstat icat ifind ils \

--- a/tools/hashtools/Makefile.am
+++ b/tools/hashtools/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 AM_CXXFLAGS += -Wno-unused-command-line-argument
 LDADD = ../../tsk/libtsk.la
-LDFLAGS += -static
 EXTRA_DIST = .indent.pro md5.c sha1.c
 
 bin_PROGRAMS = hfind

--- a/tools/imgtools/Makefile.am
+++ b/tools/imgtools/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 AM_CXXFLAGS += -Wno-unused-command-line-argument
 LDADD = ../../tsk/libtsk.la
-LDFLAGS += -static
 EXTRA_DIST = .indent.pro
 
 bin_PROGRAMS = img_cat img_stat

--- a/tools/pooltools/Makefile.am
+++ b/tools/pooltools/Makefile.am
@@ -1,6 +1,5 @@
 AM_CPPFLAGS = -I../.. -I$(srcdir)/../.. -Wall
 LDADD = ../../tsk/libtsk.la
-LDFLAGS += -static
 EXTRA_DIST = .indent.pro
 
 bin_PROGRAMS = pstat

--- a/tools/srchtools/Makefile.am
+++ b/tools/srchtools/Makefile.am
@@ -8,7 +8,6 @@ srch_strings_SOURCES = srch_strings.c
 
 sigfind_SOURCES = sigfind.cpp 
 sigfind_LDADD = ../../tsk/libtsk.la
-sigfind_LDFLAGS = -static
 
 indent:
 	indent *.c *.cpp

--- a/tools/vstools/Makefile.am
+++ b/tools/vstools/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 AM_CXXFLAGS += -Wno-unused-command-line-argument
 LDADD = ../../tsk/libtsk.la
-LDFLAGS += -static
 EXTRA_DIST = .indent.pro
 
 bin_PROGRAMS = mmls mmstat mmcat


### PR DESCRIPTION
Tools should also be statically linked when doing static builds. Fixes Issue #2495.