### PR TITLE
feat: update libvhdi and libvmdk travis dependencies

### DIFF
--- a/travis_install_libs.sh
+++ b/travis_install_libs.sh
@@ -13,6 +13,6 @@ installLib() {
 	cd ..
 }
 
-installLib libvhdi 20201204
-installLib libvmdk 20200926
+installLib libvhdi 20210425
+installLib libvmdk 20210807
 


### PR DESCRIPTION
Use last binary versions from libvhdi and libvmdk.

Source:
https://github.com/libyal/libvhdi/tags
https://github.com/libyal/libvmdk/tags