### PR TITLE
#2765 fix: Many files may be missed almost silently

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/TskCaseDbBridge.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskCaseDbBridge.java
@@ -488,7 +488,7 @@ class TskCaseDbBridge {
                 // Exception firewall to prevent unexpected return to the native code
                 logger.log(Level.SEVERE, "Unexpected error from files added callback", ex);
             }
-        } catch (TskCoreException ex) {
+        } catch (Throwable ex) {
             logger.log(Level.SEVERE, "Error adding batched files to database", ex);
             revertTransaction();
             return -1;

--- a/bindings/java/src/org/sleuthkit/datamodel/TskCaseDbBridge.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/TskCaseDbBridge.java
@@ -396,6 +396,10 @@ class TskCaseDbBridge {
 					} catch (NotUserSIDException ex) {
 						// if the owner SID is not a user SID, set the owner account to null
 						ownerIdToAccountMap.put(ownerUid, null);
+					} catch (Exception ex) {
+						// catch other exceptions to avoid skiping add batched files loop below
+						logger.log(Level.WARNING, "Error mapping ownerId " + ownerUid + " to account", ex);
+						ownerIdToAccountMap.put(ownerUid, null);
 					}
 				}
 			}

--- a/bindings/java/src/org/sleuthkit/datamodel/WindowsAccountUtils.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/WindowsAccountUtils.java
@@ -170,6 +170,7 @@ final class WindowsAccountUtils {
 	//  - We can assume and fill in SID from given account name, and vice versa.
 	//  - We map account names in foreign languages (some known set) to english names, for these well known accounts. 
 	private static final Map<String, WellKnownSidInfo> SPECIAL_SIDS_MAP =  ImmutableMap.<String, WellKnownSidInfo>builder() 
+			.put("S-1-5-17", new WellKnownSidInfo(true, "S-1-5", NTAUTHORITY_REALM_NAME, "IUSR", "IIS Default Account"))			
 			.put("S-1-5-18", new WellKnownSidInfo(true, "S-1-5", NTAUTHORITY_REALM_NAME, "SYSTEM", "Local System Account"))
 			.put("S-1-5-19", new WellKnownSidInfo(true, "S-1-5", NTAUTHORITY_REALM_NAME, "LOCAL SERVICE", "Local Service Account"))
 			.put("S-1-5-20", new WellKnownSidInfo(true, "S-1-5", NTAUTHORITY_REALM_NAME, "NETWORK SERVICE", "Network Service Account"))


### PR DESCRIPTION
Fixes #2765.

I just saw the original StringIndexOutOfBoundsException reported on #2765 wouldn't be thrown by current develop branch because the problematic code was updated to use a Matcher instead of String.subString() in WindowsAccountUtils.isWindowsWellKnownSid(sid) method.

But the issue can still be triggered by a TskCoreException declared by OsAccountManager.getWindowsOsAccount(...) or a possible RuntimeException and I still think it is important to catch other exceptions in some places in TskCaseDbBridge class to avoid skipping the while loop that inserts files into DB and also to log a SEVERE specific message if it fails. So I'm submitting this.

Please take a look at commit [fb15131](https://github.com/sleuthkit/sleuthkit/pull/2766/commits/fb1513120a939a04d160e362b19e6b380792d613), I'm not sure if it is fine.