### PR TITLE
Fixes #2723: use default JNI NewStringUTF(utf8) as fallback to avoid missing whole directory tree

### DIFF
--- a/bindings/java/jni/auto_db_java.cpp
+++ b/bindings/java/jni/auto_db_java.cpp
@@ -482,7 +482,9 @@ TSK_RETVAL_ENUM TskAutoDbJava::createJString(const char * input, jstring & newJS
 
     if (tsk_UTF8toUTF16((const UTF8 **)&source, (const UTF8 *)&source[input_len], &target, &target[input_len], TSKlenientConversion) != TSKconversionOK) {
         free(utf16_input);
-        return TSK_ERR;
+        // use default JNI method as fallback, fixes https://github.com/sleuthkit/sleuthkit/issues/2723
+        newJString = m_jniEnv->NewStringUTF(input);
+        return TSK_OK;
     }
 
     /*


### PR DESCRIPTION
Fixes #2723 using a simple fallback approach.