### PR TITLE
openssl support and minor crypto.hpp correction

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,17 +304,22 @@ AC_CHECK_FUNCS([getline])
 AC_SEARCH_LIBS(regexec, [regex], , AC_MSG_ERROR([missing regex]))
 
 
-dnl OpenSSL support for encryption - currently disabled due to automatic test failures
-dnl AX_CHECK_OPENSSL(
-dnl  [ax_openssl=yes]
-dnl  LIBTSK_LDFLAGS="$LIBTSK_LDFLAGS $OPENSSL_LDFLAGS $OPENSSL_LIBS",
-dnl  AC_SUBST([LIBTSK_LDFLAGS])
-[ax_openssl=no]
-dnl  [AC_MSG_ERROR([OpenSSL headers cannot be located. Consider using the --with-openssl option to specify an appropriate path.])]
-dnl )
-dnl For the moment, disable the openssl library so the Travis test will pass
-dnl AS_IF([test "x$ax_openssl" = xyes], AC_DEFINE(HAVE_LIBOPENSSL,1, [Define if using opensll]), [])
-
+dnl OpenSSL support for encryption  
+AX_CHECK_OPENSSL(
+  [
+   ax_openssl=yes
+   LIBTSK_LDFLAGS="$LIBTSK_LDFLAGS $OPENSSL_LDFLAGS $OPENSSL_LIBS"
+   AC_SUBST([LIBTSK_LDFLAGS])
+  ],
+  [
+   ax_openssl=no
+   AC_MSG_WARN([OpenSSL headers cannot be located. Consider using the --with-openssl option to specify an appropriate path.])
+  ]
+)
+AS_IF([test "x$ax_openssl" = "xyes"],
+       [ AC_DEFINE([HAVE_LIBOPENSSL],[1], [Define if using openssl]) ],
+       []
+)
 
 dnl Enable compliation warnings
 WARNINGS='-Wall -Wextra -Wno-unused-parameter'
@@ -361,6 +366,8 @@ dnl Print a summary
 dnl openssl is disabled, so removed line openssl support: $ax_openssl
 AC_MSG_NOTICE([
 Building:
+   openssl support:                       $ax_openssl
+
    afflib support:                        $ax_afflib
    libewf support:                        $ax_libewf
    zlib support:                          $ax_zlib

--- a/tsk/util/crypto.hpp
+++ b/tsk/util/crypto.hpp
@@ -14,6 +14,7 @@
  */
 
 #include "../base/tsk_base.h"
+#include "../base/tsk_base_i.h"
 
 #ifdef HAVE_LIBOPENSSL
 #include <openssl/evp.h>


### PR DESCRIPTION
This correction enables again libssl and the APFS patch, correcting its build on the project.

It was made a small adjustment to add openssl support and an equally small, but important, correction on crypto.hpp to enable the correct linkage/build of TSK binaries.