### PR TITLE
fix for warning: "Thread already has an open transaction.  New connection may encounter SQLITE_BUSY error."

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -934,7 +934,7 @@ public final class OsAccountManager {
 		
 		// Get all users in the realm (excluding the account)
 		List<OsAccount> osAccounts = getOsAccounts(realm, trans.getConnection());
-		osAccounts.removeIf(acc -> Objects.equals(acc, account));
+		osAccounts.removeIf(acc -> Objects.equals(acc.getId(), account.getId()));
 		
 		// Look for matching account
 		Optional<OsAccount> matchingAccount = getMatchingAccountForMerge(account, osAccounts);


### PR DESCRIPTION
The call to the _equals_ method on the OsAccount objects was involving database query due to the equals method calling _getContentChildrenCount_