### PR TITLE
fix #2800: return unsigned byte by InputStream API (-1 just if EOF)

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/ReadContentInputStream.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ReadContentInputStream.java
@@ -39,7 +39,7 @@ public final class ReadContentInputStream extends InputStream {
 	@Override
 	public int read() throws ReadContentInputStreamException {
 		byte[] buff = new byte[1];
-		return (read(buff) != -1) ? buff[0] : -1;
+		return (read(buff) != -1) ? buff[0] & 0xFF : -1;
 	}
 
 	@Override


### PR DESCRIPTION
Fix #2800. Returns unsigned byte according to method contract, avoiding to return -1 before EOF.