### PR TITLE
configure.ac: use '=' for comparison instead of '=='

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,7 @@ AS_IF([test "x$enable_java" != "xno"], [
 dnl if we found everything we need, set ax_java_support for the
 dnl status message and set X_JNI for use in Makefile
 AS_IF([test "x$JNI_CPPFLAGS" != x && test "x$ANT_FOUND" != x && test "x$JAVA" != x], [ax_java_support=yes], [ax_java_support=no])
-AM_CONDITIONAL([X_JNI],[test "x$ax_java_support" == "xyes"])
+AM_CONDITIONAL([X_JNI],[test "x$ax_java_support" = "xyes"])
 
 AC_CONFIG_COMMANDS([tsk/tsk_incs.h],
     [echo "#ifndef _TSK_INCS_H" > tsk/tsk_incs.h


### PR DESCRIPTION
The operator '==' isn't POSIX compliant[0]. Use the standard '=', as it's done everywhere else in configure.ac.

[0] https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html

Bug: https://bugs.gentoo.org/870250