### PR TITLE
Add aarch64 support to Java bindings for mac and linux

### DIFF
--- a/bindings/java/build-unix.xml
+++ b/bindings/java/build-unix.xml
@@ -67,6 +67,8 @@
 		<copy file="${jni.dylib}" tofile="${x86_64}/mac/${jni.jnilib}" overwrite="true"/>
 		<!-- amd64 -->
 		<copy file="${jni.dylib}" tofile="${amd64}/mac/${jni.jnilib}" overwrite="true"/>
+		<!-- aarch64 -->
+		<copy file="${jni.dylib}" tofile="${aarch64}/mac/${jni.jnilib}" overwrite="true"/>
 	</target>
 
 	<!-- Non-OS X -->
@@ -92,6 +94,8 @@
 		<copy file="${jni.so}" tofile="${i586}/linux/libtsk_jni.so" overwrite="true"/>
 		<!-- i686 -->
 		<copy file="${jni.so}" tofile="${i686}/linux/libtsk_jni.so" overwrite="true"/>
+		<!-- aarch64 -->
+		<copy file="${jni.so}" tofile="${aarch64}/linux/libtsk_jni.so" overwrite="true"/>
 	</target>
 
 	<target name="copyLibs" depends="copyLinuxLibs,copyMacLibs"/>

--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -33,6 +33,7 @@
 	<property name="i386" location="build/NATIVELIBS/i386"/>
 	<property name="i586" location="build/NATIVELIBS/i586"/>
 	<property name="i686" location="build/NATIVELIBS/i686"/>
+	<property name="aarch64" location="build/NATIVELIBS/aarch64"/>
 
 	<!-- Only added win folders for now -->
 	<target name="init">
@@ -63,6 +64,9 @@
 		<mkdir dir="${i686}"/>
 		<mkdir dir="${i686}/win"/>
 		<mkdir dir="${i686}/linux"/>
+		<mkdir dir="${aarch64}"/>
+		<mkdir dir="${aarch64}/mac"/>
+		<mkdir dir="${aarch64}/linux"/>
 	</target>
 
 	<!-- set classpath for dependencies-->


### PR DESCRIPTION
Was working on updating `autopsy` in Homebrew (https://github.com/Homebrew/homebrew-core/pull/156402) and noticed that it doesn't start up on ARM macOS due to missing NATIVELIBS in `sleuthkit` JAR even though native libraries are built.

`System.getProperty("os.arch")` is "aarch64" when tested on ARM macOS and on Docker Linux.