### PR TITLE
Fix incorrect bounds check for hfs_thread structs

### DIFF
--- a/tsk/fs/hfs_dent.c
+++ b/tsk/fs/hfs_dent.c
@@ -258,12 +258,20 @@ hfs_dir_open_meta_cb(HFS_INFO * hfs, int8_t level_type,
 
         /* This will link the folder to its parent, which is the ".." entry */
         else if (rec_type == HFS_FOLDER_THREAD) {
-            if ((nodesize < sizeof(hfs_thread)) || (rec_off2 > nodesize - sizeof(hfs_thread))) {
+            hfs_thread *thread = (hfs_thread *) & rec_buf[rec_off2];
+
+            // hfs_thread is of variable size on disk. The minimum size is
+            // 10 bytes (8 for the fields, 2 for the length of an empty name).
+            // First, check that we can read as far as the name length; then
+            // get the name length and check that the whole record fits into
+            // the buffer.
+            if (rec_off2 > nodesize - (sizeof(hfs_thread) - sizeof(hfs_uni_str) + 2) ||
+                rec_off2 > nodesize - (sizeof(hfs_thread) - sizeof(hfs_uni_str) + 2 + tsk_getu16(hfs->fs_info.endian, thread->name.length))) {
                 tsk_error_set_errno(TSK_ERR_FS_GENFS);
                 tsk_error_set_errstr("hfs_dir_open_meta: nodesize value out of bounds");
                 return HFS_BTREE_CB_ERR;
             }
-            hfs_thread *thread = (hfs_thread *) & rec_buf[rec_off2];
+
             strcpy(info->fs_name->name, "..");
             info->fs_name->meta_addr =
                 tsk_getu32(hfs->fs_info.endian, thread->parent_cnid);

--- a/tsk/fs/hfs_dent.c
+++ b/tsk/fs/hfs_dent.c
@@ -261,12 +261,15 @@ hfs_dir_open_meta_cb(HFS_INFO * hfs, int8_t level_type,
             hfs_thread *thread = (hfs_thread *) & rec_buf[rec_off2];
 
             // hfs_thread is of variable size on disk. The minimum size is
-            // 10 bytes (8 for the fields, 2 for the length of an empty name).
+            // 10 bytes (8 for the non-name fields, 2 for the length of an
+            // empty name).
+            const size_t min_hfs_thread_size = sizeof(hfs_thread) - sizeof(hfs_uni_str) + 2;
+
             // First, check that we can read as far as the name length; then
             // get the name length and check that the whole record fits into
             // the buffer.
-            if (rec_off2 > nodesize - (sizeof(hfs_thread) - sizeof(hfs_uni_str) + 2) ||
-                rec_off2 > nodesize - (sizeof(hfs_thread) - sizeof(hfs_uni_str) + 2 + tsk_getu16(hfs->fs_info.endian, thread->name.length))) {
+            if (rec_off2 > nodesize - min_hfs_thread_size ||
+                rec_off2 > nodesize - (min_hfs_thread_size + tsk_getu16(hfs->fs_info.endian, thread->name.length))) {
                 tsk_error_set_errno(TSK_ERR_FS_GENFS);
                 tsk_error_set_errstr("hfs_dir_open_meta: nodesize value out of bounds");
                 return HFS_BTREE_CB_ERR;


### PR DESCRIPTION
Fixes #2899. The problem was caused by an incorrect bounds check introduced in #2647.

 The `hfs_thread` struct is sized for the maximum possible name length, but the actual on-disk storage of the name is variable length. It's incorrect to require the buffer to be the maximum size, and results in entries being skipped as corrupt. Instead, the right thing to do is check that enough of the data fits into the buffer so that the name length can be read, and if so, read the name length and check that a name of that length also fits.
