### PR TITLE
Build cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,12 @@ Makefile
 .deps
 .libs
 *.swp
+.dirstamp
+
+# unit tests
+unit_tests/*/*.exe
+unit_tests/*/*.log
+unit_tests/*/*.trs
 
 #javadoc generated
 /bindings/java/javadoc
@@ -131,7 +137,6 @@ libtool
 m4/libtool.m4
 m4/lt*.m4
 config/*
-
 
 # Executables
 samples/callback_cpp_style
@@ -182,9 +187,8 @@ tools/vstools/mmls
 tools/vstools/mmstat
 tools/*/*.exe
 tools/*/*/*.exe
-unit_tests/base/*.log
-unit_tests/base/*.trs
 unit_tests/base/test_base
+
 # EMACS backup files
 *~
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ EXTRA_DIST = README_win32.txt README.md INSTALL.txt ChangeLog.txt NEWS.txt API-C
 ACLOCAL_AMFLAGS = -I m4
 
 # directories to compile
-if CPPUNIT
+if HAVE_CPPUNIT
   UNIT_TESTS=unit_tests
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_CHECK_FUNCS([strlcpy strlcat])
 
 AX_PTHREAD([
     AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.])
-    CLIBS="$PTHREAD_LIBS $LIBS"
+    LIBS="$PTHREAD_LIBS $LIBS"
     CPPFLAGS="$CPPFLAGS $PTHREAD_CFLAGS"
     LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
     CC="$PTHREAD_CC"],[])

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([tsk/base/tsk_base.h])
 AC_CONFIG_HEADERS([tsk/tsk_config.h])
-AM_INIT_AUTOMAKE([foreign tar-ustar])
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-ustar])
 AM_PROG_LIBTOOL
 AM_MAINTAINER_MODE
 

--- a/configure.ac
+++ b/configure.ac
@@ -115,11 +115,16 @@ AS_IF([test "x$ac_cv_prog_PKGCONFIG" = "xyes"],
   )]
 )
 
-dnl needed for sqllite
-AC_CHECK_LIB(dl, dlopen)
-
-AC_CHECK_HEADERS([sqlite3.h], [AC_CHECK_LIB([sqlite3], [sqlite3_open])])
-AS_IF([test "x$ac_cv_lib_sqlite3_sqlite3_open" = "xyes"], [ax_sqlite3=yes])
+dnl check again for sqlite3 if not found by pkgconfig
+AS_IF([test "x$ax_sqlite3" != "xyes"],
+  [
+    AC_CHECK_HEADERS(
+      [sqlite3.h],
+      [AC_CHECK_LIB([dl], [dlopen])
+       AC_CHECK_LIB([sqlite3], [sqlite3_open], [ax_sqlite3=yes], [])]
+    )
+  ]
+)
 
 dnl Compile the bundled sqlite if there is no system one installed
 AC_MSG_CHECKING(which sqlite3 to use)

--- a/configure.ac
+++ b/configure.ac
@@ -331,7 +331,8 @@ AC_CONFIG_FILES([
     bindings/java/jni/Makefile
     case-uco/java/Makefile
     unit_tests/Makefile
-    unit_tests/base/Makefile])
+    unit_tests/base/Makefile
+    unit_tests/img/Makefile])
 
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -331,8 +331,7 @@ AC_CONFIG_FILES([
     bindings/java/jni/Makefile
     case-uco/java/Makefile
     unit_tests/Makefile
-    unit_tests/base/Makefile
-    unit_tests/img/Makefile])
+    unit_tests/base/Makefile])
 
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,29 +1,16 @@
 dnl -*- Autoconf -*-
 dnl Process this file with autoconf to produce a configure script.
 
-
 AC_PREREQ(2.59)
 
 AC_INIT(sleuthkit, 4.12.1)
-m4_include([m4/ax_pthread.m4])
-dnl include the version from 1.12.1. This will work for
-m4_include([m4/cppunit.m4])
-m4_include([m4/ax_jni_include_dir.m4])
-m4_include([m4/ac_prog_javac_works.m4])
-m4_include([m4/ac_prog_javac.m4])
-m4_include([m4/ac_prog_java_works.m4])
-m4_include([m4/ac_prog_java.m4])
-m4_include([m4/ax_cxx_compile_stdcxx.m4])
-
+AC_CONFIG_AUX_DIR([config])
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([tsk/base/tsk_base.h])
 AC_CONFIG_HEADERS([tsk/tsk_config.h])
-AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
-AM_PATH_CPPUNIT(1.12.1)
-AM_CONDITIONAL([CPPUNIT],[test "x$no_cppunit" = x])
 AM_PROG_LIBTOOL
 AM_MAINTAINER_MODE
-AC_CONFIG_MACRO_DIR([m4])
 
 dnl Checks for programs.
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -81,19 +81,6 @@ AC_ARG_ENABLE([multithreading],
 dnl Enable multithreading by default in the presence of pthread
 AS_IF([test "x$ax_pthread_ok" = "xyes" && test "x$enable_multithreading" != "xno"], [ax_multithread=yes], [ax_multithread=no])
 
-case "$host" in
-*-*-mingw*)
-  dnl Adding the native /usr/local is wrong for cross-compiling
-  ;;
-*)
-  dnl Not all compilers include /usr/local in the include and link path
-  if test -d /usr/local/include; then
-    CPPFLAGS="$CPPFLAGS -I/usr/local/include"
-    LDFLAGS="$LDFLAGS -L/usr/local/lib"
-  fi
-  ;;
-esac
-
 dnl Add enable/disable option
 AC_ARG_ENABLE([java],
     [AS_HELP_STRING([--disable-java], [Do not build the java bindings or jar file])])

--- a/configure.ac
+++ b/configure.ac
@@ -337,14 +337,15 @@ dnl openssl is disabled, so removed line openssl support: $ax_openssl
 AC_MSG_NOTICE([
 Building:
    afflib support:                        $ax_afflib
-   libewf support:                        $ax_libewf
-   zlib support:                          $ax_zlib
-
    libbfio support:                       $ax_libbfio
+   libewf support:                        $ax_libewf
    libvhdi support:                       $ax_libvhdi
    libvmdk support:                       $ax_libvmdk
    libvslvm support:                      $ax_libvslvm
+
+   zlib support:                          $ax_zlib
+
 Features:
    Java/JNI support:                      $ax_java_support
    Multithreading:                        $ax_multithread
-]);
+])

--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,6 @@ AC_ARG_ENABLE([java],
 
 dnl Checks for libraries.
 
-
 dnl Some platforms will complain about missing included functions if libstdc++ is not included.
 AC_CHECK_LIB(stdc++, main, , AC_MSG_ERROR([missing libstdc++]))
 AC_CHECK_HEADERS(list, , , AC_MSG_ERROR([missing STL list class header]))
@@ -189,7 +188,6 @@ AS_IF([test "x$enable_cppunit" != "xno"], [
 AM_CONDITIONAL([HAVE_CPPUNIT],[test "x$ac_cv_cppunit" = xyes])
 
 dnl check for user online input
-
 AC_ARG_ENABLE([offline],
     [ AS_HELP_STRING([--enable-offline],[Turn on offline mode])],
     [case "${enableval}" in

--- a/m4/ax_pkg_check_modules.m4
+++ b/m4/ax_pkg_check_modules.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_pkg_check_modules.html
+#   https://www.gnu.org/software/autoconf-archive/ax_pkg_check_modules.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -50,7 +50,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_PKG_CHECK_MODULES],[
     m4_define([ax_package_requires],

--- a/tsk/img/Makefile.am
+++ b/tsk/img/Makefile.am
@@ -2,9 +2,29 @@ AM_CPPFLAGS = -I../.. -I$(srcdir)/../..
 EXTRA_DIST = .indent.pro 
 
 noinst_LTLIBRARIES = libtskimg.la
-libtskimg_la_SOURCES = img_open.cpp img_types.c raw.c raw.h logical_img.c logical_img.h \
-    aff.c aff.h ewf.cpp ewf.h tsk_img_i.h img_io.c mult_files.c \
-    vhd.c vhd.h vmdk.c vmdk.h img_writer.cpp img_writer.h unsupported_types.c unsupported_types.h
+
+libtskimg_la_SOURCES = \
+	aff.c \
+	aff.h \
+	ewf.cpp \
+	ewf.h \
+	img_io.c \
+	img_open.cpp \
+	img_types.c \
+	img_writer.cpp \
+	img_writer.h \
+	logical_img.c \
+	logical_img.h \
+	mult_files.c \
+	raw.c \
+  raw.h \
+	tsk_img_i.h \
+	unsupported_types.c \
+	unsupported_types.h \
+	vhd.c \
+	vhd.h \
+	vmdk.c \
+	vmdk.h
 
 indent:
 	indent *.c *.h

--- a/unit_tests/Makefile.am
+++ b/unit_tests/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS= base
+SUBDIRS = base

--- a/unit_tests/base/Makefile.am
+++ b/unit_tests/base/Makefile.am
@@ -3,11 +3,11 @@ AM_CXXFLAGS += -Wno-unused-command-line-argument $(CPPUNIT_CFLAGS)
 LDADD = ../../tsk/libtsk.la $(CPPUNIT_LIBS)
 LDFLAGS = -static 
 
-TESTS = test_base
-
 check_PROGRAMS = test_base
 
 test_base_SOURCES = ../runner.cpp errors_test.cpp errors_test.h
+
+TESTS = $(check_PROGRAMS)
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/unit_tests/base/Makefile.am
+++ b/unit_tests/base/Makefile.am
@@ -1,5 +1,5 @@
-AM_CPPFLAGS = -I../.. $(CPPUNIT_CFLAGS)
-AM_CXXFLAGS += -Wno-unused-command-line-argument
+AM_CPPFLAGS = -I../..
+AM_CXXFLAGS += -Wno-unused-command-line-argument $(CPPUNIT_CFLAGS)
 LDADD = ../../tsk/libtsk.la $(CPPUNIT_LIBS)
 LDFLAGS = -static 
 
@@ -7,7 +7,7 @@ TESTS = test_base
 
 check_PROGRAMS = test_base
 
-test_base_SOURCES = test_base.cpp errors_test.cpp errors_test.h
+test_base_SOURCES = ../runner.cpp errors_test.cpp errors_test.h
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/unit_tests/runner.cpp
+++ b/unit_tests/runner.cpp
@@ -6,15 +6,12 @@
  *
  * This software is distributed under the Common Public License 1.0
  */
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <libtsk.h>
+
+#include <iostream>
+
 #include <cppunit/CompilerOutputter.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
-
-
 
 int main(int argc, char **argv) {
 	// Get the top level suite from the registry
@@ -33,7 +30,3 @@ int main(int argc, char **argv) {
 	  // Return error code 1 if the one of test failed.
 	  return wasSuccessful ? 0 : 1;
 }
-
-
-
-


### PR DESCRIPTION
This PR cleans up numerous messes with the build setup:

* Removes unnecessary m4_includes from configure.ac
* Fixes a typo in the name of a variable holding pthreads flags.
* Stops incorrectly adding /usr/local/lib to LDFLAGS and /usr/local/include to CPPFLAGS.
* Sorts the image format support display configure prints.
* Corrects detection of cppunit.
* Makes detection of sqlite3 more robust.
* Corrects the extension for the unit tests executable.
* Adds some generated files to .gitignore.