### PR TITLE
now runs unit tests as part of ci/cd

### DIFF
--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -141,14 +141,14 @@ jobs:
           ./configure CFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' CXXFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' --enable-silent-rules --quiet
           make clean
           make $MAKE_OPTS check
-          (cd unit-tests; make $MAKE_OPTS check)
+          (cd unit_tests; make $MAKE_OPTS check)
           echo test results:
           for fn in */*.log ; do echo $fn: ; cat $fn ; done
 
       - name: Run C++ unit test and gcov
         if: env.run_codecov == 'true'
         run: |
-          (cd unit-tests; ./runner)
+          (cd unit_tests; ./runner)
           echo move the .gcno and .gcda files into place
           find . -name '.libs' -type d -exec bash -c "cd {} ; pwd ; mv -vf *.gc* .." \;
           echo gcno:

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -132,7 +132,6 @@ jobs:
 
       - name: Prepare C++ executable for running unit tests with codecov
         run: |
-          pip3 install coverage
           bash ./bootstrap
           ./configure CFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' CXXFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' --enable-silent-rules --quiet
           make clean
@@ -163,6 +162,9 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip3 install coverage
           bash <(curl -s https://codecov.io/bash)
 
       - name: newstyle upload codecov report (unexplicably fails)

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -57,6 +57,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install wget libtool autoconf automake libtool libxml2 libewf pkg-config cppunit
+          find / -type f -print | grep cppunit
           bash ./bootstrap
 
       - name: "Configure for Ubuntu"

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -136,7 +136,11 @@ jobs:
           bash ./bootstrap
           ./configure CFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' CXXFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' --enable-silent-rules --quiet
           make clean
-          make $MAKE_OPTS  check || (echo ==error== ; cat test-suite.log; exit 1)
+          make $MAKE_OPTS
+
+      - name: Run C++ unit-test with codecov
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64')
+          (cd unit-tests; make $MAKE_OPTS  check ) || (echo ==error== ; cat test-suite.log; exit 1)
           echo test results:
           for fn in */*.log ; do echo $fn: ; cat $fn ; done
 

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Prepare C++ executable for running unit tests with codecov
         run: |
-          sudo pip3 install coverage
+          pip3 install coverage
           bash ./bootstrap
           ./configure CFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' CXXFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' --enable-silent-rules --quiet
           make clean

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Prep the VM (MacOS)
         if: startsWith(matrix.os, 'macos')
@@ -129,8 +130,7 @@ jobs:
       # A separate .gcda file is created for each object file compiled with this option.
       # It contains arc transition counts, value profile counts, and some summary information.
 
-      - name: Prepare C++ checks with codecov
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64')
+      - name: Prepare C++ executable for running unit tests with codecov
         run: |
           sudo pip3 install coverage
           bash ./bootstrap
@@ -138,8 +138,7 @@ jobs:
           make clean
           make $MAKE_OPTS
 
-      - name: Run C++ unit-test with codecov
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64')
+      - name: Run C++ unit-test
         run: |
           (cd unit-tests; make $MAKE_OPTS  check ) || (echo ==error== ; cat test-suite.log; exit 1)
           echo test results:
@@ -166,7 +165,8 @@ jobs:
         run: |
           bash <(curl -s https://codecov.io/bash)
 
-      - name: upload codecov report
+      - name: newstyle upload codecov report (unexplicably fails)
+        # commented out because it unexplicitly fails
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64') && false
         uses: codecov/codecov-action@v4
         with:
@@ -185,3 +185,8 @@ jobs:
 
       - uses: ammaraskar/gcc-problem-matcher@0.2.0
         name: GCC Problem Matcher
+
+      - name: List all files
+        shell: bash
+        run: |
+          find . -ls

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -133,8 +133,9 @@ jobs:
           make clean
           make $MAKE_OPTS
 
-      - name: Run C++ unit-test
+      - name: Run C++ cppunit unit-test
         run: |
+          export CPPFLAGS="$CPPFLAGS $(pkg-config cppunit --cflags)"
           (cd unit-tests; make $MAKE_OPTS  check ) || (echo ==error== ; cat test-suite.log; exit 1)
           echo test results:
           for fn in */*.log ; do echo $fn: ; cat $fn ; done

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -1,4 +1,4 @@
- This file based on https://gist.github.com/mwouts/9842452d020c08faf9e84a3bba38a66f
+# This file based on https://gist.github.com/mwouts/9842452d020c08faf9e84a3bba38a66f
 # See: https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners
 # 2022-08-06 - slg - Updated os to be 'macos-latest', 'ubuntu-20.04', 'ubuntu-22.04'
 #                    See https://github.com/actions/virtual-environments for details.

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set codecov
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64') && true
         run: |
-          echo "run_codecov=true >> $GITHUB_ENV
+          echo "run_codecov=true" >> $GITHUB_ENV
 
       # https://github.com/actions/checkout
       - name: Checkout

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -140,6 +140,7 @@ jobs:
 
       - name: Run C++ unit-test with codecov
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64')
+        run: |
           (cd unit-tests; make $MAKE_OPTS  check ) || (echo ==error== ; cat test-suite.log; exit 1)
           echo test results:
           for fn in */*.log ; do echo $fn: ; cat $fn ; done

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -39,11 +39,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Prep the VM (MacOS)
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          brew install cppunit
-
       - name: Prep the VM (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |
@@ -61,7 +56,7 @@ jobs:
       - name: "Configure for MacOS"
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install wget libtool autoconf automake libtool libxml2 libewf pkg-config
+          brew install wget libtool autoconf automake libtool libxml2 libewf pkg-config cppunit
           bash ./bootstrap
 
       - name: "Configure for Ubuntu"

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -135,7 +135,6 @@ jobs:
 
       - name: Run C++ cppunit unit-test
         run: |
-          export CPPFLAGS="$CPPFLAGS $(pkg-config cppunit --cflags)"
           (cd unit-tests; make $MAKE_OPTS  check ) || (echo ==error== ; cat test-suite.log; exit 1)
           echo test results:
           for fn in */*.log ; do echo $fn: ; cat $fn ; done

--- a/.github/workflows/compile-mac_linux-codecov.yml
+++ b/.github/workflows/compile-mac_linux-codecov.yml
@@ -1,4 +1,4 @@
-# This file based on https://gist.github.com/mwouts/9842452d020c08faf9e84a3bba38a66f
+ This file based on https://gist.github.com/mwouts/9842452d020c08faf9e84a3bba38a66f
 # See: https://help.github.com/en/actions/reference/software-installed-on-github-hosted-runners
 # 2022-08-06 - slg - Updated os to be 'macos-latest', 'ubuntu-20.04', 'ubuntu-22.04'
 #                    See https://github.com/actions/virtual-environments for details.
@@ -32,6 +32,15 @@ jobs:
       NOHARDFAIL: TRUE
 
     steps:
+      - name: Set variables
+        run: |
+          echo "run_codecov=false" >> $GITHUB_ENV
+
+      - name: Set codecov
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64') && true
+        run: |
+          echo "run_codecov=true >> $GITHUB_ENV
+
       # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@v4
@@ -126,22 +135,20 @@ jobs:
       # A separate .gcda file is created for each object file compiled with this option.
       # It contains arc transition counts, value profile counts, and some summary information.
 
-      - name: Prepare C++ executable for running unit tests with codecov
+      - name: Prepare C++ executable and make check
         run: |
           bash ./bootstrap
           ./configure CFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' CXXFLAGS='-g -O0 -fprofile-arcs -ftest-coverage' --enable-silent-rules --quiet
           make clean
-          make $MAKE_OPTS
-
-      - name: Run C++ cppunit unit-test
-        run: |
-          (cd unit-tests; make $MAKE_OPTS  check ) || (echo ==error== ; cat test-suite.log; exit 1)
+          make $MAKE_OPTS check
+          (cd unit-tests; make $MAKE_OPTS check)
           echo test results:
           for fn in */*.log ; do echo $fn: ; cat $fn ; done
 
-      - name: Run gcov
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64')
+      - name: Run C++ unit test and gcov
+        if: env.run_codecov == 'true'
         run: |
+          (cd unit-tests; ./runner)
           echo move the .gcno and .gcda files into place
           find . -name '.libs' -type d -exec bash -c "cd {} ; pwd ; mv -vf *.gc* .." \;
           echo gcno:
@@ -154,7 +161,7 @@ jobs:
           ls -l tests
 
       - name: oldstyle upload codecov report
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.platform, 'x64') && true
+        if: env.run_codecov == 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
       - uses: actions/setup-dotnet@v1
       - uses: microsoft/setup-msbuild@v1.1
 
@@ -65,7 +68,7 @@ jobs:
       - name: bash printenv
         shell: bash
         run: |
-          printenv
+          printenv | sort
 
       - name: Build TSK
         run: |
@@ -80,3 +83,8 @@ jobs:
           cd case-uco\java
           ant -q
           cd ..\..
+
+      - name: List all files
+        shell: bash
+        run: |
+          find . -ls

--- a/unit_tests/Makefile.am
+++ b/unit_tests/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I.. -I$(srcdir)/..
+AM_CPPFLAGS = -I.. -I$(srcdir)/..  -I/System/Volumes/Data/opt/homebrew/Cellar/cppunit/1.15.1/include/
 AM_CFLAGS += $(PTHREAD_CFLAGS)
 AM_CXXFLAGS += -Wno-unused-command-line-argument $(PTHREAD_CFLAGS)
 LDADD = ../tsk/libtsk.la

--- a/unit_tests/Makefile.am
+++ b/unit_tests/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I.. -I$(srcdir)/..  -I/System/Volumes/Data/opt/homebrew/Cellar/cp
 AM_CFLAGS += $(PTHREAD_CFLAGS)
 AM_CXXFLAGS += -Wno-unused-command-line-argument $(PTHREAD_CFLAGS)
 LDADD = ../tsk/libtsk.la
-LDFLAGS += -static $(PTHREAD_LIBS) -lcppunit
+LDFLAGS += -static $(PTHREAD_LIBS) -L/opt/homebrew/Cellar/cppunit/1.15.1/lib -lcppunit
 
 
 SUBDIRS = base img


### PR DESCRIPTION
@uckelman-sf it fixing this to use catch2, but this works for now.
* @uckelman-sf  - Please note that on MacOS CI/CD the path for cppunit is hard-coded until the autoconf file gets fixed.
* @uckelman-sf  - Please note that codecov upload is working, but something seems off. I should get it fixed at some point.