### PR TITLE
Fixed incorrectly cased header file name

### DIFF
--- a/tsk/fs/logical_fs.cpp
+++ b/tsk/fs/logical_fs.cpp
@@ -26,7 +26,7 @@
 #include "tsk/img/logical_img.h"
 
 #ifdef TSK_WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 using std::vector;


### PR DESCRIPTION
The case of header filenames doesn't matter on Windows, but needs to be correct on systems where paths are case-sensitive.