### PR TITLE
Don't define fseeko if it's already defined

### DIFF
--- a/tsk/base/tsk_os.h
+++ b/tsk/base/tsk_os.h
@@ -51,7 +51,10 @@
 #define roundup(x, y)   \
     ( ( ((x)+((y) - 1)) / (y)) * (y) )
 
+#ifndef fseeko
 #define fseeko fseek
+#endif
+
 #define daddr_t int
 #endif
 


### PR DESCRIPTION
This fixes a compilation error when cross-compiling with MinGW.