### PR TITLE
Remove unnecessary m4_includes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,8 +5,6 @@ AC_PREREQ([2.69])
 
 AC_INIT([sleuthkit],[4.12.1])
 AC_CONFIG_AUX_DIR([config])
-m4_include([m4/slg_address_sanitizer.m4])
-m4_include([m4/slg_noopt.m4])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([tsk/base/tsk_base.h])
 AC_CONFIG_HEADERS([tsk/tsk_config.h])


### PR DESCRIPTION
`m4` is the set as the include directory. Use of `m4_include` for specific files is unnecessary.