### PR TITLE
Switch fiwalk from libregex to std::regex

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,6 @@ AC_SUBST([CXXLD])
 
 dnl Dependencies for fiwalk
 AC_CHECK_FUNCS([getline])
-AC_SEARCH_LIBS(regexec, [regex], , AC_MSG_ERROR([missing regex]))
 
 dnl OpenSSL support for encryption - currently disabled due to automatic test failures
 dnl AX_CHECK_OPENSSL(

--- a/tools/fiwalk/src/arff.cpp
+++ b/tools/fiwalk/src/arff.cpp
@@ -28,13 +28,7 @@
 #include <sys/time.h>
 #endif
 
-#ifdef _MSC_VER
-  #include "regex.h"  //use regex in src tree
-#else
-  extern "C" {
-    #include <regex.h>
-  }
-#endif
+#include <regex>
 
 #include "arff.h"
 
@@ -73,25 +67,19 @@ bool arff::is_weka_date(const string &s)
 /* microsoft metadata date format: YYYY-MM-DDTHH:MM:SSZ */
 bool arff::is_msword_date(const string &s)
 {
-  //regex_t objects hold the regular expressions
-  static regex_t msdoc_date;
+  static const std::regex msdoc_date("[0-9]{4}-[01]{1}[0-9]{1}-[0123]{1}[0-9]{1}T[012]{1}[0-9]{1}:[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}Z", std::regex::extended | std::regex::icase);
 
-  regcomp(&msdoc_date, "[0-9]{4}-[01]{1}[0-9]{1}-[0123]{1}[0-9]{1}T[012]{1}[0-9]{1}:[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}Z", REG_EXTENDED|REG_ICASE);
-
-  return regexec(&msdoc_date, s.c_str(), 0, NULL, 0)==REGEX_MATCH;
-
+  std::smatch m;
+  return std::regex_match(s, m, msdoc_date);
 }
 
 /* exif metadate date format: YYYY:MM:DD HH:MM:SS */
 bool arff::is_exif_date(const string &s)
 {
-  //regex_t objects hold the regular expressions
-  static regex_t exif_date;
+  static const std::regex exif_date("[0-9]{4}:[01]{1}[0-9]{1}:[0123]{1}[0-9]{1} [012]{1}[0-9]{1}:[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}", std::regex::extended | std::regex::icase);
 
-  regcomp(&exif_date, "[0-9]{4}:[01]{1}[0-9]{1}:[0123]{1}[0-9]{1} [012]{1}[0-9]{1}:[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}", REG_EXTENDED|REG_ICASE);
-
-  return regexec(&exif_date, s.c_str(), 0, NULL, 0)==REGEX_MATCH;
-
+  std::smatch m;
+  return std::regex_match(s, m, exif_date);
 }
 
 /* checks to see if input string is a recognized date format-- one of

--- a/tools/fiwalk/src/plugin.cpp
+++ b/tools/fiwalk/src/plugin.cpp
@@ -8,7 +8,7 @@
  *
  * dgi      means use the digitial forensics gateway interface; each plug-in is called
  *          with the filename on the command line to analyze, and the found terms are sent
- *	    to stdout as a series of name: value pairs.
+ *      to stdout as a series of name: value pairs.
  *
  * command  the command to run.
  *
@@ -32,8 +32,8 @@
 #include <sys/stat.h>
 #ifdef TSK_WIN32
 #include <direct.h>
-#define popen	_popen
-#define pclose	_pclose
+#define popen  _popen
+#define pclose  _pclose
 #else
 #include <dirent.h>
 #endif
@@ -95,89 +95,91 @@ ssize_t getline(char** lineptr, size_t*, FILE* stream) {
 
 class myglob {
 public:
-    regex_t reg;
+  regex_t reg;
 
-    myglob(const std::string &pattern){
-	/* Build the regular expression from the pattern */
-	string re;				// the regular expression
+  myglob(const std::string &pattern){
+    /* Build the regular expression from the pattern */
+    string re;        // the regular expression
 
-	re.push_back('^');			// beginning of string
-	for(string::const_iterator it = pattern.begin(); it!=pattern.end(); it++){
-	    switch(*it){
-	    case '?': re.push_back('.'); break;
-	    case '.': re.append("[.]");  break;
-	    case '(': re.append("\\(");  break;
-	    case ')': re.append("\\)");  break;
-	    case '*': re.append(".*");   break;
-	    default:  re.push_back(*it); break;
-	    }
-	}
-	re.push_back('$');
-	if(regcomp(&reg,re.c_str(),REG_EXTENDED|REG_ICASE)){
-	    std::cerr << "invalid regular expression: " << re << "\n";
-	    exit(1);
-	}
-    };
-    bool match(const std::string &fname){
-	regmatch_t pmatch[10];
-	memset(pmatch,0,sizeof(pmatch));
-	int res = regexec(&reg,fname.c_str(),10,pmatch,0);
-	return (res==0);
-    };
-    ~myglob(){
-	regfree(&reg);
-    };
+    re.push_back('^');      // beginning of string
+    for(string::const_iterator it = pattern.begin(); it!=pattern.end(); it++){
+      switch(*it) {
+      case '?': re.push_back('.'); break;
+      case '.': re.append("[.]");  break;
+      case '(': re.append("\\(");  break;
+      case ')': re.append("\\)");  break;
+      case '*': re.append(".*");   break;
+      default:  re.push_back(*it); break;
+      }
+    }
+    re.push_back('$');
+    if(regcomp(&reg,re.c_str(),REG_EXTENDED|REG_ICASE)){
+      std::cerr << "invalid regular expression: " << re << "\n";
+      exit(1);
+    }
+  };
+
+  bool match(const std::string &fname){
+    regmatch_t pmatch[10];
+    memset(pmatch,0,sizeof(pmatch));
+    int res = regexec(&reg,fname.c_str(),10,pmatch,0);
+    return (res==0);
+  };
+
+  ~myglob(){
+    regfree(&reg);
+  };
 };
 
 
 /** describes each plugin */
 class plugins {
 public:
-    myglob *glob;
-    string pattern;		// what we want
-    string method;
-    string path;
-    plugins():glob(0){
-    }
-    plugins(string pattern,string method,string path){
-	this->pattern = pattern;
-	this->glob = new myglob(pattern.c_str());
-	this->method = method;
-	this->path = path;
+  myglob *glob;
+  string pattern;    // what we want
+  string method;
+  string path;
+  plugins():glob(0){
+  }
+  plugins(string pattern,string method,string path){
+    this->pattern = pattern;
+    this->glob = new myglob(pattern.c_str());
+    this->method = method;
+    this->path = path;
 
+  }
+  ~plugins() {
+    if(glob){
+      delete glob;
+      glob=0;
     }
-    ~plugins() {
-	if(glob){
-	    delete glob;
-	    glob=0;
-	}
-    }
+  }
 };
 
 vector<class plugins *> plugin_list;
 
 static bool all_whitespace(const char *buf)
 {
-    while(*buf){
-	if(!isspace(*buf)) return false;
-	buf++;
-    }
-    return true;
+  while(*buf){
+    if(!isspace(*buf)) return false;
+    buf++;
+  }
+  return true;
 }
 
 /** Return TRUE if the FNAME requires plugin processing */
 const plugins *current_plugin = 0;
 bool plugin_match(const std::string &fname)
 {
-    for(vector<class plugins *>::const_iterator i = plugin_list.begin();
-	i != plugin_list.end();
-	i++){
-	if( (*i)->glob->match(fname)){
-	    current_plugin = (*i);
-	    return true;
-	}
+  for(vector<class plugins *>::const_iterator i = plugin_list.begin();
+    i != plugin_list.end();
+    i++){
+    if( (*i)->glob->match(fname)){
+      current_plugin = (*i);
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 /** Called by fiwalk main for each extracted file.
@@ -188,101 +190,101 @@ bool plugin_match(const std::string &fname)
  */
 void fiwalk::plugin_process(const std::string &fname)
 {
-    comment("plugin_process",fname.c_str());
-    static bool first = true;
-    static regex_t ncv;
-    if(first){
-	if(regcomp(&ncv,"([-a-zA-Z0-9_]+): +(.*)",REG_EXTENDED)) err(1,"regcomp");
-	first = 0;
+  comment("plugin_process",fname.c_str());
+  static bool first = true;
+  static regex_t ncv;
+  if(first){
+    if(regcomp(&ncv,"([-a-zA-Z0-9_]+): +(.*)",REG_EXTENDED)) err(1,"regcomp");
+    first = 0;
+  }
+
+  if(current_plugin->method=="dgi"){
+    string cmd = current_plugin->path + " " + fname;
+    FILE *f = popen(cmd.c_str(),"r");
+    if(!f) err(1,"fopen: %s",cmd.c_str());
+    char *linebuf=0;
+    size_t linecapp=0;
+    if(getline(&linebuf,&linecapp,f)>0){
+      char *cc = strchr(linebuf,'\n');
+      if(cc){    // we found an end-of-line
+        *cc = '\000';
+      }
+
+      /* process name: value pairs */
+      regmatch_t pmatch[4];
+      memset(pmatch,0,sizeof(pmatch));
+      if(regexec(&ncv,linebuf,4,pmatch,0)){
+        fprintf(stderr,"*** FILE: %s   line: %u\n",__FILE__,__LINE__);
+        fprintf(stderr,"*** plugin %s returned: '%s'\n", current_plugin->path.c_str(),linebuf);
+        fprintf(stderr,"*** original command line: %s\n",cmd.c_str());
+        fprintf(stderr,"*** %s will not be deleted.\n",fname.c_str());
+        exit(1);
+      }
+      linebuf[pmatch[1].rm_eo] = 0;
+      linebuf[pmatch[2].rm_eo] = 0;
+      char *name = linebuf+pmatch[1].rm_so;
+      char *value = linebuf+pmatch[2].rm_so;
+
+      /* clean any characters in the name */
+      for(char *cc=name;*cc;cc++){
+        if (!isalpha(*cc)) *cc='_';
+      }
+      file_info(name,value);  // report each identified name & value
+      free(linebuf);
     }
-
-    if(current_plugin->method=="dgi"){
-	string cmd = current_plugin->path + " " + fname;
-	FILE *f = popen(cmd.c_str(),"r");
-	if(!f) err(1,"fopen: %s",cmd.c_str());
-        char *linebuf=0;
-        size_t linecapp=0;
-        if(getline(&linebuf,&linecapp,f)>0){
-	    char *cc = strchr(linebuf,'\n');
-	    if(cc){		// we found an end-of-line
-		*cc = '\000';
-	    }
-
-	    /* process name: value pairs */
-	    regmatch_t pmatch[4];
-	    memset(pmatch,0,sizeof(pmatch));
-	    if(regexec(&ncv,linebuf,4,pmatch,0)){
-		fprintf(stderr,"*** FILE: %s   line: %u\n",__FILE__,__LINE__);
-		fprintf(stderr,"*** plugin %s returned: '%s'\n", current_plugin->path.c_str(),linebuf);
-		fprintf(stderr,"*** original command line: %s\n",cmd.c_str());
-		fprintf(stderr,"*** %s will not be deleted.\n",fname.c_str());
-		exit(1);
-	    }
-	    linebuf[pmatch[1].rm_eo] = 0;
-	    linebuf[pmatch[2].rm_eo] = 0;
-	    char *name = linebuf+pmatch[1].rm_so;
-	    char *value = linebuf+pmatch[2].rm_so;
-
-	    /* clean any characters in the name */
-	    for(char *cc=name;*cc;cc++){
-                if (!isalpha(*cc)) *cc='_';
-	    }
-	    file_info(name,value);	// report each identified name & value
-            free(linebuf);
-	}
-	pclose(f);
-	return;
-    }
+    pclose(f);
+    return;
+  }
 }
 
 
 void fiwalk::config_read(const char *fname)
 {
-    /* make sure the glob function works */
-    myglob *g1 = new myglob("*.jpeg");
-    myglob *g2 = new myglob("*.jpg");
+  /* make sure the glob function works */
+  myglob *g1 = new myglob("*.jpeg");
+  myglob *g2 = new myglob("*.jpg");
 
-    assert(g1->match("file.jpeg")==true);
-    assert(g1->match("file.jpg")==false);
+  assert(g1->match("file.jpeg")==true);
+  assert(g1->match("file.jpg")==false);
 
-    assert(g2->match("file.jpeg")==false);
-    assert(g2->match("file.jpg")==true);
-    delete g1;
-    delete g2;
+  assert(g2->match("file.jpeg")==false);
+  assert(g2->match("file.jpg")==true);
+  delete g1;
+  delete g2;
 
-    // Compile the regular expression we will use;
-    // Unfortunately the POSIX regex has no support for \s
-    regex_t r;
-    if(regcomp(&r,"([^ \t]+)[ \t]+([^ \t]+)[ \t]+([^\t\r\n]+)",REG_EXTENDED)) err(1,"regcomp");
-    FILE *f = fopen(fname,"r");
-    if(!f) err(1,"%s",fname);
-    char linebuf[1024];
-    int linenumber = 0;
-    while(fgets(linebuf,sizeof(linebuf),f)){
-	linenumber++;
-	char *cc = strchr(linebuf,'#');
-	if(cc) *cc = 0;			// terminate #'s
+  // Compile the regular expression we will use;
+  // Unfortunately the POSIX regex has no support for \s
+  regex_t r;
+  if(regcomp(&r,"([^ \t]+)[ \t]+([^ \t]+)[ \t]+([^\t\r\n]+)",REG_EXTENDED)) err(1,"regcomp");
+  FILE *f = fopen(fname,"r");
+  if(!f) err(1,"%s",fname);
+  char linebuf[1024];
+  int linenumber = 0;
+  while(fgets(linebuf,sizeof(linebuf),f)){
+    linenumber++;
+    char *cc = strchr(linebuf,'#');
+    if(cc) *cc = 0;      // terminate #'s
 
-	/* if the line all whitespace ignore it */
-	if(all_whitespace(linebuf)) continue;
+    /* if the line all whitespace ignore it */
+    if(all_whitespace(linebuf)) continue;
 
-	/* parse the line */
-	regmatch_t pmatch[10];
-	memset(pmatch,0,sizeof(pmatch));
-	int res = regexec(&r,linebuf,10,pmatch,0);
-	if(res){
-	    fprintf(stderr,"Error in configuration file line %d: %s\n",linenumber,linebuf);
-	    exit(1);
-	}
-	linebuf[pmatch[1].rm_eo] = 0;
-	linebuf[pmatch[2].rm_eo] = 0;
-	linebuf[pmatch[3].rm_eo] = 0;
-
-	class plugins *plug = new plugins(linebuf+pmatch[1].rm_so, linebuf+pmatch[2].rm_so, linebuf+pmatch[3].rm_so);
-	plug->glob = new myglob(plug->pattern.c_str());
-	comment("pattern: %s  method: %s  path: %s",plug->pattern.c_str(),plug->method.c_str(),plug->path.c_str());
-	plugin_list.push_back(plug);
+    /* parse the line */
+    regmatch_t pmatch[10];
+    memset(pmatch,0,sizeof(pmatch));
+    int res = regexec(&r,linebuf,10,pmatch,0);
+    if(res){
+      fprintf(stderr,"Error in configuration file line %d: %s\n",linenumber,linebuf);
+      exit(1);
     }
-    fclose(f);
-    regfree(&r);
+    linebuf[pmatch[1].rm_eo] = 0;
+    linebuf[pmatch[2].rm_eo] = 0;
+    linebuf[pmatch[3].rm_eo] = 0;
+
+    class plugins *plug = new plugins(linebuf+pmatch[1].rm_so, linebuf+pmatch[2].rm_so, linebuf+pmatch[3].rm_so);
+    plug->glob = new myglob(plug->pattern.c_str());
+    comment("pattern: %s  method: %s  path: %s",plug->pattern.c_str(),plug->method.c_str(),plug->path.c_str());
+    plugin_list.push_back(plug);
+  }
+  fclose(f);
+  regfree(&r);
 }


### PR DESCRIPTION
fiwalk depends on libregex. There isn't a mingw package for libregex in Ubuntu, which means we can't compile for mingw in the test runners as-is. C++11 has `std::regex`, which has the same functionality as libregex with no additional dependencies.

This PR adjusts fiwalk to use `std::regex`.