### PR TITLE
Use libewf_handle_read_buffer_at_offset with newer versions of libewf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,8 +143,19 @@ dnl Check if we should link with zlib
 TSK_OPT_DEP_CHECK([zlib], [ZLIB], [zlib], [zlib.h], [z], [inflate])
 dnl Check if we should link with libbfio
 TSK_OPT_DEP_CHECK([libbfio], [], [libbfio], [libbfio.h], [bfio], [libbfio_get_version])
+
 dnl Check if we should link with libewf
 TSK_OPT_DEP_CHECK([libewf], [EWF], [libewf], [libewf.h], [ewf], [libewf_get_version])
+dnl Check for libewf_handle_read_buffer_at_offset, in newer versions of libewf
+AS_IF(
+  [test "x$ax_libewf" != "xno"],
+  [AC_CHECK_LIB(
+    [ewf],
+    [libewf_handle_read_buffer_at_offset],
+    [AC_DEFINE([HAVE_LIBEWF_HANDLE_READ_BUFFER_AT_OFFSET], [1], [Define to 1 if you have the `libewf_handle_read_buffer_at_offset' function.])]
+  )]
+)
+
 dnl Check if we should link with libqcow
 TSK_OPT_DEP_CHECK([libqcow], [QCOW], [libqcow], [libqcow.h], [qcow], [libqcow_get_version])
 dnl Check if we should link with libvhdi

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -68,7 +68,7 @@ ewf_image_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf,
 
     tsk_take_lock(&(ewf_info->read_lock));
 #if defined( HAVE_LIBEWF_V2_API )
-#if defined(LIBEWF_VERSION) && LIBEWF_VERSION >= 20141129
+#ifdef HAVE_LIBEWF_HANDLE_READ_BUFFER_AT_OFFSET
     cnt = libewf_handle_read_buffer_at_offset(
 #else
     cnt = libewf_handle_read_random(

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -68,8 +68,13 @@ ewf_image_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf,
 
     tsk_take_lock(&(ewf_info->read_lock));
 #if defined( HAVE_LIBEWF_V2_API )
-    cnt = libewf_handle_read_random(ewf_info->handle,
-        buf, len, offset, &ewf_error);
+#if defined(LIBEWF_VERSION) && LIBEWF_VERSION >= 20141129
+    cnt = libewf_handle_read_buffer_at_offset(
+#else
+    cnt = libewf_handle_read_random(
+#endif
+        ewf_info->handle, buf, len, offset, &ewf_error
+    );
     if (cnt < 0) {
         char *errmsg = NULL;
         tsk_error_reset();


### PR DESCRIPTION
libewf_handle_read_random() was renamed libewf_handle_read_buffer_at_offset() as of libewf 20141129. Check for libewf_handle_read_buffer_at_offseton so we can select the correct function name.