### PR TITLE
Remove support for libewf V1 API

### DIFF
--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -23,8 +23,6 @@ using std::string;
 
 #define TSK_EWF_ERROR_STRING_SIZE 512
 
-
-#if defined( HAVE_LIBEWF_V2_API )
 /**
  * Get error string from libewf and make buffer empty if that didn't work. 
  * @returns 1 if error message was not set
@@ -40,16 +38,13 @@ getError(libewf_error_t * ewf_error,
     libewf_error_free(&ewf_error);
     return retval <= 0;
 }
-#endif
 
 static ssize_t
 ewf_image_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf,
     size_t len)
 {
-#if defined( HAVE_LIBEWF_V2_API )
     char error_string[TSK_EWF_ERROR_STRING_SIZE];
     libewf_error_t *ewf_error = NULL;
-#endif
 
     ssize_t cnt;
     IMG_EWF_INFO *ewf_info = (IMG_EWF_INFO *) img_info;
@@ -67,7 +62,6 @@ ewf_image_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf,
     }
 
     tsk_take_lock(&(ewf_info->read_lock));
-#if defined( HAVE_LIBEWF_V2_API )
 #ifdef HAVE_LIBEWF_HANDLE_READ_BUFFER_AT_OFFSET
     cnt = libewf_handle_read_buffer_at_offset(
 #else
@@ -90,17 +84,7 @@ ewf_image_read(TSK_IMG_INFO * img_info, TSK_OFF_T offset, char *buf,
         tsk_release_lock(&(ewf_info->read_lock));
         return -1;
     }
-#else
-    cnt = libewf_read_random(ewf_info->handle, buf, len, offset);
-    if (cnt < 0) {
-        tsk_error_reset();
-        tsk_error_set_errno(TSK_ERR_IMG_READ);
-        tsk_error_set_errstr("ewf_image_read - offset: %" PRIdOFF
-            " - len: %" PRIuSIZE " - %s", offset, len, strerror(errno));
-        tsk_release_lock(&(ewf_info->read_lock));
-        return -1;
-    }
-#endif
+
     tsk_release_lock(&(ewf_info->read_lock));
 
     return cnt;
@@ -130,12 +114,10 @@ ewf_glob_free(IMG_EWF_INFO* ewf_info) {
     // should do in v1...
     // @@@ Probably a memory leak in v1 unless libewf_close deals with it
     if (ewf_info->used_ewf_glob != 0) {
-#if defined ( HAVE_LIBEWF_V2_API)
 #ifdef TSK_WIN32
         libewf_glob_wide_free(ewf_info->img_info.images, ewf_info->img_info.num_img, NULL);
 #else
         libewf_glob_free(ewf_info->img_info.images, ewf_info->img_info.num_img, NULL);
-#endif
 #endif
         // ensure that tsk_img_free() does not double free images
         ewf_info->img_info.images = NULL;
@@ -148,12 +130,8 @@ ewf_image_close(TSK_IMG_INFO * img_info)
 {
     IMG_EWF_INFO *ewf_info = (IMG_EWF_INFO *) img_info;
 
-#if defined ( HAVE_LIBEWF_V2_API)
     libewf_handle_close(ewf_info->handle, NULL);
     libewf_handle_free(&(ewf_info->handle), NULL);
-#else
-    libewf_close(ewf_info->handle);
-#endif
 
     ewf_glob_free(ewf_info);
 
@@ -211,22 +189,13 @@ ewf_open(int a_num_img,
     const TSK_TCHAR * const a_images[], unsigned int a_ssize)
 {
     int is_error;
-#if defined( HAVE_LIBEWF_V2_API )
     char error_string[TSK_EWF_ERROR_STRING_SIZE];
 
     libewf_error_t *ewf_error = NULL;
     int result = 0;
-#elif !defined( LIBEWF_STRING_DIGEST_HASH_LENGTH_MD5 )
-    uint8_t md5_hash[16];
-#endif
 
     IMG_EWF_INFO *ewf_info = NULL;
     TSK_IMG_INFO *img_info = NULL;
-
-#if !defined( HAVE_LIBEWF_V2_API)
-    if (tsk_verbose)
-        libewf_set_notify_values(stderr, 1);
-#endif
 
     if ((ewf_info =
             (IMG_EWF_INFO *) tsk_img_malloc(sizeof(IMG_EWF_INFO))) ==
@@ -239,7 +208,6 @@ ewf_open(int a_num_img,
     // See if they specified only the first of the set...
     ewf_info->used_ewf_glob = 0;
     if (a_num_img == 1) {
-#if defined( HAVE_LIBEWF_V2_API)
 #ifdef TSK_WIN32
         is_error = (libewf_glob_wide(a_images[0], TSTRLEN(a_images[0]),
                 LIBEWF_FORMAT_UNKNOWN, &ewf_info->img_info.images,
@@ -259,25 +227,6 @@ ewf_open(int a_num_img,
             goto on_error;
         }
 
-#else                           //use v1
-
-#ifdef TSK_WIN32
-        ewf_info->img_info.num_img =
-            libewf_glob_wide(a_images[0], TSTRLEN(a_images[0]),
-            LIBEWF_FORMAT_UNKNOWN, &ewf_info->img_info.images);
-#else
-        ewf_info->img_info.num_img =
-            libewf_glob(a_images[0], TSTRLEN(a_images[0]),
-            LIBEWF_FORMAT_UNKNOWN, &ewf_info->img_info.images);
-#endif
-        if (ewf_info->img_info.num_img <= 0) {
-            tsk_error_reset();
-            tsk_error_set_errno(TSK_ERR_IMG_MAGIC);
-            tsk_error_set_errstr("ewf_open: Not an E01 glob name");
-            goto on_error;
-        }
-#endif                          // end v1
-
         ewf_info->used_ewf_glob = 1;
         if (tsk_verbose)
             tsk_fprintf(stderr,
@@ -289,8 +238,6 @@ ewf_open(int a_num_img,
             goto on_error;
         }
     }
-
-#if defined( HAVE_LIBEWF_V2_API )
 
     // Check the file signature before we call the library open
 #if defined( TSK_WIN32 )
@@ -409,98 +356,6 @@ ewf_open(int a_num_img,
     }
     ewf_info->sha1hash_isset = result;
 
-
-#else                           // V1 API
-
-    // Check the file signature before we call the library open
-#if defined( TSK_WIN32 )
-    is_error = (libewf_check_file_signature_wide(a_images[0]) != 1);
-#else
-    is_error = (libewf_check_file_signature(a_images[0]) != 1);
-#endif
-    if (is_error)
-    {
-        tsk_error_reset();
-        tsk_error_set_errno(TSK_ERR_IMG_MAGIC);
-        tsk_error_set_errstr("ewf_open: Not an EWF file");
-        if (tsk_verbose)
-            tsk_fprintf(stderr, "Not an EWF file\n");
-
-        goto on_error;
-    }
-
-#if defined( TSK_WIN32 )
-    ewf_info->handle = libewf_open_wide(
-        (wchar_t * const *) ewf_info->img_info.images, ewf_info->img_info.num_img,
-        LIBEWF_OPEN_READ);
-#else
-    ewf_info->handle = libewf_open(
-        (char *const *) ewf_info->img_info.images, ewf_info->img_info.num_img,
-        LIBEWF_OPEN_READ);
-#endif
-    if (ewf_info->handle == NULL) {
-        tsk_error_reset();
-        tsk_error_set_errno(TSK_ERR_IMG_OPEN);
-        tsk_error_set_errstr("ewf_open file: %" PRIttocTSK
-            ": Error opening", ewf_info->img_info.images[0]);
-
-        if (tsk_verbose) {
-            tsk_fprintf(stderr, "Error opening EWF file\n");
-        }
-        goto on_error;
-    }
-#if defined( LIBEWF_STRING_DIGEST_HASH_LENGTH_MD5 )
-    // 2007 version
-    img_info->size = libewf_get_media_size(ewf_info->handle);
-
-    ewf_info->md5hash_isset = libewf_get_stored_md5_hash(ewf_info->handle,
-        ewf_info->md5hash, LIBEWF_STRING_DIGEST_HASH_LENGTH_MD5);
-#else
-    // libewf-20080322 version
-    if (libewf_get_media_size(ewf_info->handle,
-            (size64_t *) & (img_info->size)) != 1) {
-        tsk_error_reset();
-        tsk_error_set_errno(TSK_ERR_IMG_OPEN);
-        tsk_error_set_errstr("ewf_open file: %" PRIttocTSK
-            ": Error getting size of image", ewf_info->img_info.images[0]);
-
-        if (tsk_verbose) {
-            tsk_fprintf(stderr, "Error getting size of EWF file\n");
-        }
-        goto on_error;
-    }
-    if (libewf_get_md5_hash(ewf_info->handle, md5_hash, 16) == 1) {
-        int md5_string_iterator = 0;
-        int md5_hash_iterator = 0;
-
-        for (md5_hash_iterator = 0;
-            md5_hash_iterator < 16; md5_hash_iterator++) {
-            int digit = md5_hash[md5_hash_iterator] / 16;
-
-            if (digit <= 9) {
-                ewf_info->md5hash[md5_string_iterator++] =
-                    '0' + (char) digit;
-            }
-            else {
-                ewf_info->md5hash[md5_string_iterator++] =
-                    'a' + (char) (digit - 10);
-            }
-            digit = md5_hash[md5_hash_iterator] % 16;
-
-            if (digit <= 9) {
-                ewf_info->md5hash[md5_string_iterator++] =
-                    '0' + (char) digit;
-            }
-            else {
-                ewf_info->md5hash[md5_string_iterator++] =
-                    'a' + (char) (digit - 10);
-            }
-        }
-        ewf_info->md5hash_isset = 1;
-    }
-#endif                          /* defined( LIBEWF_STRING_DIGEST_HASH_LENGTH_MD5 ) */
-#endif                          /* defined( HAVE_LIBEWF_V2_API ) */
-
     // use what they gave us
     if (a_ssize != 0) {
         img_info->sector_size = a_ssize;
@@ -546,15 +401,9 @@ ewf_open(int a_num_img,
 
 on_error:
     if (ewf_info->handle) {
-#if defined( HAVE_LIBEWF_V2_API )
         libewf_handle_close(ewf_info->handle, NULL);
-#else
-        libewf_close(ewf_info->handle);
-#endif
     }
-#if defined( HAVE_LIBEWF_V2_API )
     libewf_handle_free(&(ewf_info->handle), NULL);
-#endif
     ewf_glob_free(ewf_info);
     tsk_img_free(ewf_info);
     return NULL;

--- a/tsk/img/ewf.h
+++ b/tsk/img/ewf.h
@@ -21,12 +21,6 @@
 #include <libewf.h>
 #include <string>
 
-// libewf version 2 no longer defines LIBEWF_HANDLE
-#undef HAVE_LIBEWF_V2_API
-#if !defined( LIBEWF_HANDLE )
-#define HAVE_LIBEWF_V2_API
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The V1 API for libewf hasn't been in any libewf release for more than a decade. This PR removes support for it.