### PR TITLE
Fix appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ for:
         - job_name: Linux Build
 
     install:
-      - sudo apt install -y autoconf
+      - sudo apt install -y autoconf python3-venv
 
     build_script:
       - cat /etc/os-release


### PR DESCRIPTION
The AppVeyor worker is missing the python3-venv package:
```
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.
    apt-get install python3-venv
You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.
Failing command: ['/home/appveyor/projects/sleuthkit/tests/venv/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']
```