### PR TITLE
Clean warnings

### DIFF
--- a/tests/fiwalk_test.cpp
+++ b/tests/fiwalk_test.cpp
@@ -50,6 +50,7 @@ void check_image(std::string img_path, std::string dfxml2_path) {
         o.argv = argv;
         o.opt_variable = false;
         o.opt_zap = true;
+        o.opt_md5 = true;               // compute the MD5 of every file (for testing file extraction)
         o.xml_fn = dfxml2_path;
         o.run();
         CHECK(o.file_count > 0);

--- a/tools/fiwalk/plugins/jpeg_extract.cpp
+++ b/tools/fiwalk/plugins/jpeg_extract.cpp
@@ -19,7 +19,7 @@ int main(int argc,char **argv)
 	fprintf(stderr,"usage: %s <filename>",argv[0]);
 	exit(1);
     }
-    sprintf(cmdbuf,"exif -m %s 2>/dev/null",argv[1]);
+    snprintf(cmdbuf, sizeof(cmdbuf), "exif -m %s 2>/dev/null",argv[1]);
     FILE *f = popen(cmdbuf,"r");
     if(!f) perror(cmdbuf);
 

--- a/tools/fiwalk/src/hexbuf.c
+++ b/tools/fiwalk/src/hexbuf.c
@@ -21,7 +21,7 @@ const char *hexbuf(char *dst,int dst_len,const unsigned char *bin,int bytes,int 
     while(bytes>0 && dst_len > 3){
 //	int add_spaces = 0;
 
-	sprintf(dst,fmt,*bin); // convert the next byte
+	snprintf(dst, 3, fmt,*bin); // convert the next byte
 	dst += 2;
 	bin += 1;
 	dst_len -= 2;

--- a/tools/fiwalk/src/sha2.c
+++ b/tools/fiwalk/src/sha2.c
@@ -839,7 +839,7 @@ void test(const char *vector, unsigned char *digest,
     output[2 * digest_size] = '\0';
 
     for (i = 0; i < (int) digest_size ; i++) {
-       sprintf(output + 2 * i, "%02x", digest[i]);
+        snprintf(output + 2 * i, 3, "%02x", digest[i]);
     }
 
     printf("H: %s\n", output);

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -1313,7 +1313,7 @@ TskDbSqlite::addFile(TSK_FS_FILE* fs_file,
             snprintf(buf,sizeof(buf),"%x%x", (md5[i] >> 4) & 0xf, md5[i] & 0xf);
             md5Text[i*2] = buf[0];
             md5Text[i*2+1] = buf[1];
-            md5Text[i*2+2] = NULL;
+            md5Text[i*2+2] = '\000';
         }
         md5TextPtr = md5Text;
     }

--- a/tsk/auto/db_sqlite.cpp
+++ b/tsk/auto/db_sqlite.cpp
@@ -1309,8 +1309,11 @@ TskDbSqlite::addFile(TSK_FS_FILE* fs_file,
         // copy the hash as hexidecimal into the buffer
         for (int i = 0; i < 16; i++)
         {
-            sprintf(&(md5Text[i * 2]), "%x%x", (md5[i] >> 4) & 0xf,
-                md5[i] & 0xf);
+            char buf[3];
+            snprintf(buf,sizeof(buf),"%x%x", (md5[i] >> 4) & 0xf, md5[i] & 0xf);
+            md5Text[i*2] = buf[0];
+            md5Text[i*2+1] = buf[1];
+            md5Text[i*2+2] = NULL;
         }
         md5TextPtr = md5Text;
     }

--- a/tsk/auto/tsk_db.cpp
+++ b/tsk/auto/tsk_db.cpp
@@ -44,8 +44,8 @@ bool TskDb::getParentPathAndName(const char *path, const char **ret_parent_path,
     // name to match with the 'name' column in tsk_files table
 
     // reset all arrays
-    parent_name[0] = '\0';
-    parent_path[0] = '\0';
+    parent_name[0] = '\0';              // instance variable
+    parent_path[0] = '\0';              // instance variable
 
     size_t path_len = strlen(path);
     if (path_len >= MAX_PATH_LENGTH) {
@@ -69,7 +69,7 @@ bool TskDb::getParentPathAndName(const char *path, const char **ret_parent_path,
     // step 1, copy everything into parent_path and clean it up
     // add leading slash if its not in input.
     if (path[0] != '/') {
-        sprintf(parent_path, "%s", "/");
+        snprintf(parent_path, sizeof(parent_path), "%s", "/");
     }
 
     strncat(parent_path, path, MAX_PATH_LENGTH);
@@ -90,7 +90,7 @@ bool TskDb::getParentPathAndName(const char *path, const char **ret_parent_path,
         // character found in the string
         size_t position = chptr - parent_path;
 
-        sprintf(parent_name, "%s", chptr+1);  // copy everything after slash into parent_name
+        snprintf(parent_name, sizeof(parent_name), "%s", chptr+1);  // copy everything after slash into parent_name
         *ret_name = parent_name;
 
         parent_path[position + 1] = '\0';   // add terminating null after last "/"

--- a/tsk/base/crc.c
+++ b/tsk/base/crc.c
@@ -58,11 +58,9 @@ Status  : Copyright (C) Ross Williams, 1993. However, permission is
 /******************************************************************************/
 
 LOCAL ulong reflect P_((ulong v,int b));
-LOCAL ulong reflect (v,b)
+LOCAL ulong reflect (ulong v,int b)
 /* Returns the value v with the bottom b [0,32] bits reflected. */
 /* Example: reflect(0x3e23L,3) == 0x3e26                        */
-ulong v;
-int   b;
 {
  int   i;
  ulong t = v;
@@ -80,27 +78,23 @@ int   b;
 /******************************************************************************/
 
 LOCAL ulong widmask P_((p_cm_t));
-LOCAL ulong widmask (p_cm)
+LOCAL ulong widmask (p_cm_t p_cm)
 /* Returns a longword whose value is (2^p_cm->cm_width)-1.     */
 /* The trick is to do this portably (e.g. without doing <<32). */
-p_cm_t p_cm;
 {
  return (((1L<<(p_cm->cm_width-1))-1L)<<1)|1L;
 }
 
 /******************************************************************************/
 
-void cm_ini (p_cm)
-p_cm_t p_cm;
+void cm_ini (p_cm_t p_cm)
 {
  p_cm->cm_reg = p_cm->cm_init;
 }
 
 /******************************************************************************/
 
-void cm_nxt (p_cm,ch)
-p_cm_t p_cm;
-int    ch;
+void cm_nxt (p_cm_t p_cm,int ch)
 {
  int   i;
  ulong uch  = (ulong) ch;
@@ -121,18 +115,14 @@ int    ch;
 
 /******************************************************************************/
 
-void cm_blk (p_cm,blk_adr,blk_len)
-p_cm_t   p_cm;
-p_ubyte_ blk_adr;
-ulong    blk_len;
+void cm_blk (p_cm_t p_cm,p_ubyte_ blk_adr,ulong blk_len)
 {
  while (blk_len--) cm_nxt(p_cm,*blk_adr++);
 }
 
 /******************************************************************************/
 
-ulong cm_crc (p_cm)
-p_cm_t p_cm;
+ulong cm_crc (p_cm_t p_cm)
 {
  if (p_cm->cm_refot)
     return p_cm->cm_xorot ^ reflect(p_cm->cm_reg,p_cm->cm_width);

--- a/tsk/base/md5c.c
+++ b/tsk/base/md5c.c
@@ -196,9 +196,7 @@ TSK_MD5_Final(unsigned char digest[16], TSK_MD5_CTX * context)
 /* MD5 basic transformation. Transforms state based on block.
  */
 static void
-MD5Transform(state, block)
-  UINT4 state[4];
-  unsigned char block[64];
+MD5Transform(UINT4 state[4], unsigned char block[64])
 {
     UINT4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
@@ -290,10 +288,7 @@ MD5Transform(state, block)
   a multiple of 4.
  */
 static void
-Encode(output, input, len)
-  unsigned char *output;
-  UINT4 *input;
-  unsigned int len;
+Encode(unsigned char *output, UINT4 *input, unsigned int len)
 {
     unsigned int i, j;
 
@@ -309,10 +304,7 @@ Encode(output, input, len)
   a multiple of 4.
  */
 static void
-Decode(output, input, len)
-  UINT4 *output;
-  unsigned char *input;
-  unsigned int len;
+Decode(UINT4 *output,  unsigned char *input,   unsigned int len)
 {
     unsigned int i, j;
 
@@ -326,10 +318,7 @@ Decode(output, input, len)
  */
 
 static void
-MD5_memcpy(output, input, len)
-  POINTER output;
-  POINTER input;
-  unsigned int len;
+MD5_memcpy(POINTER output,   POINTER input,   unsigned int len)
 {
     unsigned int i;
 
@@ -340,10 +329,7 @@ MD5_memcpy(output, input, len)
 /* Note: Replace "for loop" with standard memset if possible.
  */
 static void
-MD5_memset(output, value, len)
-  POINTER output;
-  int value;
-  unsigned int len;
+MD5_memset(POINTER output,   int value,   unsigned int len)
 {
     unsigned int i;
 

--- a/tsk/base/sha1c.c
+++ b/tsk/base/sha1c.c
@@ -157,8 +157,7 @@ TSK_SHA_Init(TSK_SHA_CTX * shsInfo)
    Note that this corrupts the shsInfo->data area */
 
 static void
-SHSTransform(digest, data)
-  UINT4 *digest, *data;
+SHSTransform(UINT4 *digest, *data)
 {
     UINT4 A, B, C, D, E;        /* Local vars */
     UINT4 eData[16];            /* Expanded data */

--- a/tsk/base/sha1c.c
+++ b/tsk/base/sha1c.c
@@ -157,7 +157,7 @@ TSK_SHA_Init(TSK_SHA_CTX * shsInfo)
    Note that this corrupts the shsInfo->data area */
 
 static void
-SHSTransform(UINT4 *digest, *data)
+SHSTransform(UINT4 *digest, UINT4 *data)
 {
     UINT4 A, B, C, D, E;        /* Local vars */
     UINT4 eData[16];            /* Expanded data */

--- a/tsk/fs/fatfs_meta.c
+++ b/tsk/fs/fatfs_meta.c
@@ -551,7 +551,7 @@ fatfs_make_data_runs(TSK_FS_FILE * a_fs_file)
         TSK_FS_ATTR_RUN *data_run = NULL;
         TSK_FS_ATTR_RUN *data_run_tmp = NULL;
         TSK_FS_ATTR_RUN *data_run_head = NULL;
-        TSK_OFF_T full_len_s = 0;
+        // TSK_OFF_T full_len_s = 0;         // set but not used
         uint8_t canRecover = 1; // set to 0 if recovery is not possible
 
         if (tsk_verbose)
@@ -674,7 +674,7 @@ fatfs_make_data_runs(TSK_FS_FILE * a_fs_file)
                 data_run->addr = sbase;
             }
             data_run->len += fatfs->csize;
-            full_len_s += fatfs->csize;
+            // full_len_s += fatfs->csize;    // set but not used
 
             size_remain -= (fatfs->csize << fatfs->ssize_sh);
             clust++;
@@ -733,7 +733,7 @@ fatfs_make_data_runs(TSK_FS_FILE * a_fs_file)
         TSK_LIST *list_seen = NULL;
         TSK_FS_ATTR_RUN *data_run = NULL;
         TSK_FS_ATTR_RUN *data_run_head = NULL;
-        TSK_OFF_T full_len_s = 0;
+        // TSK_OFF_T full_len_s = 0;   // set but not used
         TSK_DADDR_T sbase;
         /* Do normal cluster chain walking for a file or directory, including
          * FAT32 and exFAT root directories. */
@@ -797,7 +797,7 @@ fatfs_make_data_runs(TSK_FS_FILE * a_fs_file)
             }
 
             data_run->len += fatfs->csize;
-            full_len_s += fatfs->csize;
+            // full_len_s += fatfs->csize;  // set but not used
             size_remain -= (fatfs->csize * fs->block_size);
 
             if ((int64_t) size_remain > 0) {

--- a/tsk/fs/iso9660.c
+++ b/tsk/fs/iso9660.c
@@ -2325,7 +2325,7 @@ iso9660_get_default_attr_type(const TSK_FS_FILE * a_file)
 static int
 load_vol_desc(TSK_FS_INFO * fs)
 {
-    int count = 0;
+    //int count = 0;  // set but never used
     ISO_INFO *iso = (ISO_INFO *) fs;
     TSK_OFF_T offs;
     char *myname = "iso_load_vol_desc";
@@ -2435,7 +2435,7 @@ load_vol_desc(TSK_FS_INFO * fs)
                 else {
                     ptmp->next = p;
                     p->next = NULL;
-                    count++;
+                    // count++; // set but never used
                 }
             }
 
@@ -2443,7 +2443,7 @@ load_vol_desc(TSK_FS_INFO * fs)
             else {
                 iso->pvd = p;
                 p->next = NULL;
-                count++;
+                // count++; // set but never used
             }
 
             break;
@@ -2468,7 +2468,7 @@ load_vol_desc(TSK_FS_INFO * fs)
                 else {
                     stmp->next = s;
                     s->next = NULL;
-                    count++;
+                    // count++;  // set but never used
                 }
             }
 
@@ -2476,7 +2476,7 @@ load_vol_desc(TSK_FS_INFO * fs)
             else {
                 iso->svd = s;
                 s->next = NULL;
-                count++;
+                // count++;   // set but never used
             }
 
             break;
@@ -2527,7 +2527,7 @@ load_vol_desc(TSK_FS_INFO * fs)
                 p->next = NULL;
                 free(p);
                 p = NULL;
-                count--;
+                // count--;   // set but never used
                 break;
             }
         }


### PR DESCRIPTION
removed some warnings by rewriting some function declarations to be C17 complaint, and also replacing `sprintf` with `snprintf`.