### PR TITLE
Disable dynamic extension loading in bundled sqlite3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,9 @@ AC_MSG_CHECKING(which sqlite3 to use)
 AS_IF([test "x$ax_sqlite3" = "xyes"],
       [AC_MSG_RESULT([system])
        PACKAGE_LIBS_PRIVATE="$PACKAGE_LIBS_PRIVATE -lsqlite3"],
-      [AC_MSG_RESULT([bundled])])
+      [AC_MSG_RESULT([bundled])
+       CPPFLAGS="$CFLAGS -DSQLITE_OMIT_LOAD_EXTENSION"]
+)
 AM_CONDITIONAL([HAVE_LIBSQLITE3], [test "x$ax_sqlite3" = "xyes"])
 
 dnl Check if we should link with OpenSSL

--- a/tsk/hashdb/sqlite_hdb.cpp
+++ b/tsk/hashdb/sqlite_hdb.cpp
@@ -12,7 +12,11 @@
 #include "tsk_hashdb_i.h"
 #include "tsk_hash_info.h"
 
-#include "tsk/auto/sqlite3.h"
+#ifdef HAVE_LIBSQLITE3
+  #include <sqlite3.h>
+#else
+  #include "../auto/sqlite3.h"
+#endif
 
 /**
 * \file sqlite_hdb.cpp


### PR DESCRIPTION
The bundled sqlite3 is currently built with dynamic extension loading turned on. Nothing in Sleuthkit uses dynamic extension loading. Dynamic extension loading uses libdl (which contains dlopen), and that generates compiler warnings during static builds when using the bundled sqlite3.

This PR turns off dynamic extension loading when using the bundled sqlite3.