### PR TITLE
Fix deadlock in error test

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -187,12 +187,6 @@ jobs:
         run: |
           ./configure ${{ matrix.configure_opts }} --enable-address-sanitizer
 
-      - name: DEBUG - just run fiwalk and see if it hangs
-        if: ${{ matrix.address_sanitizer == 'yes' }}
-        run: |
-          make -j tests/fiwalk_test VERBOSE=1
-          tests/fiwalk_test
-
       - name: Run make with address-sanitizer
         if: ${{ matrix.address_sanitizer == 'yes' }}
         run: |

--- a/test/tsk/base/test_tsk_error.cpp
+++ b/test/tsk/base/test_tsk_error.cpp
@@ -24,10 +24,7 @@ TEST_CASE("void ErrorsTest::testInitialState()","[errors]") {
 
 TEST_CASE("void ErrorsTest::testLengthChecks()","[errors]") {
   tsk_error_get_info();
-  std::string s;
-  for (unsigned x = 0; x < 4096; x ++) {
-    s = s + std::string("x");
-  }
+  const std::string s(4096, 'x');
   tsk_error_set_errstr("%s", s.c_str());
   std::string es(tsk_error_get_errstr());
   REQUIRE(es.size() < 1025);

--- a/test/tsk/base/test_tsk_error.cpp
+++ b/test/tsk/base/test_tsk_error.cpp
@@ -8,148 +8,112 @@
 #include "tsk/tsk_config.h"
 #include "tsk/libtsk.h"
 
+#include <condition_variable>
 #include <cstring>
+#include <mutex>
+#include <thread>
 
 #include "catch.hpp"
 
-#ifdef HAVE_PTHREAD
-#ifdef __APPLE__
-#include <mach/semaphore.h>
-#include <mach/task.h>
-extern "C" mach_port_t mach_task_self(void);
-#define SEM_TYPE semaphore_t
-#else
-#include <errno.h>
-#include <semaphore.h>
-#define SEM_TYPE sem_t
-#endif
-#endif
-
-
 TEST_CASE("void ErrorsTest::testInitialState()","[errors]") {
-	TSK_ERROR_INFO *ei = tsk_error_get_info();
-	REQUIRE(0 == ei->t_errno);
-	REQUIRE(0 == ei->errstr[0]);
-	REQUIRE(0 == ei->errstr2[0]);
+  TSK_ERROR_INFO *ei = tsk_error_get_info();
+  REQUIRE(0 == ei->t_errno);
+  REQUIRE(0 == ei->errstr[0]);
+  REQUIRE(0 == ei->errstr2[0]);
 }
 
 TEST_CASE("void ErrorsTest::testLengthChecks()","[errors]") {
-	tsk_error_get_info();
-	std::string s;
-	for (unsigned x = 0; x < 4096; x ++) {
-		s = s + std::string("x");
-	}
-	tsk_error_set_errstr("%s", s.c_str());
-	std::string es(tsk_error_get_errstr());
-	REQUIRE(es.size() < 1025);
+  tsk_error_get_info();
+  std::string s;
+  for (unsigned x = 0; x < 4096; x ++) {
+    s = s + std::string("x");
+  }
+  tsk_error_set_errstr("%s", s.c_str());
+  std::string es(tsk_error_get_errstr());
+  REQUIRE(es.size() < 1025);
 }
 
-#ifdef HAVE_PTHREAD
-
 struct xErrorsTestShared {
-	SEM_TYPE sync_barrier;
-	bool errno_check_failed;
-	bool errstr_check_failed;
-	bool errstr2_check_failed;
-	bool failure;
-
-	xErrorsTestShared() {
-		failure = false;
-		errno_check_failed = false;
-		errstr_check_failed = false;
-		errstr2_check_failed = false;
-	}
+  bool errno_check_failed = false;
+  bool errstr_check_failed = false;
+  bool errstr2_check_failed = false;
 };
 
 /*
  * This thread sets error variables, updates the semaphore,
  * waits on the semaphore, and reads them back.
  */
-void * thread_1(void *arg) {
-	xErrorsTestShared * shared = (xErrorsTestShared*) arg;
-	// wait to be told to start.
-#ifdef __APPLE__
-	kern_return_t se = semaphore_wait(shared->sync_barrier);
-	if (se != 0) {
-		fprintf(stderr, "sem_wait failed: %d\n", se);
-		shared->failure = true;
-	}
-#else
-	if (sem_wait(&shared->sync_barrier) != 0) {
-		fprintf(stderr, "sem_wait failed: %s\n", strerror(errno));
-		shared->failure = true;
-	}
-#endif
-	tsk_error_set_errno(42);
-	tsk_error_set_errstr("I just set errno to %d.", 42);
-	tsk_error_set_errstr2("Indeed, I just set errno to %d.", 42);
-#ifdef __APPLE__
-	se = semaphore_signal(shared->sync_barrier);
-	if (se != 0) {
-		fprintf(stderr, "sem_signal failed: %d\n", se);
-		shared->failure = true;
-	}
-	se = semaphore_wait(shared->sync_barrier);
-	if (se != 0) {
-		fprintf(stderr, "sem_wait failed: %d\n", se);
-		shared->failure = true;
-	}
-#else
-	sem_post(&shared->sync_barrier);
-	sem_wait(&shared->sync_barrier);
-#endif
-	shared->errno_check_failed = 42 != tsk_error_get_errno();
-	char const * s = tsk_error_get_errstr();
-	shared->errstr_check_failed = 0 != strcmp("I just set errno to 42.", s);
-	s = tsk_error_get_errstr2();
-	shared->errstr2_check_failed = 0 != strcmp("Indeed, I just set errno to 42.", s);
-	return 0;
+void thread_1(xErrorsTestShared& shared, std::mutex& m, std::condition_variable& cv, int& state) {
+  {
+    // wait to be told to start
+    std::unique_lock<std::mutex> l(m);
+    cv.wait(l, [&]{ return state == 1; });
+
+    tsk_error_set_errno(42);
+    tsk_error_set_errstr("I just set errno to %d.", 42);
+    tsk_error_set_errstr2("Indeed, I just set errno to %d.", 42);
+
+    state = 2;
+  }
+  cv.notify_one();
+
+  {
+    // wait to be told to start
+    std::unique_lock<std::mutex> l(m);
+    cv.wait(l, [&]{ return state == 3; });
+
+    shared.errno_check_failed = 42 != tsk_error_get_errno();
+    char const* s = tsk_error_get_errstr();
+    shared.errstr_check_failed = 0 != strcmp("I just set errno to 42.", s);
+    s = tsk_error_get_errstr2();
+    shared.errstr2_check_failed = 0 != strcmp("Indeed, I just set errno to 42.", s);
+  }
+  cv.notify_one();
 }
+
+#ifdef TSK_MULTITHREAD_LIB
 
 TEST_CASE("void ErrorsTest::testMultithreaded()","[errors]") {
-	xErrorsTestShared shared;
-	tsk_error_reset();
-	// start semaphore unlocked. Thread will lock.
-#ifdef __APPLE__
-	kern_return_t se;
-	se = semaphore_create(mach_task_self(), &shared.sync_barrier, SYNC_POLICY_FIFO, 0);
-        REQUIRE(se==0);
-#else
-	REQUIRE(sem_init(&shared.sync_barrier, 0, 0)==0);
-#endif
-	pthread_t thread1;
+  xErrorsTestShared shared;
+  tsk_error_reset();
 
-	int pte = pthread_create(&thread1, 0, thread_1, &shared);
-        REQUIRE(pte==0);
+  std::condition_variable cv;
+  std::mutex m;
 
-#ifdef __APPLE__
-	se = semaphore_signal(shared.sync_barrier);
-        REQUIRE(se==0);
-	se = semaphore_wait(shared.sync_barrier);
-	REQUIRE(se==0);
-#else
-	// give thread permission to proceed
-	REQUIRE (sem_post(&shared.sync_barrier) == 0);
-	// wait for thread to set some things.
-	REQUIRE (sem_wait(&shared.sync_barrier) == 0);
-#endif
+  int state = 0;
 
-	REQUIRE(0 == tsk_error_get_errno());
-	REQUIRE(0 == tsk_error_get_errstr()[0]);
-	REQUIRE(0 == tsk_error_get_errstr2()[0]);
+  // start the child
+  std::thread child(thread_1, std::ref(shared), std::ref(m), std::ref(cv), std::ref(state));
 
-	// give thread permission to proceed
-#ifdef __APPLE__
-	se = semaphore_signal(shared.sync_barrier);
-        REQUIRE(se==0);
-#else
-	REQUIRE (sem_post(&shared.sync_barrier) == 0);
-#endif
-	void *exitval = 0;
-	pte = pthread_join(thread1, &exitval);
-        REQUIRE(pte == 0);
-	REQUIRE(!shared.errno_check_failed);
-	REQUIRE(!shared.errstr_check_failed);
-	REQUIRE(!shared.errstr2_check_failed);
+  // give child permission to proceed
+  {
+    std::lock_guard<std::mutex> l(m);
+    state = 1;
+  }
+  cv.notify_one();
+
+  // wait for child to set some things.
+  {
+    std::unique_lock<std::mutex> l(m);
+    cv.wait(l, [&]{ return state == 2; });
+  }
+
+  REQUIRE(tsk_error_get_errno() == 0);
+  REQUIRE(std::strlen(tsk_error_get_errstr()) == 0);
+  REQUIRE(std::strlen(tsk_error_get_errstr2()) == 0);
+
+  // give child permission to proceed
+  {
+    std::lock_guard<std::mutex> l(m);
+    state = 3;
+  }
+  cv.notify_one();
+
+  child.join();
+
+  REQUIRE(!shared.errno_check_failed);
+  REQUIRE(!shared.errstr_check_failed);
+  REQUIRE(!shared.errstr2_check_failed);
 }
+
 #endif


### PR DESCRIPTION
The main thread incremented the semaphore, then decremented the semaphore. Most of the time the child thread got to the semaphore between those, and everything ran as intended. Once in a while, the child thread lost the race, resulting in a deadlock.