### PR TITLE
Ensure functions in sha2.h aren't declared if we have libcrypto

### DIFF
--- a/tools/fiwalk/src/sha2.h
+++ b/tools/fiwalk/src/sha2.h
@@ -34,6 +34,10 @@
 #ifndef SHA2_H
 #define SHA2_H
 
+#include "tsk/tsk_config.h"
+
+#ifndef HAVE_LIBCRYPTO
+
 #define SHA224_DIGEST_LENGTH ( 224 / 8)
 #define SHA256_DIGEST_LENGTH ( 256 / 8)
 #define SHA384_DIGEST_LENGTH ( 384 / 8)
@@ -104,5 +108,6 @@ void SHA512(const unsigned char *message, unsigned int len,
 }
 #endif
 
-#endif /* !SHA2_H */
+#endif
 
+#endif /* !SHA2_H */


### PR DESCRIPTION
This fixes a name collision when compiling with libcrypto.