### PR TITLE
Fix signatures of TskAuto::getErrorList() and TskAuto::errorRecordToString():

### DIFF
--- a/tsk/auto/auto.cpp
+++ b/tsk/auto/auto.cpp
@@ -974,7 +974,7 @@ uint8_t TskAuto::registerError() {
 }
 
 
-const std::vector<TskAuto::error_record> TskAuto::getErrorList() {
+const std::vector<TskAuto::error_record>& TskAuto::getErrorList() {
     return m_errors;
 }
 
@@ -982,7 +982,7 @@ void TskAuto::resetErrorList() {
     m_errors.clear();
 }
 
-std::string TskAuto::errorRecordToString(error_record &rec) {
+std::string TskAuto::errorRecordToString(const error_record& rec) {
     tsk_error_reset();
     tsk_error_set_errno(rec.code);
     tsk_error_set_errstr("%s", rec.msg1.c_str());

--- a/tsk/auto/tsk_auto.h
+++ b/tsk/auto/tsk_auto.h
@@ -206,14 +206,14 @@ class TskAuto {
      * the errors or never called addToErrorList().
      * @returns list of errors.
      */
-    const std::vector<error_record> getErrorList();
+    const std::vector<error_record>& getErrorList();
 
     /**
      * Remove the errors on the internal list.
      */
     void resetErrorList();
 
-    static std::string errorRecordToString(error_record &rec);
+    static std::string errorRecordToString(const error_record &rec);
 
 
     /**


### PR DESCRIPTION
This PR fixes two API problems with `TskAuto`:

* Fixed signature of `TskAuto::getErrorList()`: Returning a `const std::vector` makes no sense; the intent is clearly to return a const reference to the error list, not an unmodifiable copy.

* Fixed signature of `TskAuto::errorRecordToString()`: You can't pass a const record to it, and all the records from `getErrorList()` are/were const. `errorRecordToString()` doesn't modify the error record and ought to work with records from `getErrorList()`, so its argument should be a const reference.