### PR TITLE
Add options struct to image open API

### DIFF
--- a/tsk/img/img_open.cpp
+++ b/tsk/img/img_open.cpp
@@ -51,6 +51,9 @@
 #include <vector>
 #include <utility>
 
+const TSK_IMG_OPTIONS DEFAULT_IMG_OPTIONS{
+};
+
 bool sector_size_ok(unsigned int sector_size) {
     if (sector_size > 0 && sector_size < 512) {
         tsk_error_set_errno(TSK_ERR_IMG_ARG);
@@ -270,10 +273,11 @@ img_open_detect_type(
 }
 
 TSK_IMG_INFO* img_open(
-    int num_img,
-    const TSK_TCHAR* const images[],
-    TSK_IMG_TYPE_ENUM type,
-    unsigned int a_ssize
+  int num_img,
+  const TSK_TCHAR* const images[],
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize,
+  [[maybe_unused]] const TSK_IMG_OPTIONS* opts
 )
 {
     if (tsk_verbose)
@@ -308,12 +312,24 @@ TSK_IMG_INFO* img_open(
  *
  * @return Pointer to TSK_IMG_INFO or NULL on error
  */
-TSK_IMG_INFO *
-tsk_img_open_sing(const TSK_TCHAR * a_image, TSK_IMG_TYPE_ENUM type,
-    unsigned int a_ssize)
+TSK_IMG_INFO*
+tsk_img_open_sing(
+  const TSK_TCHAR* a_image,
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize)
+{
+    return tsk_img_open_sing_opt(a_image, type, a_ssize, &DEFAULT_IMG_OPTIONS);
+}
+
+TSK_IMG_INFO*
+tsk_img_open_sing_opt(
+  const TSK_TCHAR* a_image,
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize,
+  const TSK_IMG_OPTIONS* opts)
 {
     const TSK_TCHAR *const a = a_image;
-    return tsk_img_open(1, &a, type, a_ssize);
+    return tsk_img_open_opt(1, &a, type, a_ssize, opts);
 }
 
 /**
@@ -335,9 +351,22 @@ tsk_img_open_sing(const TSK_TCHAR * a_image, TSK_IMG_TYPE_ENUM type,
  * @return Pointer to TSK_IMG_INFO or NULL on error
  */
 TSK_IMG_INFO *
-tsk_img_open(int num_img,
-    const TSK_TCHAR * const images[], TSK_IMG_TYPE_ENUM type,
-    unsigned int a_ssize)
+tsk_img_open(
+  int num_img,
+  const TSK_TCHAR* const images[],
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize)
+{
+    return tsk_img_open_opt(num_img, images, type, a_ssize, &DEFAULT_IMG_OPTIONS);
+}
+
+TSK_IMG_INFO*
+tsk_img_open_opt(
+  int num_img,
+  const TSK_TCHAR* const images[],
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize,
+  const TSK_IMG_OPTIONS* opt)
 {
     // Get rid of any old error messages laying around
     tsk_error_reset();
@@ -346,7 +375,7 @@ tsk_img_open(int num_img,
         return nullptr;
     }
 
-    return img_open(num_img, images, type, a_ssize);
+    return img_open(num_img, images, type, a_ssize, opt);
 }
 
 /**
@@ -362,12 +391,24 @@ tsk_img_open(int num_img,
  *
  * @return Pointer to TSK_IMG_INFO or NULL on error
  */
-TSK_IMG_INFO *
-tsk_img_open_utf8_sing(const char *a_image,
-    TSK_IMG_TYPE_ENUM type, unsigned int a_ssize)
+TSK_IMG_INFO*
+tsk_img_open_utf8_sing(
+  const char* a_image,
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize)
+{
+    return tsk_img_open_utf8_sing_opt(a_image, type, a_ssize, &DEFAULT_IMG_OPTIONS);
+}
+
+TSK_IMG_INFO*
+tsk_img_open_utf8_sing_opt(
+  const char* a_image,
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize,
+  const TSK_IMG_OPTIONS* opts)
 {
     const char *const a = a_image;
-    return tsk_img_open_utf8(1, &a, type, a_ssize);
+    return tsk_img_open_utf8_opt(1, &a, type, a_ssize, opts);
 }
 
 /**
@@ -390,6 +431,17 @@ tsk_img_open_utf8(
     const char *const images[],
     TSK_IMG_TYPE_ENUM type,
     unsigned int a_ssize)
+{
+    return tsk_img_open_utf8_opt(num_img, images, type, a_ssize, &DEFAULT_IMG_OPTIONS);
+}
+
+TSK_IMG_INFO*
+tsk_img_open_utf8_opt(
+  int num_img,
+  const char *const images[],
+  TSK_IMG_TYPE_ENUM type,
+  unsigned int a_ssize,
+  const TSK_IMG_OPTIONS* opts)
 {
     // Get rid of any old error messages laying around
     tsk_error_reset();
@@ -443,7 +495,7 @@ tsk_img_open_utf8(
 #else
     const TSK_TCHAR* const* imgs = images;
 #endif
-    return img_open(num_img, imgs, type, a_ssize);
+    return img_open(num_img, imgs, type, a_ssize, opts);
 }
 
 /**

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -83,6 +83,10 @@ extern "C" {
         TSK_IMG_TYPE_UNSUPP = 0xffff      ///< Unsupported disk image type
     } TSK_IMG_TYPE_ENUM;
 
+    typedef struct TSK_IMG_OPTIONS {
+
+    } TSK_IMG_OPTIONS;
+
 #define TSK_IMG_INFO_CACHE_NUM  32
 #define TSK_IMG_INFO_CACHE_LEN  65536
 
@@ -116,21 +120,71 @@ extern "C" {
     };
 
     // open and close functions
-    extern TSK_IMG_INFO *tsk_img_open_sing(const TSK_TCHAR * a_image,
-        TSK_IMG_TYPE_ENUM type, unsigned int a_ssize);
-    extern TSK_IMG_INFO *tsk_img_open(int,
-        const TSK_TCHAR * const images[], TSK_IMG_TYPE_ENUM,
-        unsigned int a_ssize);
-    extern TSK_IMG_INFO *tsk_img_open_utf8_sing(const char *a_image,
-        TSK_IMG_TYPE_ENUM type, unsigned int a_ssize);
-    extern TSK_IMG_INFO *tsk_img_open_utf8(int num_img,
-        const char *const images[], TSK_IMG_TYPE_ENUM type,
-        unsigned int a_ssize);
-    extern TSK_IMG_INFO *tsk_img_open_external(void* ext_img_info,
-        TSK_OFF_T size, unsigned int sector_size,
+    extern TSK_IMG_INFO *tsk_img_open_sing(
+        const TSK_TCHAR * a_image,
+        TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize
+    );
+
+    extern TSK_IMG_INFO *tsk_img_open(
+        int num_img,
+        const TSK_TCHAR * const images[],
+        TSK_IMG_TYPE_ENUM,
+        unsigned int a_ssize
+    );
+
+    extern TSK_IMG_INFO *tsk_img_open_utf8_sing(
+        const char *a_image,
+        TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize
+    );
+
+    extern TSK_IMG_INFO *tsk_img_open_utf8(
+        int num_img,
+        const char *const images[],
+        TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize
+    );
+
+    TSK_IMG_INFO *tsk_img_open_sing_opt(
+        const TSK_TCHAR * a_image,
+        TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize,
+        const TSK_IMG_OPTIONS* opts
+    );
+
+    TSK_IMG_INFO *tsk_img_open_opt(
+        int num_img,
+        const TSK_TCHAR * const images[],
+        TSK_IMG_TYPE_ENUM,
+        unsigned int a_ssize,
+        const TSK_IMG_OPTIONS* opts
+    );
+
+    TSK_IMG_INFO *tsk_img_open_utf8_sing_opt(
+        const char *a_image,
+        TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize,
+        const TSK_IMG_OPTIONS* opts
+    );
+
+    TSK_IMG_INFO* tsk_img_open_utf8_opt(
+        int num_img,
+        const char *const images[],
+        TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize,
+        const TSK_IMG_OPTIONS* opts
+    );
+
+    extern TSK_IMG_INFO *tsk_img_open_external(
+        void* ext_img_info,
+        TSK_OFF_T size,
+        unsigned int sector_size,
         ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len),
         void (*close) (TSK_IMG_INFO *),
-        void (*imgstat) (TSK_IMG_INFO *, FILE *));
+        void (*imgstat) (TSK_IMG_INFO *, FILE *)
+    );
+
     extern void tsk_img_close(TSK_IMG_INFO *);
 
     // read functions

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -84,7 +84,7 @@ extern "C" {
     } TSK_IMG_TYPE_ENUM;
 
     typedef struct TSK_IMG_OPTIONS {
-
+        int dummy;
     } TSK_IMG_OPTIONS;
 
 #define TSK_IMG_INFO_CACHE_NUM  32


### PR DESCRIPTION
We need to be able to pass options to the image open functions for things like setting a default time zone and image block cache parameters.