### PR TITLE
string format specifier fix

### DIFF
--- a/tsk/base/tsk_os.h
+++ b/tsk/base/tsk_os.h
@@ -212,7 +212,7 @@ typedef char TSK_TCHAR;         ///< Character data type that is UTF-16 (wchar_t
 #define TZSET	tzset
 #define TZNAME	tzname
 
-#define PRIcTSK _TSK_T("hs")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
+#define PRIcTSK _TSK_T("s")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
 #define PRIttocTSK  "s"         ///< printf macro to print a TSK_TCHAR string to stderr or other char device
 #define PRIuSIZE "zu"           ///< printf macro to print a size_t value in non-Windows printf codes
 

--- a/tsk/base/tsk_os.h
+++ b/tsk/base/tsk_os.h
@@ -212,7 +212,7 @@ typedef char TSK_TCHAR;         ///< Character data type that is UTF-16 (wchar_t
 #define TZSET	tzset
 #define TZNAME	tzname
 
-#define PRIcTSK _TSK_T("s")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
+#define PRIcTSK _TSK_T("hs")     ///< sprintf macro to print a UTF-8 char string to TSK_TCHAR buffer
 #define PRIttocTSK  "s"         ///< printf macro to print a TSK_TCHAR string to stderr or other char device
 #define PRIuSIZE "zu"           ///< printf macro to print a size_t value in non-Windows printf codes
 

--- a/tsk/hashdb/binsrch_index.cpp
+++ b/tsk/hashdb/binsrch_index.cpp
@@ -111,20 +111,20 @@ static uint8_t
         hdb_binsrch_info->hash_type = htype;
         hdb_binsrch_info->hash_len = TSK_HDB_HTYPE_MD5_LEN;
         TSNPRINTF(hdb_binsrch_info->idx_fname, flen,
-            _TSK_T("%s-%s.idx"),
+            _TSK_T("%s-%") PRIcTSK _TSK_T(".idx"),
             hdb_binsrch_info->base.db_fname, TSK_HDB_HTYPE_MD5_STR);
         TSNPRINTF(hdb_binsrch_info->idx_idx_fname, flen,
-            _TSK_T("%s-%s.idx2"),
+            _TSK_T("%s-%") PRIcTSK _TSK_T(".idx2"),
             hdb_binsrch_info->base.db_fname, TSK_HDB_HTYPE_MD5_STR);
         return 0;
     case TSK_HDB_HTYPE_SHA1_ID:
         hdb_binsrch_info->hash_type = htype;
         hdb_binsrch_info->hash_len = TSK_HDB_HTYPE_SHA1_LEN;
         TSNPRINTF(hdb_binsrch_info->idx_fname, flen,
-            _TSK_T("%s-%s.idx"),
+            _TSK_T("%s-%") PRIcTSK _TSK_T(".idx"),
             hdb_binsrch_info->base.db_fname, TSK_HDB_HTYPE_SHA1_STR);
         TSNPRINTF(hdb_binsrch_info->idx_idx_fname, flen,
-            _TSK_T("%s-%s.idx2"),
+            _TSK_T("%s-%") PRIcTSK _TSK_T(".idx2"),
             hdb_binsrch_info->base.db_fname, TSK_HDB_HTYPE_SHA1_STR);
         return 0;
 
@@ -702,7 +702,7 @@ uint8_t
         return 1;
     }
     TSNPRINTF(hdb_binsrch_info->uns_fname, flen,
-        _TSK_T("%s-%s-ns.idx"), hdb_binsrch_info->base.db_fname,
+        _TSK_T("%s-%") PRIcTSK _TSK_T("-ns.idx"), hdb_binsrch_info->base.db_fname,
         TSK_HDB_HTYPE_STR(hdb_binsrch_info->hash_type));
 
 


### PR DESCRIPTION
I believe this commit caused issues in Autopsy with importing hash sets: https://github.com/sleuthkit/sleuthkit/commit/a6d4d2917e9dbd8a0fbd6a9a14f4bffad967c1d7.  I believe this code should fix that issue without compiler warnings.