### PR TITLE
Upgrade CI runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -62,7 +62,7 @@ jobs:
             runner: "ubuntu-24.04"
             configure_opts: "--host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --disable-java --enable-shared --disable-static"
             winearch: 'win64'
-            winepath: 'Z:\usr\lib\gcc\x86_64-w64-mingw32\10-posix'
+            winepath: 'Z:\usr\lib\gcc\x86_64-w64-mingw32\13-posix'
             wineprefix: '/home/runner/.wine64'
             codecov: "no"
             prefix: ""
@@ -76,7 +76,7 @@ jobs:
             runner: "ubuntu-24.04"
             configure_opts: "--host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --disable-java --disable-shared --enable-static"
             winearch: 'win64'
-            winepath: 'Z:\usr\lib\gcc\x86_64-w64-mingw32\10-posix'
+            winepath: 'Z:\usr\lib\gcc\x86_64-w64-mingw32\13-posix'
             wineprefix: '/home/runner/.wine64'
             codecov: "no"
             prefix: ""
@@ -91,7 +91,7 @@ jobs:
             configure_opts:   "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --enable-shared --disable-static --disable-java"
             configure_optsnj: "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --enable-shared --disable-static"
             winearch: 'win32'
-            winepath: 'Z:\usr\lib\gcc\i686-w64-mingw32\10-posix'
+            winepath: 'Z:\usr\lib\gcc\i686-w64-mingw32\13-posix'
             wineprefix: '/home/runner/.wine32'
             codecov: "no"
             prefix: ""
@@ -106,7 +106,7 @@ jobs:
             configure_opts:   "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --disable-shared --enable-static --disable-java"
             configure_optsnj: "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --disable-shared --enable-static"
             winearch: 'win32'
-            winepath: 'Z:\usr\lib\gcc\i686-w64-mingw32\10-posix'
+            winepath: 'Z:\usr\lib\gcc\i686-w64-mingw32\13-posix'
             wineprefix: '/home/runner/.wine32'
             codecov: "no"
             prefix: ""

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -36,7 +36,7 @@ jobs:
             arch: "x86_64"
             linkage: "shared"
             compiler: "gcc"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
             configure_opts: "--with-libewf --with-libqcow --with-libvhdi --with-libvmdk --disable-java CFLAGS=-Werror CXXFLAGS=-Werror"
             codecov: "no"
             prefix:
@@ -48,7 +48,7 @@ jobs:
             arch: "x86_64"
             linkage: "shared"
             compiler: "clang"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
             configure_opts: "--with-libewf --with-libqcow --with-libvhdi --with-libvmdk --disable-java CC=clang CXX=clang++ CFLAGS=-Werror CXXFLAGS=-Werror"
             codecov: "no"
             prefix: ""
@@ -59,7 +59,7 @@ jobs:
             arch: "x86_64"
             linkage: "shared"
             compiler: "gcc"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
             configure_opts: "--host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --disable-java --enable-shared --disable-static"
             winearch: 'win64'
             winepath: 'Z:\usr\lib\gcc\x86_64-w64-mingw32\10-posix'
@@ -73,7 +73,7 @@ jobs:
             arch: "x86_64"
             linkage: "static"
             compiler: "gcc"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
             configure_opts: "--host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --disable-java --disable-shared --enable-static"
             winearch: 'win64'
             winepath: 'Z:\usr\lib\gcc\x86_64-w64-mingw32\10-posix'
@@ -87,7 +87,7 @@ jobs:
             arch: "i686"
             linkage: "shared"
             compiler: "gcc"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
             configure_opts:   "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --enable-shared --disable-static --disable-java"
             configure_optsnj: "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --enable-shared --disable-static"
             winearch: 'win32'
@@ -101,7 +101,7 @@ jobs:
           - os: "mingw"
             arch: "i686"
             linkage: "static"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
             compiler: "gcc"
             configure_opts:   "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --disable-shared --enable-static --disable-java"
             configure_optsnj: "--host=i686-w64-mingw32 --target=i686-w64-mingw32 --disable-shared --enable-static"

--- a/tools/fiwalk/src/hash_t.h
+++ b/tools/fiwalk/src/hash_t.h
@@ -223,9 +223,8 @@ public:
   }
 
   std::string hexdigest() const {
-    std::string ret;
-    char buf[this->SIZE*2 + 1];
-    return std::string(hexdigest(buf, sizeof(buf)));
+    std::string buf('\0', this->SIZE*2);
+    return std::string(hexdigest(&buf[0], buf.size()));
   }
 
   /**

--- a/tools/fiwalk/src/hash_t.h
+++ b/tools/fiwalk/src/hash_t.h
@@ -224,7 +224,8 @@ public:
 
   std::string hexdigest() const {
     std::string buf('\0', this->SIZE*2);
-    return std::string(hexdigest(&buf[0], buf.size()));
+    hexdigest(&buf[0], buf.size());
+    return buf;
   }
 
   /**


### PR DESCRIPTION
This PR upgrades the CI runners to Ubuntu 24.04. This gives us access to compilers which support C++20.