### PR TITLE
Check the correct variable for encrypted pools in TskAutoDb::addUnallocFsSpaceToDb

### DIFF
--- a/tsk/auto/auto_db.cpp
+++ b/tsk/auto/auto_db.cpp
@@ -1398,7 +1398,7 @@ TSK_RETVAL_ENUM TskAutoDb::addUnallocFsSpaceToDb(size_t & numFs) {
 
                             }
                             else {
-                                if (curVsPartInfo.flags & TSK_POOL_VOLUME_FLAG_ENCRYPTED) {
+                                if (pool->vol_list->flags & TSK_POOL_VOLUME_FLAG_ENCRYPTED) {
                                     tsk_error_reset();
                                     tsk_error_set_errno(TSK_ERR_FS_ENCRYPTED);
                                     tsk_error_set_errstr(


### PR DESCRIPTION
`TSK_VS_PART_INFO::flags` is a `TSK_VS_PART_FLAG_ENUM`, not a `TSK_POOL_VOLUME_FLAGS`, so it makes no sense to check for `TSK_POOL_VOLUME_FLAG_ENCRYPTED` in it. Presumably the correct variable to test is `vol_info->flags`, from the `TSK_POOL_VOLUME_INFO`.

Fixes #3128.