### PR TITLE
Fix warnings which arise when compiling with C++20

### DIFF
--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -10,8 +10,8 @@
 #
 #   Check for baseline language coverage in the compiler for the specified
 #   version of the C++ standard.  If necessary, add switches to CXX and
-#   CXXCPP to enable support.  VERSION may be '11', '14', '17', or '20' for
-#   the respective C++ standard version.
+#   CXXCPP to enable support.  VERSION may be '11', '14', '17', '20', or
+#   '23' for the respective C++ standard version.
 #
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
@@ -36,14 +36,15 @@
 #   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
 #   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
 #   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
-#   Copyright (c) 2021 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
+#   Copyright (c) 2021, 2024 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
+#   Copyright (c) 2015, 2022, 2023, 2024 Olly Betts
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 18
+#serial 25
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -53,6 +54,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
         [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
         [$1], [20], [ax_cxx_compile_alternatives="20"],
+        [$1], [23], [ax_cxx_compile_alternatives="23"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -159,31 +161,41 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
 dnl  Test body for checking C++11 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11]
 )
 
 dnl  Test body for checking C++14 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
 )
 
 dnl  Test body for checking C++17 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
 )
 
 dnl  Test body for checking C++20 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
+)
+
+dnl  Test body for checking C++23 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
 )
 
 
@@ -201,7 +213,17 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
 // MSVC always sets __cplusplus to 199711L in older versions; newer versions
 // only set it correctly if /Zc:__cplusplus is specified as well as a
 // /std:c++NN switch:
+//
 // https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+//
+// The value __cplusplus ought to have is available in _MSVC_LANG since
+// Visual Studio 2015 Update 3:
+//
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+//
+// This was also the first MSVC version to support C++14 so we can't use the
+// value of either __cplusplus or _MSVC_LANG to quickly rule out MSVC having
+// C++11 or C++14 support, but we can check _MSVC_LANG for C++17 and later.
 #elif __cplusplus < 201103L && !defined _MSC_VER
 
 #error "This is not a C++11 compiler"
@@ -617,7 +639,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201703L && !defined _MSC_VER
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
 
 #error "This is not a C++17 compiler"
 
@@ -983,7 +1005,7 @@ namespace cxx17
 
 }  // namespace cxx17
 
-#endif  // __cplusplus < 201703L && !defined _MSC_VER
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
 
 ]])
 
@@ -996,7 +1018,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 202002L && !defined _MSC_VER
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
 
 #error "This is not a C++20 compiler"
 
@@ -1013,6 +1035,36 @@ namespace cxx20
 
 }  // namespace cxx20
 
-#endif  // __cplusplus < 202002L && !defined _MSC_VER
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+]])
+
+
+dnl  Tests for new features in C++23
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_23], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+#error "This is not a C++23 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx23
+{
+
+// As C++23 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx23
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
 
 ]])

--- a/tools/autotools/tsk_comparedir.cpp
+++ b/tools/autotools/tsk_comparedir.cpp
@@ -14,7 +14,9 @@
 #include <locale.h>
 #include <sys/stat.h>
 #include <errno.h>
+
 #include <set>
+#include <string>
 
 #ifdef WIN32
 #include <windows.h>
@@ -162,13 +164,12 @@ uint8_t
     DIR *dp;
     struct dirent *dirp;
     char file[TSK_CD_BUFSIZE];
-    char fullPath[TSK_CD_BUFSIZE];
     struct stat status;
 
-    strncpy(fullPath, m_lclDir, TSK_CD_BUFSIZE-1);
-    strncat(fullPath, a_dir, TSK_CD_BUFSIZE-strlen(fullPath)-1);
+    std::string fullPath(m_lclDir);
+    fullPath += a_dir;
 
-    if ((dp = opendir(fullPath)) == NULL) {
+    if ((dp = opendir(fullPath.c_str())) == NULL) {
         fprintf(stderr, "Error opening directory");
         return 1;
     }
@@ -178,10 +179,10 @@ uint8_t
         strncat(file, "/", TSK_CD_BUFSIZE-strlen(file)-1);
         strncat(file, dirp->d_name, TSK_CD_BUFSIZE-strlen(file)-1);
 
-        strncpy(fullPath, m_lclDir, TSK_CD_BUFSIZE-1);
-        strncat(fullPath, file, TSK_CD_BUFSIZE-strlen(fullPath)-1);
+        fullPath = m_lclDir;
+        fullPath += file;
 
-        stat(fullPath, &status);
+        stat(fullPath.c_str(), &status);
         if (S_ISDIR(status.st_mode)) {
             // skip the '.' and '..' entries
             if ((dirp->d_name[0] == '.') && ((dirp->d_name[1] == '\0') || ((dirp->d_name[1] == '.') && (dirp->d_name[2] == '\0')))) {

--- a/tsk/fs/fatfs_utils.c
+++ b/tsk/fs/fatfs_utils.c
@@ -306,7 +306,7 @@ fatfs_utf16_inode_str_2_utf8(FATFS_INFO *a_fatfs, UTF16 *a_src, size_t a_src_len
     if (conv_result != TSKconversionOK) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_FS_UNICODE);
-        tsk_error_set_errstr("%s: Error converting %s for inum %"PRIuINUM" from UTF16 to UTF8: %d", func_name, a_desc, a_inum, conv_result);
+        tsk_error_set_errstr("%s: Error converting %s for inum %" PRIuINUM " from UTF16 to UTF8: %d", func_name, a_desc, a_inum, conv_result);
         *a_dest = '\0';
         return conv_result;
     }

--- a/tsk/fs/fs_attr.cpp
+++ b/tsk/fs/fs_attr.cpp
@@ -934,8 +934,8 @@ tsk_fs_attr_walk_nonres(const TSK_FS_ATTR * fs_attr,
                 }
 
                 // we return 0s for reads past the initsize
-                else if ((off >= fs_attr->nrd.initsize)
-                    && ((a_flags & TSK_FS_FILE_READ_FLAG_SLACK) == 0)) {
+                else if (off >= fs_attr->nrd.initsize
+                    && (a_flags & TSK_FS_FILE_WALK_FLAG_SLACK) == 0) {
                     memset(buf, 0, fs->block_size);
                 }
                 else {
@@ -959,8 +959,8 @@ tsk_fs_attr_walk_nonres(const TSK_FS_ATTR * fs_attr,
                         free(buf);
                         return 1;
                     }
-                    if ((off + fs->block_size > fs_attr->nrd.initsize)
-                        && ((a_flags & TSK_FS_FILE_READ_FLAG_SLACK) == 0)) {
+                    if (off + fs->block_size > fs_attr->nrd.initsize
+                        && (a_flags & TSK_FS_FILE_WALK_FLAG_SLACK) == 0) {
                         memset(&buf[fs_attr->nrd.initsize - off], 0,
                             fs->block_size -
                             (size_t) (fs_attr->nrd.initsize - off));

--- a/tsk/fs/fs_dir.cpp
+++ b/tsk/fs/fs_dir.cpp
@@ -715,7 +715,10 @@ tsk_fs_dir_walk_recursive(TSK_FS_INFO * a_fs, DENT_DINFO * a_dinfo,
         }
 
         // call the action if we have the right flags.
-        if ((fs_file->name->flags & a_flags) == fs_file->name->flags) {
+        const TSK_FS_NAME_FLAG_ENUM n_flags =
+            (TSK_FS_NAME_FLAG_ENUM) (((a_flags & TSK_FS_DIR_WALK_FLAG_ALLOC) ? TSK_FS_NAME_FLAG_ALLOC : 0) |
+            ((a_flags & TSK_FS_DIR_WALK_FLAG_UNALLOC) ? TSK_FS_NAME_FLAG_UNALLOC : 0));
+        if ((fs_file->name->flags & n_flags) == fs_file->name->flags) {
 
             retval = a_action(fs_file, a_dinfo->dirs, a_ptr);
             if (retval == TSK_WALK_STOP) {

--- a/tsk/fs/fs_dir.cpp
+++ b/tsk/fs/fs_dir.cpp
@@ -257,7 +257,7 @@ tsk_fs_dir_add(TSK_FS_DIR * a_fs_dir, const TSK_FS_NAME * a_fs_name)
 			if (a_fs_dir->names_used >= MAX_DIR_SIZE_TO_PROCESS) {
 				tsk_error_reset();
 				tsk_error_set_errno(TSK_ERR_FS_GENFS);
-				tsk_error_set_errstr("tsk_fs_dir_add: Directory too large to process (addr: %" PRIuSIZE")", a_fs_dir->addr);
+				tsk_error_set_errstr("tsk_fs_dir_add: Directory too large to process (addr: %" PRIuINUM ")", a_fs_dir->addr);
 				return 1;
 			}
 

--- a/tsk/fs/fs_dir.cpp
+++ b/tsk/fs/fs_dir.cpp
@@ -1167,7 +1167,7 @@ tsk_fs_dir_load_inum_named(TSK_FS_INFO * a_fs)
      * be fewer callbacks for UNALLOC than ALLOC.
      */
     if (tsk_fs_dir_walk_internal(a_fs, a_fs->root_inum,
-            (TSK_FS_DIR_WALK_FLAG_ENUM) (TSK_FS_NAME_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE | TSK_FS_DIR_WALK_FLAG_NOORPHAN), load_named_dir_walk_cb, NULL, 0)) {
+            (TSK_FS_DIR_WALK_FLAG_ENUM) (TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE | TSK_FS_DIR_WALK_FLAG_NOORPHAN), load_named_dir_walk_cb, NULL, 0)) {
         tsk_error_errstr2_concat
             ("- tsk_fs_dir_load_inum_named: identifying inodes allocated by file names");
         return TSK_ERR;

--- a/tsk/fs/fs_parse.c
+++ b/tsk/fs/fs_parse.c
@@ -55,12 +55,12 @@ tsk_fs_parse_inum(const TSK_TCHAR * str, TSK_INUM_T * inum,
         *id_used = 0;
 
     /* Make a copy of the input string */
-    tmpstr =
-        (TSK_TCHAR *) tsk_malloc((TSTRLEN(str) + 1) * sizeof(TSK_TCHAR));
+    const size_t tmplen = TSTRLEN(str);
+    tmpstr = (TSK_TCHAR *) tsk_malloc((tmplen + 1) * sizeof(TSK_TCHAR));
     if (tmpstr == NULL)
         return 1;
 
-    TSTRNCPY(tmpstr, str, TSTRLEN(str) + 1);
+    TSTRNCPY(tmpstr, str, tmplen + 1);
 
     if ((tdash = TSTRCHR(tmpstr, _TSK_T('-'))) != NULL) {
         *tdash = '\0';

--- a/tsk/fs/hfs.cpp
+++ b/tsk/fs/hfs.cpp
@@ -583,7 +583,7 @@ hfs_ext_find_extent_record_attr(HFS_INFO * hfs, uint32_t cnid,
                 if (sizeof(hfs_btree_key_ext) > nodesize - rec_off) {
                     tsk_error_set_errno(TSK_ERR_FS_GENFS);
                     tsk_error_set_errstr
-                    ("hfs_ext_find_extent_record_attr: record %d in leaf node %d truncated (have %d vs %" PRIu64 " bytes)", rec, cur_node, nodesize - (int)rec_off,
+                    ("hfs_ext_find_extent_record_attr: record %d in leaf node %d truncated (have %d vs %" PRIuSIZE " bytes)", rec, cur_node, nodesize - (int)rec_off,
                         sizeof(hfs_btree_key_ext));
                     return 1;
                 }
@@ -976,7 +976,7 @@ hfs_cat_traverse(HFS_INFO * hfs,
                 if ((keylen < 6) || (keylen > nodesize - rec_off)) {
                     tsk_error_set_errno(TSK_ERR_FS_GENFS);
                     tsk_error_set_errstr
-                        ("hfs_cat_traverse: length of key %d in leaf node %d out of bounds (6 < %" PRIu64 " < %"
+                        ("hfs_cat_traverse: length of key %d in leaf node %d out of bounds (6 < %" PRIuSIZE " < %"
                         PRIu16 ")", rec, cur_node, keylen, nodesize);
                     return 1;
                 }

--- a/tsk/fs/hfs.cpp
+++ b/tsk/fs/hfs.cpp
@@ -508,7 +508,7 @@ hfs_ext_find_extent_record_attr(HFS_INFO * hfs, uint32_t cnid,
                     if (nodesize < 4 || keylen + 4 > nodesize || rec_off >= nodesize - 4 - keylen) {
                         tsk_error_set_errno(TSK_ERR_FS_GENFS);
                         tsk_error_set_errstr
-                            ("hfs_ext_find_extent_record_attr: offset and keylenth of record %d in index node %d too large (%" PRIu64 " vs %"
+                            ("hfs_ext_find_extent_record_attr: offset and keylenth of record %d in index node %d too large (%" PRIuSIZE " vs %"
                             PRIu16 ")", rec, cur_node,
                             rec_off + keylen, nodesize);
                         return 1;
@@ -859,8 +859,8 @@ hfs_cat_traverse(HFS_INFO * hfs,
                 if ((keylen < 6) || (keylen > nodesize - rec_off)) {
                     tsk_error_set_errno(TSK_ERR_FS_GENFS);
                     tsk_error_set_errstr
-                        ("hfs_cat_traverse: length of key %d in index node %d out of bounds (6 < %" PRIu64 " < %"
-                        PRIu64 ")", rec, cur_node, keylen, nodesize - rec_off);
+                        ("hfs_cat_traverse: length of key %d in index node %d out of bounds (6 < %" PRIuSIZE " < %"
+                        PRIuSIZE ")", rec, cur_node, keylen, nodesize - rec_off);
                     return 1;
                 }
 
@@ -894,7 +894,7 @@ hfs_cat_traverse(HFS_INFO * hfs,
                     if (keylen > nodesize - rec_off) {
                         tsk_error_set_errno(TSK_ERR_FS_GENFS);
                         tsk_error_set_errstr
-                            ("hfs_cat_traverse: offset of record and keylength %d in index node %d too large (%" PRIu64 " vs %"
+                            ("hfs_cat_traverse: offset of record and keylength %d in index node %d too large (%" PRIuSIZE " vs %"
                             PRIu16 ")", rec, cur_node,
                             (int) rec_off + keylen, nodesize);
                         return 1;

--- a/tsk/fs/nofs_misc.cpp
+++ b/tsk/fs/nofs_misc.cpp
@@ -130,7 +130,7 @@ tsk_fs_nofs_block_walk(TSK_FS_INFO * fs, TSK_DADDR_T a_start_blk,
     }
 
     /* All swap has is allocated blocks... exit if not wanted */
-    if (!(a_flags & TSK_FS_BLOCK_FLAG_ALLOC)) {
+    if (!(a_flags & TSK_FS_BLOCK_WALK_FLAG_ALLOC)) {
         return 0;
     }
 

--- a/tsk/fs/ntfs.cpp
+++ b/tsk/fs/ntfs.cpp
@@ -3502,7 +3502,6 @@ ntfs_sds_to_str(TSK_FS_INFO * a_fs, const ntfs_attr_sds * a_sds,
         int i, len;
         char *sid_str_offset = NULL;
         char *sid_str = NULL;
-        unsigned int sid_str_len;
 
         //tsk_fprintf(stderr, "Sub-Authority Count: %i\n", sid->sub_auth_count);
         authority = 0;
@@ -3512,18 +3511,18 @@ ntfs_sds_to_str(TSK_FS_INFO * a_fs, const ntfs_attr_sds * a_sds,
         //tsk_fprintf(stderr, "NT Authority: %" PRIu64 "\n", authority);
 
         // "S-1-AUTH-SUBAUTH-SUBAUTH..."
-        sid_str_len = 4 + 13 + (1 + 10) * sid->sub_auth_count + 1;
+        const size_t sid_str_len = 4 + 13 + (1 + 10) * sid->sub_auth_count;
 
         // Allocate the buffer for the string representation of the SID.
-        if ((sid_str = (char *) tsk_malloc(sid_str_len)) == NULL) {
+        if ((sid_str = (char *) tsk_malloc(sid_str_len + 1)) == NULL) {
             return 1;
         }
 
-        len = sprintf(sid_str, "S-1-%" PRIu64, authority);
+        len = snprintf(sid_str, sid_str_len + 1, "S-1-%" PRIu64, authority);
         sid_str_offset = sid_str + len;
 
         for (i = 0; i < sid->sub_auth_count; i++) {
-            len = sprintf(sid_str_offset, "-%" PRIu32, sid->sub_auth[i]);
+            len = snprintf(sid_str_offset, sid_str_len + 1 - len, "-%" PRIu32, sid->sub_auth[i]);
             sid_str_offset += len;
         }
         *a_sidstr = sid_str;

--- a/tsk/hashdb/hashkeeper.c
+++ b/tsk/hashdb/hashkeeper.c
@@ -321,7 +321,7 @@ uint8_t
             idx_cnt++;
 
             /* Set the previous hash value */
-            strncpy(phash, hash, TSK_HDB_HTYPE_MD5_LEN + 1);
+            strncpy(phash, hash, TSK_HDB_HTYPE_MD5_LEN);
     }
 
     if (idx_cnt > 0) {


### PR DESCRIPTION
Note that this PR does not switch to compiling with C++20---it only corrects warnings you'd get if you did.