### PR TITLE
Don't clobber user variables in configure.ac

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -27,6 +27,7 @@ jobs:
             compiler: "gcc"
             runner: "macos-latest"
             configure_opts: "--with-libewf --disable-java"
+            make_flags: "CFLAGS=-Werror CXXFLAGS=-Werror"
             codecov: "yes"
             prefix: "CODECOV"
             address_sanitizer: "yes"
@@ -37,7 +38,8 @@ jobs:
             linkage: "shared"
             compiler: "gcc"
             runner: "ubuntu-24.04"
-            configure_opts: "--with-libewf --with-libqcow --with-libvhdi --with-libvmdk --disable-java CFLAGS=-Werror CXXFLAGS=-Werror"
+            configure_opts: "--with-libewf --with-libqcow --with-libvhdi --with-libvmdk --disable-java"
+            make_flags: "CFLAGS=-Werror CXXFLAGS=-Werror"
             codecov: "no"
             prefix:
             address_sanitizer: "yes"
@@ -49,7 +51,8 @@ jobs:
             linkage: "shared"
             compiler: "clang"
             runner: "ubuntu-24.04"
-            configure_opts: "--with-libewf --with-libqcow --with-libvhdi --with-libvmdk --disable-java CC=clang CXX=clang++ CFLAGS=-Werror CXXFLAGS=-Werror"
+            configure_opts: "--with-libewf --with-libqcow --with-libvhdi --with-libvmdk --disable-java CC=clang CXX=clang++"
+            make_flags: "CFLAGS=-Werror CXXFLAGS=-Werror"
             codecov: "no"
             prefix: ""
             address_sanitizer: "yes"
@@ -176,12 +179,12 @@ jobs:
 
       - name: Run make
         run: |
-          make -j${{ steps.cores.outputs.cores }} check VERBOSE=1 TESTS=
+          make -j${{ steps.cores.outputs.cores }} check ${{ matrix.make_flags }} VERBOSE=1 TESTS=
 
       - name: Run make check on Mac/Linux
         if: ${{ matrix.os != 'mingw' }}
         run: |
-          make -j${{ steps.cores.outputs.cores }} check VERBOSE=1 || result=1 ; for i in $(find test -name '*.log') ; do printf '\n%79s\n' | tr ' ' '=' ; echo "$i" ; cat "$i" ; done ; exit $result
+          make -j${{ steps.cores.outputs.cores }} check ${{ matrix.make_flags }} VERBOSE=1 || result=1 ; for i in $(find test -name '*.log') ; do printf '\n%79s\n' | tr ' ' '=' ; echo "$i" ; cat "$i" ; done ; exit $result
 
       - name: Run make check on Mingw
         if: ${{ matrix.os == 'mingw' }}
@@ -190,7 +193,7 @@ jobs:
           WINEPATH: ${{ matrix.winepath }}
           WINEPREFIX: ${{ matrix.wineprefix }}
         run: |
-          make -j${{ steps.cores.outputs.cores }} check VERBOSE=1 LOG_COMPILER=scripts/wine_wrapper.sh || result=1 ; for i in $(find test -name '*.log') ; do printf '\n%79s\n' | tr ' ' '=' ; echo "$i" ; cat "$i" ; done ; exit $result
+          make -j${{ steps.cores.outputs.cores }} check ${{ matrix.make_flags }} VERBOSE=1 LOG_COMPILER=scripts/wine_wrapper.sh || result=1 ; for i in $(find test -name '*.log') ; do printf '\n%79s\n' | tr ' ' '=' ; echo "$i" ; cat "$i" ; done ; exit $result
 
       - name: Clean up
         if: ${{ matrix.os != 'mingw' }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,9 @@
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CPPFLAGS = -I$(srcdir)/tsk
-AM_CFLAGS = -Wall -Wextra
-AM_CXXFLAGS = -Wall -Wextra -Woverloaded-virtual
+AM_CPPFLAGS = -I$(srcdir)/tsk $(SQLITE3_CPPFLAGS) $(CRYPTO_CPPFLAGS) $(AFFLIB_CPPFLAGS) $(AFF4_CPPFLAGS) $(EWF_CPPFLAGS) $(QCOW_CPPFLAGS) $(VHDI_CPPFLAGS) $(VMDK_CPPFLAGS) $(VSLVM_CPPFLAGS) $(BFIO_CPPFLAGS) $(ZLIB_CPPFLAGS)
+AM_CFLAGS = -Wall -Wextra $(PTHREAD_CFLAGS) $(SQLITE3_CFLAGS) $(CRYPTO_CFLAGS) $(AFFLIB_CFLAGS) $(AFF4_CFLAGS) $(EWF_CFLAGS) $(QCOW_CFLAGS) $(VHDI_CFLAGS) $(VMDK_CFLAGS) $(VSLVM_CFLAGS) $(BFIO_CFLAGS) $(ZLIB_CFLAGS)
+AM_CXXFLAGS = -Wall -Wextra -Woverloaded-virtual $(PTHREAD_CXXFLAGS) $(CRYPTO_CXXFLAGS) $(SQLITE3_CXXFLAGS) $(AFFLIB_CXXFLAGS) $(AFF4_CXXFLAGS) $(EWF_CXXFLAGS) $(QCOW_CXXFLAGS) $(VHDI_CXXFLAGS) $(VMDK_CXXFLAGS) $(VSLVM_CXXFLAGS) $(BFIO_CXXFLAGS) $(ZLIB_CXXFLAGS)
+AM_LDFLAGS = $(SQLITE3_LDFLAGS) $(AFFLIB_LDFLAGS) $(CRYPTO_LDFLAGS) $(AFF4_LDFLAGS) $(EWF_LDFLAGS) $(QCOW_LDFLAGS) $(VHDI_LDFLAGS) $(VMDK_LDFLAGS) $(VSLVM_LDFLAGS) $(BFIO_LDFLAGS) $(ZLIB_LDFLAGS)
 
 CLEANFILES = *.gcov
 
@@ -126,7 +127,21 @@ nobase_dist_data_DATA = \
 # Library
 #
 
-TSK_LIB = tsk/libtsk.la
+TSK_LIBS = \
+	tsk/libtsk.la \
+	$(PTHREAD_LIBS) \
+	$(SQLITE3_LIBS) \
+	$(CRYPTO_LIBS) \
+	$(AFFLIB_LIBS) \
+	$(AFF4_LIBS) \
+	$(EWF_LIBS) \
+	$(QCOW_LIBS) \
+	$(VHDI_LIBS) \
+	$(VMDK_LIBS) \
+	$(VSLVM_LIBS) \
+	$(BFIO_LIBS) \
+	$(ZLIB_LIBS) \
+	$(STDCPP_LIBS)
 
 noinst_LTLIBRARIES = \
 	tools/libtsktools.la \
@@ -306,8 +321,6 @@ tsk_pool_libtskpool_la_SOURCES = \
 	tsk/pool/pool_read.cpp \
 	tsk/pool/pool_types.cpp
 
-tsk_util_libtskutil_la_CPPFLAGS = $(AM_CPPFLAGS) $(OPENSSL_INCLUDES)
-tsk_util_libtskutil_la_LDFLAGS = $(AM_LDFLAGS) $(OPENSSL_LDFLAGS)
 tsk_util_libtskutil_la_SOURCES = \
 	tsk/util/crypto.cpp \
 	tsk/util/detect_encryption.c \
@@ -350,11 +363,10 @@ tsk_libtsk_la_LIBADD = \
 	tsk/pool/libtskpool.la \
 	tsk/util/Bitlocker/libtskbitlocker.la \
 	tsk/util/libtskutil.la \
-	tsk/vs/libtskvs.la \
-	$(OPENSSL_LIBS)
+	tsk/vs/libtskvs.la
 
 # current:revision:age
-tsk_libtsk_la_LDFLAGS = -version-info 21:1:2 $(LIBTSK_LDFLAGS)
+tsk_libtsk_la_LDFLAGS = $(AM_LDFLAGS) -version-info 21:1:2 $(LIBTSK_LDFLAGS)
 
 EXTRA_DIST += \
 	tsk/tsk_tools_i.h \
@@ -409,21 +421,21 @@ tools_libtsktools_la_SOURCES = \
 	tools/util.cpp \
 	tools/util.h
 
-tools_autotools_tsk_comparedir_LDADD = $(TSK_LIB)
+tools_autotools_tsk_comparedir_LDADD = $(TSK_LIBS)
 tools_autotools_tsk_comparedir_SOURCES = \
 	tools/autotools/tsk_comparedir.cpp \
 	tools/autotools/tsk_comparedir.h
 
-tools_autotools_tsk_gettimes_LDADD = $(TSK_LIB)
+tools_autotools_tsk_gettimes_LDADD = $(TSK_LIBS)
 tools_autotools_tsk_gettimes_SOURCES = tools/autotools/tsk_gettimes.cpp
 
-tools_autotools_tsk_imageinfo_LDADD = $(TSK_LIB)
+tools_autotools_tsk_imageinfo_LDADD = $(TSK_LIBS)
 tools_autotools_tsk_imageinfo_SOURCES = tools/autotools/tsk_imageinfo.cpp
 
-tools_autotools_tsk_loaddb_LDADD = $(TSK_LIB)
+tools_autotools_tsk_loaddb_LDADD = $(TSK_LIBS)
 tools_autotools_tsk_loaddb_SOURCES = tools/autotools/tsk_loaddb.cpp
 
-tools_autotools_tsk_recover_LDADD = $(TSK_LIB)
+tools_autotools_tsk_recover_LDADD = $(TSK_LIBS)
 tools_autotools_tsk_recover_SOURCES = tools/autotools/tsk_recover.cpp
 
 tools_fiwalk_plugins_jpeg_extract_SOURCES = tools/fiwalk/plugins/jpeg_extract.cpp
@@ -456,7 +468,7 @@ tools/fiwalk/plugins/Libextract_plugin.class: tools/fiwalk/plugins/Libextract_pl
 
 noinst_LTLIBRARIES += tools/fiwalk/src/libfiwalk.la
 
-tools_fiwalk_src_libfiwalk_la_LIBADD = $(TSK_LIB)
+tools_fiwalk_src_libfiwalk_la_LIBADD = $(TSK_LIBS)
 tools_fiwalk_src_libfiwalk_la_SOURCES = \
 	tools/fiwalk/src/arff.cpp \
 	tools/fiwalk/src/arff.h \
@@ -486,77 +498,77 @@ tools_fiwalk_src_fiwalk_SOURCES = tools/fiwalk/src/fiwalk_main.cpp
 
 EXTRA_DIST += tools/fstools/fscheck.cpp
 
-tools_fstools_blkcalc_LDADD = $(TSK_LIB)
+tools_fstools_blkcalc_LDADD = $(TSK_LIBS)
 tools_fstools_blkcalc_SOURCES = tools/fstools/blkcalc.cpp
 
-tools_fstools_blkcat_LDADD = $(TSK_LIB)
+tools_fstools_blkcat_LDADD = $(TSK_LIBS)
 tools_fstools_blkcat_SOURCES = tools/fstools/blkcat.cpp
 
-tools_fstools_blkls_LDADD = $(TSK_LIB)
+tools_fstools_blkls_LDADD = $(TSK_LIBS)
 tools_fstools_blkls_SOURCES = tools/fstools/blkls.cpp
 
-tools_fstools_blkstat_LDADD = $(TSK_LIB)
+tools_fstools_blkstat_LDADD = $(TSK_LIBS)
 tools_fstools_blkstat_SOURCES = tools/fstools/blkstat.cpp
 
-tools_fstools_ffind_LDADD = $(TSK_LIB)
+tools_fstools_ffind_LDADD = $(TSK_LIBS)
 tools_fstools_ffind_SOURCES = tools/fstools/ffind.cpp
 
-tools_fstools_fls_LDADD = $(TSK_LIB) tools/libtsktools.la
+tools_fstools_fls_LDADD = $(TSK_LIBS) tools/libtsktools.la
 tools_fstools_fls_SOURCES = tools/fstools/fls.cpp
 
-tools_fstools_fcat_LDADD = $(TSK_LIB)
+tools_fstools_fcat_LDADD = $(TSK_LIBS)
 tools_fstools_fcat_SOURCES = tools/fstools/fcat.cpp
 
-tools_fstools_fsstat_LDADD = $(TSK_LIB)
+tools_fstools_fsstat_LDADD = $(TSK_LIBS)
 tools_fstools_fsstat_SOURCES = tools/fstools/fsstat.cpp
 
-tools_fstools_icat_LDADD = $(TSK_LIB)
+tools_fstools_icat_LDADD = $(TSK_LIBS)
 tools_fstools_icat_SOURCES = tools/fstools/icat.cpp
 
-tools_fstools_ifind_LDADD = $(TSK_LIB)
+tools_fstools_ifind_LDADD = $(TSK_LIBS)
 tools_fstools_ifind_SOURCES = tools/fstools/ifind.cpp
 
-tools_fstools_ils_LDADD = $(TSK_LIB)
+tools_fstools_ils_LDADD = $(TSK_LIBS)
 tools_fstools_ils_SOURCES = tools/fstools/ils.cpp
 
-tools_fstools_istat_LDADD = $(TSK_LIB)
+tools_fstools_istat_LDADD = $(TSK_LIBS)
 tools_fstools_istat_SOURCES = tools/fstools/istat.cpp
 
-tools_fstools_jcat_LDADD = $(TSK_LIB)
+tools_fstools_jcat_LDADD = $(TSK_LIBS)
 tools_fstools_jcat_SOURCES = tools/fstools/jcat.cpp
 
-tools_fstools_jls_LDADD = $(TSK_LIB)
+tools_fstools_jls_LDADD = $(TSK_LIBS)
 tools_fstools_jls_SOURCES = tools/fstools/jls.cpp
 
-tools_fstools_usnjls_LDADD = $(TSK_LIB)
+tools_fstools_usnjls_LDADD = $(TSK_LIBS)
 tools_fstools_usnjls_SOURCES = tools/fstools/usnjls.cpp
 
 EXTRA_DIST += tools/hashtools/md5.c tools/hashtools/sha1.c
 
-tools_hashtools_hfind_LDADD = $(TSK_LIB)
+tools_hashtools_hfind_LDADD = $(TSK_LIBS)
 tools_hashtools_hfind_SOURCES = tools/hashtools/hfind.cpp
 
-tools_imgtools_img_cat_LDADD = $(TSK_LIB)
+tools_imgtools_img_cat_LDADD = $(TSK_LIBS)
 tools_imgtools_img_cat_SOURCES = tools/imgtools/img_cat.cpp
 
-tools_imgtools_img_stat_LDADD = $(TSK_LIB)
+tools_imgtools_img_stat_LDADD = $(TSK_LIBS)
 tools_imgtools_img_stat_SOURCES = tools/imgtools/img_stat.cpp
 
-tools_pooltools_pstat_LDADD = $(TSK_LIB)
+tools_pooltools_pstat_LDADD = $(TSK_LIBS)
 tools_pooltools_pstat_SOURCES = tools/pooltools/pstat.cpp
 
 tools_srchtools_srch_strings_SOURCES = tools/srchtools/srch_strings.c
 
-tools_srchtools_sigfind_LDADD = $(TSK_LIB)
+tools_srchtools_sigfind_LDADD = $(TSK_LIBS)
 tools_srchtools_sigfind_SOURCES = tools/srchtools/sigfind.cpp
 
-tools_vstools_mmls_LDADD = $(TSK_LIB) tools/libtsktools.la
+tools_vstools_mmls_LDADD = $(TSK_LIBS) tools/libtsktools.la
 tools_vstools_mmls_SOURCES = tools/vstools/mmls.cpp
 
-tools_vstools_mmstat_LDADD = $(TSK_LIB)
+tools_vstools_mmstat_LDADD = $(TSK_LIBS)
 tools_vstools_mmstat_SOURCES = tools/vstools/mmstat.cpp
 
-tools_vstools_mmcat_LDADD = $(TSK_LIB)
+tools_vstools_mmcat_LDADD = $(TSK_LIBS)
 tools_vstools_mmcat_SOURCES = tools/vstools/mmcat.cpp
 
 bin_SCRIPTS = tools/sorter/sorter tools/timeline/mactime
@@ -645,9 +657,7 @@ check_PROGRAMS = \
 # and link into a single executable.
 # This makes things easier with codecov.
 test_runner_CPPFLAGS = $(AM_CPPFLAGS) -Ivendors $(CATCH2_CPPFLAGS)
-test_runner_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_runner_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_runner_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
+test_runner_LDADD = $(TSK_LIBS)
 test_runner_SOURCES = \
 	test/tsk/base/test_tsk_error.cpp \
 	test/tsk/img/test_aff4.cpp \
@@ -674,10 +684,7 @@ test_runner_SOURCES = \
 EXTRA_test_runner_DEPENDENCIES = test/get_images/test_images.txt
 
 test_fiwalk_fiwalk_test_CPPFLAGS = $(AM_CPPFLAGS) -Ivendors $(CATCH2_CPPFLAGS)
-test_fiwalk_fiwalk_test_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_fiwalk_fiwalk_test_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_fiwalk_fiwalk_test_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
-test_fiwalk_fiwalk_test_LDADD = $(TSK_LIB)
+test_fiwalk_fiwalk_test_LDADD = $(TSK_LIBS)
 test_fiwalk_fiwalk_test_SOURCES = \
 	test/fiwalk/fiwalk_test.cpp \
 	$(tools_fiwalk_src_libfiwalk_la_SOURCES)
@@ -689,37 +696,22 @@ test/get_images/test_images.txt: test/get_images/test_images.yaml test/get_image
 
 CLEANFILES += test/get_images/test_images.txt
 
-test_img_dump_img_dump_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_img_dump_img_dump_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_img_dump_img_dump_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
-test_img_dump_img_dump_LDADD = $(TSK_LIB)
+test_img_dump_img_dump_LDADD = $(TSK_LIBS)
 test_img_dump_img_dump_SOURCES = test/img_dump/img_dump.cpp
 
-test_legacy_fs_fname_apis_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_fs_fname_apis_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_fs_fname_apis_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
-test_legacy_fs_fname_apis_LDADD = $(TSK_LIB)
+test_legacy_fs_fname_apis_LDADD = $(TSK_LIBS)
 test_legacy_fs_fname_apis_SOURCES = test/legacy/fs_fname_apis.cpp
 
-test_legacy_fs_attrlist_apis_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_fs_attrlist_apis_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_fs_attrlist_apis_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
-test_legacy_fs_attrlist_apis_LDADD = $(TSK_LIB)
+test_legacy_fs_attrlist_apis_LDADD = $(TSK_LIBS)
 test_legacy_fs_attrlist_apis_SOURCES = test/legacy/fs_attrlist_apis.cpp
 
-test_legacy_fs_thread_test_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_fs_thread_test_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_fs_thread_test_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
-test_legacy_fs_thread_test_LDADD = $(TSK_LIB)
+test_legacy_fs_thread_test_LDADD = $(TSK_LIBS)
 test_legacy_fs_thread_test_SOURCES = \
 	test/legacy/fs_thread_test.cpp \
 	test/legacy/tsk_thread.cpp \
 	test/legacy/tsk_thread.h
 
-test_legacy_read_apis_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_read_apis_CXXFLAGS = $(AM_CXXFLAGS) $(PTHREAD_CFLAGS)
-test_legacy_read_apis_LDFLAGS = $(AM_LDFLAGS) $(PTHREAD_LIBS)
-test_legacy_read_apis_LDADD = $(TSK_LIB)
+test_legacy_read_apis_LDADD = $(TSK_LIBS)
 test_legacy_read_apis_SOURCES = test/legacy/read_apis.cpp
 
 #
@@ -752,7 +744,7 @@ jar_DATA = $(tsk_jar) $(tsk_caseuco_jar)
 lib_LTLIBRARIES += bindings/java/jni/libtsk_jni.la
 
 bindings_java_jni_libtsk_jni_la_CPPFLAGS = $(AM_CPPFLAGS) $(JNI_CPPFLAGS)
-bindings_java_jni_libtsk_jni_la_LIBADD = $(TSK_LIB)
+bindings_java_jni_libtsk_jni_la_LIBADD = $(TSK_LIBS)
 bindings_java_jni_libtsk_jni_la_SOURCES = \
 	bindings/java/jni/auto_db_java.cpp \
 	bindings/java/jni/auto_db_java.h \
@@ -824,16 +816,16 @@ noinst_PROGRAMS = \
 	samples/posix_cpp_style \
 	samples/posix_style
 
-samples_callback_cpp_style_LDADD = $(TSK_LIB)
+samples_callback_cpp_style_LDADD = $(TSK_LIBS)
 samples_callback_cpp_style_SOURCES = samples/callback-cpp-style.cpp
 
-samples_callback_style_LDADD = $(TSK_LIB)
+samples_callback_style_LDADD = $(TSK_LIBS)
 samples_callback_style_SOURCES = samples/callback-style.cpp
 
-samples_posix_cpp_style_LDADD = $(TSK_LIB)
+samples_posix_cpp_style_LDADD = $(TSK_LIBS)
 samples_posix_cpp_style_SOURCES = samples/posix-cpp-style.cpp
 
-samples_posix_style_LDADD = $(TSK_LIB)
+samples_posix_style_LDADD = $(TSK_LIBS)
 samples_posix_style_SOURCES = samples/posix-style.cpp
 
 #
@@ -860,7 +852,7 @@ fls_apfs_fuzzer_SOURCES = \
 
 fls_apfs_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 fls_btrfs_fuzzer_SOURCES = \
 	ossfuzz/fls_fuzzer.cc \
@@ -872,7 +864,7 @@ fls_btrfs_fuzzer_CPPFLAGS = \
 
 fls_btrfs_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 fls_ext_fuzzer_SOURCES = \
 	ossfuzz/fls_fuzzer.cc \
@@ -884,7 +876,7 @@ fls_ext_fuzzer_CPPFLAGS = \
 
 fls_ext_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 fls_fat_fuzzer_SOURCES = \
 	ossfuzz/fls_fuzzer.cc \
@@ -896,7 +888,7 @@ fls_fat_fuzzer_CPPFLAGS = \
 
 fls_fat_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 fls_hfs_fuzzer_SOURCES = \
 	ossfuzz/fls_fuzzer.cc \
@@ -908,7 +900,7 @@ fls_hfs_fuzzer_CPPFLAGS = \
 
 fls_hfs_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 fls_iso9660_fuzzer_SOURCES = \
 	ossfuzz/fls_fuzzer.cc \
@@ -920,7 +912,7 @@ fls_iso9660_fuzzer_CPPFLAGS = \
 
 fls_iso9660_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 fls_ntfs_fuzzer_SOURCES = \
 	ossfuzz/fls_fuzzer.cc \
@@ -932,7 +924,7 @@ fls_ntfs_fuzzer_CPPFLAGS = \
 
 fls_ntfs_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 mmls_dos_fuzzer_SOURCES = \
 	ossfuzz/mem_img.h \
@@ -944,7 +936,7 @@ mmls_dos_fuzzer_CPPFLAGS = \
 
 mmls_dos_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 mmls_gpt_fuzzer_SOURCES = \
 	ossfuzz/mem_img.h \
@@ -956,7 +948,7 @@ mmls_gpt_fuzzer_CPPFLAGS = \
 
 mmls_gpt_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 mmls_mac_fuzzer_SOURCES = \
 	ossfuzz/mem_img.h \
@@ -968,7 +960,7 @@ mmls_mac_fuzzer_CPPFLAGS = \
 
 mmls_mac_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 
 mmls_sun_fuzzer_SOURCES = \
 	ossfuzz/mem_img.h \
@@ -980,5 +972,5 @@ mmls_sun_fuzzer_CPPFLAGS = \
 
 mmls_sun_fuzzer_LDADD = \
 	@LIB_FUZZING_ENGINE@ \
-	$(TSK_LIB)
+	$(TSK_LIBS)
 endif # HAVE_LIB_FUZZING_ENGINE

--- a/Makefile.am
+++ b/Makefile.am
@@ -652,10 +652,6 @@ check_PROGRAMS = \
 	test/legacy/fs_thread_test \
 	test/legacy/read_apis
 
-# Unit tests:
-# Instead of linking with ../tsk/libtsk.la, we recompile everything from scratch
-# and link into a single executable.
-# This makes things easier with codecov.
 test_runner_CPPFLAGS = $(AM_CPPFLAGS) -Ivendors $(CATCH2_CPPFLAGS)
 test_runner_LDADD = $(TSK_LIBS)
 test_runner_SOURCES = \
@@ -671,15 +667,7 @@ test_runner_SOURCES = \
 	test/tsk/img/test_vmdk.cpp \
 	test/tsk/util/test_crypto.cpp \
 	test/tsk/hashdb/test_binsrch_index.cpp \
-	test/runner.cpp \
-	$(tsk_auto_libtskauto_la_SOURCES) \
-	$(tsk_base_libtskbase_la_SOURCES) \
-	$(tsk_fs_libtskfs_la_SOURCES) \
-	$(tsk_hashdb_libtskhashdb_la_SOURCES) \
-	$(tsk_img_libtskimg_la_SOURCES) \
-	$(tsk_pool_libtskpool_la_SOURCES) \
-	$(tsk_util_libtskutil_la_SOURCES) \
-	$(tsk_vs_libtskvs_la_SOURCES)
+	test/runner.cpp
 
 EXTRA_test_runner_DEPENDENCIES = test/get_images/test_images.txt
 

--- a/configure.ac
+++ b/configure.ac
@@ -25,9 +25,6 @@ AC_PATH_PROG(PERL, perl)
 
 TSK_CHECK_PROG_PKGCONFIG
 
-
-
-
 dnl Checks for header files.
 dnl AC_HEADER_MAJOR
 dnl AC_HEADER_SYS_WAIT

--- a/configure.ac
+++ b/configure.ac
@@ -66,11 +66,9 @@ AC_CHECK_FUNCS([ishexnumber err errx warn warnx vasprintf getrusage])
 AC_CHECK_FUNCS([strlcpy strlcat strnlen])
 
 AX_PTHREAD([
-    AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.])
-    LIBS="$PTHREAD_LIBS $LIBS"
-    CPPFLAGS="$CPPFLAGS $PTHREAD_CFLAGS"
-    LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
-    CC="$PTHREAD_CC"],[])
+    AC_DEFINE(HAVE_PTHREAD, 1, [Define if you have POSIX threads libraries and header files.])
+    CC="$PTHREAD_CC"
+    CXX="$PTHREAD_CXX"], [])
 
 dnl Permit single-threaded builds
 AC_ARG_ENABLE([multithreading],
@@ -87,7 +85,9 @@ AC_ARG_ENABLE([java],
 dnl Checks for libraries.
 
 dnl Some platforms will complain about missing included functions if libstdc++ is not included.
-AC_CHECK_LIB(stdc++, main, , AC_MSG_ERROR([missing libstdc++]))
+AC_CHECK_LIB(stdc++, main, [], AC_MSG_ERROR([missing libstdc++]))
+AC_SUBST([STDCPP_LIBS], ['-lstdc++'])
+
 AC_CHECK_HEADERS(list, , , AC_MSG_ERROR([missing STL list class header]))
 AC_CHECK_HEADERS(map, , , AC_MSG_ERROR([missing STL map class header]))
 AC_CHECK_HEADERS(queue, , , AC_MSG_ERROR([missing STL queue class header]))
@@ -103,9 +103,7 @@ AS_IF([test "x$ac_cv_prog_PKGCONFIG" = "xyes"],
     SAVED_AX_PACKAGE_REQUIRES_PRIVATE="$AX_PACKAGE_REQUIRES_PRIVATE"
     TSK_PKG_CHECK_MODULES([SQLITE3], [], [sqlite3],
     [
-      CFLAGS="$CFLAGS $SQLITE3_CFLAGS"
-      CXXFLAGS="$CXXFLAGS $SQLITE3_CFLAGS"
-      LIBS="$LIBS $SQLITE3_LIBS"
+      SQLITE3_CXXFLAGS="$SQLITE3_CFLAGS"
     ],
     [
       AX_PACKAGE_REQUIRES_PRIVATE="$SAVED_AX_PACKAGE_REQUIRES_PRIVATE"
@@ -119,8 +117,10 @@ AS_IF([test "x$ax_sqlite3" != "xyes"],
   [
     AC_CHECK_HEADERS(
       [sqlite3.h],
-      [AC_CHECK_LIB([dl], [dlopen])
-       AC_CHECK_LIB([sqlite3], [sqlite3_open], [ax_sqlite3=yes], [])]
+      [
+        AC_CHECK_LIB([dl], [dlopen], [ax_dl=yes], [])
+        AC_CHECK_LIB([sqlite3], [sqlite3_open], [ax_sqlite3=yes], [])
+      ]
     )
   ]
 )
@@ -128,21 +128,29 @@ AS_IF([test "x$ax_sqlite3" != "xyes"],
 dnl Compile the bundled sqlite if there is no system one installed
 AC_MSG_CHECKING(which sqlite3 to use)
 AS_IF([test "x$ax_sqlite3" = "xyes"],
-      [AC_MSG_RESULT([system])
-       PACKAGE_LIBS_PRIVATE="$PACKAGE_LIBS_PRIVATE -lsqlite3"],
+      [
+        AC_MSG_RESULT([system])
+        PACKAGE_LIBS_PRIVATE="$PACKAGE_LIBS_PRIVATE -lsqlite3"
+        SQLITE3_LIBS='-lsqlite3'
+        AS_IF([test "x$ax_dl" = "xyes"], [SQLITE3_LIBS="$SQLITE3_LIBS -ldl"])
+      ],
       [AC_MSG_RESULT([bundled])
-       CPPFLAGS="$CFLAGS -DSQLITE_OMIT_LOAD_EXTENSION"]
+       SQLITE3_CPPFLAGS="-DSQLITE_OMIT_LOAD_EXTENSION"]
 )
 AM_CONDITIONAL([HAVE_LIBSQLITE3], [test "x$ax_sqlite3" = "xyes"])
 
+AC_SUBST([SQLITE3_CPPFLAGS])
+AC_SUBST([SQLITE3_CXXFLAGS])
+AC_SUBST([SQLITE3_LIBS])
+
 dnl Check if we should link with OpenSSL
-TSK_OPT_DEP_CHECK([libcrypto], [LIBOPENSSL], [libcrypto], [openssl/sha.h], [crypto], [SHA1])
+TSK_OPT_DEP_CHECK([libcrypto], [CRYPTO], [libcrypto], [openssl/sha.h], [crypto], [SHA1])
 dnl Check if we should link with afflib
 dnl note that afflib/utils.h explicitly checks for openssl/pem.h, so we need to test for it also
-TSK_OPT_DEP_CHECK([afflib], [], [], [afflib/afflib.h], [afflib], [af_open])
+TSK_OPT_DEP_CHECK([afflib], [AFFLIB], [], [afflib/afflib.h], [afflib], [af_open])
 AC_CHECK_HEADERS([openssl/pem.h])
 dnl Check if we should link with libaff4
-TSK_OPT_DEP_CHECK([libaff4], [], [], [aff4/libaff4-c.h], [aff4], [AFF4_version])
+TSK_OPT_DEP_CHECK([libaff4], [AFF4], [], [aff4/libaff4-c.h], [aff4], [AFF4_version])
 dnl Check if we should link with zlib
 TSK_OPT_DEP_CHECK([zlib], [ZLIB], [zlib], [zlib.h], [z], [inflate])
 dnl Check if we should link with libbfio
@@ -174,7 +182,7 @@ AS_IF(
 )
 
 dnl Check if we should link with libvslvm
-TSK_OPT_DEP_CHECK([libvslvm], [LVM], [libvslvm], [libvslvm.h], [vslvm], [libvslvm_get_version])
+TSK_OPT_DEP_CHECK([libvslvm], [VSLVM], [libvslvm], [libvslvm.h], [vslvm], [libvslvm_get_version])
 
 dnl check for user online input
 AC_ARG_ENABLE([offline],

--- a/m4/tsk_opt_dep_check.m4
+++ b/m4/tsk_opt_dep_check.m4
@@ -64,13 +64,6 @@ AC_DEFUN([TSK_OPT_DEP_CHECK], [
   AS_IF(
     [test "x[$]with_$1" != "xno"],
     [
-      dnl Save flags so we can reset them if the library isn't found
-      SAVED_CPPFLAGS="$CPPFLAGS"
-      SAVED_CFLAGS="$CFLAGS"
-      SAVED_CXXFLAGS="$CXXFLAGS"
-      SAVED_LDFLAGS="$LDFLAGS"
-      SAVED_LIBS="$LIBS"
-
       AS_IF([test "x[$]with_$1" = "xyes" -o "x[$]with_$1" = "xmaybe"],
         [
           dnl Check for lib using pkg-config, if we have it
@@ -80,10 +73,7 @@ AC_DEFUN([TSK_OPT_DEP_CHECK], [
               SAVED_AX_PACKAGE_REQUIRES_PRIVATE="$AX_PACKAGE_REQUIRES_PRIVATE"
               TSK_PKG_CHECK_MODULES([$2], [], [$3],
               [
-                CPPFLAGS="$CPPFLAGS [$]$2[]_CFLAGS"
-                CFLAGS="$CFLAGS [$]$2[]_CFLAGS"
-                CXXFLAGS="$CXXFLAGS [$]$2[]_CFLAGS"
-                LIBS="$LIBS [$]$2[]_LIBS"
+                $2[]_CXXFLAGS="[$]$2[]_CFLAGS"
                 ax_$1=yes
               ],
               [
@@ -98,13 +88,27 @@ AC_DEFUN([TSK_OPT_DEP_CHECK], [
           dnl A directory was given; check that it exists
           AS_IF([test -d "[$]with_$1/include"],
             [
-              CPPFLAGS="$CPPFLAGS -I[$]with_$1/include"
-              LDFLAGS="$LDFLAGS -L[$]with_$1/lib"
+              $2[]_CPPFLAGS="-I[$]with_$1/include"
+              $2[]_LIBS="-L[$]with_$1/lib -l$5"
             ],
             [AC_MSG_FAILURE([$1 directory not found at [$]with_$1])]
           )
         ]
       )
+
+      dnl Save the user variables
+      SAVED_CPPFLAGS="$CPPFLAGS"
+      SAVED_CFLAGS="$CFLAGS"
+      SAVED_CXXFLAGS="$CXXFLAGS"
+      SAVED_LDFLAGS="$LDFLAGS"
+      SAVED_LIBS="$LIBS"
+
+      dnl Use the discovered values for AC_CHECK_HEADERS, AC_CHECK_LIB
+      CPPFLAGS="$CPPFLAGS [$]$2[]_CPPFLAGS"
+      CFLAGS="$CFLAGS [$]$2[]_CFLAGS"
+      CXXFLAGS="$CXXFLAGS [$]$2[]_CXXFLAGS"
+      LDFLAGS="$LDFLAGS [$]$2[]_LDFLAGS"
+      LIBS="$LIBS [$]$2[]_LIBS"
 
       dnl Check if the library is usable
       AC_CHECK_HEADERS([$4], [AC_CHECK_LIB([$5], [$6])])
@@ -113,28 +117,38 @@ AC_DEFUN([TSK_OPT_DEP_CHECK], [
           dnl Library found and usable
           AS_IF([test "x[$]ax_$1" = "xyes"],
             [
-              dnl Library found with pkg-config; reset CPPFLAGS so as not
-              dnl to duplicate flags pkg-config puts into CFLAGS
-              CPPFLAGS="$SAVED_CPPFLAGS"
+              dnl Library found with pkg-config, nothing to do
             ],
             [
-              ax_$1=yes
               dnl Library found without pkg-config; ensure that it is added
               dnl to Libs.private in tsk.pc
               PACKAGE_LIBS_PRIVATE="$PACKAGE_LIBS_PRIVATE -l$5"
+
+              dnl Set $2_LIBS if not already set
+              AS_IF([test -z "[$]$2[]_LIBS"], [$2[]_LIBS="-l$5"])
+              ax_$1=yes
             ]
           )
         ],
         [
-          dnl Library not found or unusable; reset flags
-          CPPFLAGS="$SAVED_CPPFLAGS"
-          CFLAGS="$SAVED_CFLAGS"
-          CXXFLAGS="$SAVED_CXXFLAGS"
-          LDFLAGS="$SAVED_LDFLAGS"
-          LIBS="$SAVED_LIBS"
+          dnl Library not found or unusable
           ax_$1=no
         ]
       )
+
+      dnl Reset user variables
+      CPPFLAGS="$SAVED_CPPFLAGS"
+      CFLAGS="$SAVED_CFLAGS"
+      CXXFLAGS="$SAVED_CXXFLAGS"
+      LDFLAGS="$SAVED_LDFLAGS"
+      LIBS="$SAVED_LIBS"
+
+      dnl Export library flags
+      AC_SUBST([$2_CPPFLAGS])
+      AC_SUBST([$2_CFLAGS])
+      AC_SUBST([$2_CXXFLAGS])
+      AC_SUBST([$2_LDFLAGS])
+      AC_SUBST([$2_LIBS])
     ]
   )
 

--- a/win32/tsk_jni/tsk_jni.vcxproj
+++ b/win32/tsk_jni/tsk_jni.vcxproj
@@ -358,7 +358,7 @@
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(JDK_HOME)\include;$(JDK_HOME)\include\win32;$(ProjectDir)\..\..;$(TskNugetIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;TSK_JNI_EXPORTS;HAVE_LIBEWF;HAVE_LIBOPENSSL;WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;TSK_JNI_EXPORTS;HAVE_LIBEWF;HAVE_LIBCRYPTO;WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>


### PR DESCRIPTION
The user variables (`CPPFLAGS`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS`) shouldn't be reset in `configure.ac`, as that defeats their purpose as user overrides, e.g., by interfering with setting `-Werror` for builds.