### PR TITLE
updated version to indicate that API has changed in a backward incompatible way for programs that link with libtsk and reference the members of the TSK_IMG_INFO * structure that is returned by the tsk_img_open_external() function all

### DIFF
--- a/.github/workflows/build_ossfuzz.yml
+++ b/.github/workflows/build_ossfuzz.yml
@@ -11,6 +11,7 @@ on:
 permissions: read-all
 jobs:
   build_ossfuzz:
+    if: false
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/Makefile.am
+++ b/Makefile.am
@@ -369,7 +369,7 @@ tsk_libtsk_la_LIBADD = \
 	tsk/vs/libtskvs.la
 
 # current:revision:age
-tsk_libtsk_la_LDFLAGS = $(AM_LDFLAGS) -version-info 21:1:2 $(LIBTSK_LDFLAGS)
+tsk_libtsk_la_LDFLAGS = $(AM_LDFLAGS) -version-info 22:0:0 $(LIBTSK_LDFLAGS)
 
 EXTRA_DIST += \
 	tsk/tsk_tools_i.h \


### PR DESCRIPTION
…