### PR TITLE
Move members of TSK_IMG_INFO intended to be private to their own struct

### DIFF
--- a/ossfuzz/fls_apfs_fuzzer.cc
+++ b/ossfuzz/fls_apfs_fuzzer.cc
@@ -54,7 +54,7 @@ out_pool:
   tsk_pool_close(pool);
 
 out_img:
-  img->close(img);
+  tsk_img_close(img);
 
   return 0;
 }

--- a/ossfuzz/fls_fuzzer.cc
+++ b/ossfuzz/fls_fuzzer.cc
@@ -38,6 +38,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     fs->close(fs);
   }
 
-  img->close(img);
+  tsk_img_close(img);
   return 0;
 }

--- a/ossfuzz/mmls_fuzzer.cc
+++ b/ossfuzz/mmls_fuzzer.cc
@@ -43,6 +43,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     tsk_vs_close(vs);
   }
 
-  img->close(img);
+  tsk_img_close(img);
   return 0;
 }

--- a/test/tsk/img/test_img_io.cpp
+++ b/test/tsk/img/test_img_io.cpp
@@ -15,7 +15,7 @@ TEST_CASE("tsk_img_read null img") {
 
 TEST_CASE("tsk_img_read null buffer") {
   std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_free)> img{
-    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(TSK_IMG_INFO)),
+    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(IMG_INFO)),
     tsk_img_free
   };
   REQUIRE(img);
@@ -26,7 +26,7 @@ TEST_CASE("tsk_img_read null buffer") {
 
 TEST_CASE("tsk_img_read negative offset") {
   std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_free)> img{
-    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(TSK_IMG_INFO)),
+    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(IMG_INFO)),
     tsk_img_free
   };
   REQUIRE(img);
@@ -38,7 +38,7 @@ TEST_CASE("tsk_img_read negative offset") {
 
 TEST_CASE("tsk_img_read offset past end") {
   std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_free)> img{
-    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(TSK_IMG_INFO)),
+    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(IMG_INFO)),
     tsk_img_free
   };
   REQUIRE(img);
@@ -53,7 +53,7 @@ TEST_CASE("tsk_img_read length overflow") {
   // Overflow isn't possible when size_t is smaller than TSK_OFF_T
   if (std::numeric_limits<size_t>::max() > std::numeric_limits<TSK_OFF_T>::max()) {
     std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_free)> img{
-      (TSK_IMG_INFO*) tsk_img_malloc(sizeof(TSK_IMG_INFO)),
+      (TSK_IMG_INFO*) tsk_img_malloc(sizeof(IMG_INFO)),
       tsk_img_free
     };
     REQUIRE(img);
@@ -68,23 +68,23 @@ TEST_CASE("tsk_img_read length overflow") {
 TEST_CASE("tsk_img_read inner function failed") {
 
   const auto closer = [](TSK_IMG_INFO* img) {
-    auto cache = static_cast<LegacyCache*>(img->cache_holder);
+    auto cache = static_cast<LegacyCache*>(reinterpret_cast<IMG_INFO*>(img)->cache);
     delete cache;
     tsk_img_free(img);
   };
 
   std::unique_ptr<TSK_IMG_INFO, decltype(closer)> img{
-    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(TSK_IMG_INFO)),
+    (TSK_IMG_INFO*) tsk_img_malloc(sizeof(IMG_INFO)),
     closer
   };
 
   REQUIRE(img);
 
-  img->cache_holder = new LegacyCache();
+  reinterpret_cast<IMG_INFO*>(img.get())->cache = new LegacyCache();
 
-  img->cache_read = tsk_img_read_legacy;
+  reinterpret_cast<IMG_INFO*>(img.get())->cache_read = tsk_img_read_legacy;
 
-  img->read = [](TSK_IMG_INFO*, TSK_OFF_T, char*, size_t) {
+  reinterpret_cast<IMG_INFO*>(img.get())->read = [](TSK_IMG_INFO*, TSK_OFF_T, char*, size_t) {
     return (ssize_t) -1;
   };
 

--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -9,6 +9,7 @@
  * This software is distributed under the Common Public License 1.0
  */
 #include "tsk/tsk_tools_i.h"
+#include "tsk/img/tsk_img_i.h"
 
 static TSK_TCHAR *progname;
 
@@ -118,7 +119,7 @@ main(int argc, char **argv1)
         tsk_printf("%s\n", str);
     }
     else {
-        img->imgstat(img, stdout);
+        reinterpret_cast<IMG_INFO*>(img)->imgstat(img, stdout);
     }
 
     tsk_img_close(img);

--- a/tsk/img/aff.c
+++ b/tsk/img/aff.c
@@ -298,9 +298,10 @@ aff_open(int a_num_img, const TSK_TCHAR * const images[], unsigned int a_ssize)
     aff_info->af_file = NULL;
 
     img_info = (TSK_IMG_INFO *) aff_info;
-    img_info->read = aff_read;
-    img_info->close = aff_close;
-    img_info->imgstat = aff_imgstat;
+
+    aff_info->img_info->read = aff_read;
+    aff_info->img_info->close = aff_close;
+    aff_info->img_info->imgstat = aff_imgstat;
 
     // Save the image path in TSK_IMG_INFO - this is mostly for consistency
     // with the other image types and is not currently used

--- a/tsk/img/aff.h
+++ b/tsk/img/aff.h
@@ -26,6 +26,8 @@
 #include <afflib/afflib_i.h>
 #endif
 
+#include "tsk_img_i.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,7 +38,7 @@ extern "C" {
  * Stores AFF-specific data
  */
 typedef struct {
-    TSK_IMG_INFO img_info;
+    IMG_INFO img_info;
     AFFILE *af_file;
 
     tsk_lock_t read_lock;

--- a/tsk/img/aff4.cpp
+++ b/tsk/img/aff4.cpp
@@ -266,9 +266,10 @@ aff4_open(
 
     img_info->sector_size = 512;
     img_info->itype = TSK_IMG_TYPE_AFF4_AFF4;
-    img_info->read = &aff4_image_read;
-    img_info->close = &aff4_image_close;
-    img_info->imgstat = &aff4_image_imgstat;
+
+    aff4_info->img_info.read = &aff4_image_read;
+    aff4_info->img_info.close = &aff4_image_close;
+    aff4_info->img_info.imgstat = &aff4_image_imgstat;
 
     // initialize the API lock
     tsk_init_lock(&(aff4_info->read_lock));

--- a/tsk/img/aff4.h
+++ b/tsk/img/aff4.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 typedef struct {
-  TSK_IMG_INFO img_info;
+  IMG_INFO img_info;
   AFF4_Handle* handle;
   tsk_lock_t read_lock;   ///< Lock for the handle
 } IMG_AFF4_INFO;

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -355,7 +355,7 @@ ewf_open(int a_num_img,
 
     if (LIBEWF_HANDLE_OPEN(ewf_info->handle,
             images_native,
-            ewf_info->img_info.num_img, LIBEWF_OPEN_READ, &ewf_error) != 1) {
+            img_info->num_img, LIBEWF_OPEN_READ, &ewf_error) != 1) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_OPEN);
 
@@ -461,9 +461,10 @@ ewf_open(int a_num_img,
         }
     }
     img_info->itype = TSK_IMG_TYPE_EWF_EWF;
-    img_info->read = &ewf_image_read;
-    img_info->close = &ewf_image_close;
-    img_info->imgstat = &ewf_image_imgstat;
+
+    ewf_info->img_info.read = &ewf_image_read;
+    ewf_info->img_info.close = &ewf_image_close;
+    ewf_info->img_info.imgstat = &ewf_image_imgstat;
 
     // initialize the read lock
     tsk_init_lock(&(ewf_info->read_lock));

--- a/tsk/img/ewf.h
+++ b/tsk/img/ewf.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../base/tsk_os_cpp.h"
+#include "tsk_img_i.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +35,7 @@ extern "C" {
         unsigned int a_ssize);
 
     typedef struct {
-        TSK_IMG_INFO img_info;
+        IMG_INFO img_info;
         libewf_handle_t *handle;
         char md5hash[33];
         int md5hash_isset;

--- a/tsk/img/img_writer.cpp
+++ b/tsk/img/img_writer.cpp
@@ -748,7 +748,7 @@ TSK_RETVAL_ENUM tsk_img_writer_create(
     TSTRNCPY(writer->fileName, outputFileName, TSTRLEN(outputFileName) + 1);
 
     /* Calculation time */
-    writer->imageSize = raw_info->img_info.size;
+    writer->imageSize = raw_info->img_info.img_info.size;
     if (writer->imageSize > VHD_MAX_IMAGE_SIZE) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_IMG_OPEN);

--- a/tsk/img/logical_img.cpp
+++ b/tsk/img/logical_img.cpp
@@ -164,9 +164,9 @@ logical_open(
 		logical_info->inum_cache[i].cache_age = 0;
 	}
 
-	img_info->read = logical_read;
-	img_info->close = logical_close;
-	img_info->imgstat = logical_imgstat;
+	logical_info->img_info.read = logical_read;
+	logical_info->img_info.close = logical_close;
+	logical_info->img_info.imgstat = logical_imgstat;
 
 	size_t len = TSTRLEN(a_images[0]);
 	logical_info->base_path =

--- a/tsk/img/logical_img.h
+++ b/tsk/img/logical_img.h
@@ -15,6 +15,8 @@
 #ifndef _LOGICAL_H
 #define _LOGICAL_H
 
+#include "tsk_img_i.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,7 +48,7 @@ extern "C" {
   struct LegacyCache;
 
     typedef struct {
-		TSK_IMG_INFO img_info;
+		IMG_INFO img_info;
 		TSK_TCHAR * base_path;
 		uint8_t is_winobj;
 

--- a/tsk/img/pool.hpp
+++ b/tsk/img/pool.hpp
@@ -15,13 +15,14 @@
 #define _POOL_H
 
 #include "../pool/tsk_pool.h"
+#include "tsk_img_i.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
     typedef struct {
-        TSK_IMG_INFO img_info;
+        IMG_INFO img_info;
 
         const TSK_POOL_INFO *pool_info;
         TSK_DADDR_T pvol_block;

--- a/tsk/img/qcow.cpp
+++ b/tsk/img/qcow.cpp
@@ -269,10 +269,12 @@ qcow_open(int a_num_img,
     else {
         img_info->sector_size = 512;
     }
+
     img_info->itype = TSK_IMG_TYPE_QCOW_QCOW;
-    img_info->read = &qcow_image_read;
-    img_info->close = &qcow_image_close;
-    img_info->imgstat = &qcow_image_imgstat;
+
+    qcow_info->img_info.read = &qcow_image_read;
+    qcow_info->img_info.close = &qcow_image_close;
+    qcow_info->img_info.imgstat = &qcow_image_imgstat;
 
     // initialize the read lock
     tsk_init_lock(&(qcow_info->read_lock));

--- a/tsk/img/qcow.h
+++ b/tsk/img/qcow.h
@@ -22,6 +22,8 @@
 
 #include <libqcow.h>
 
+#include "tsk_img_i.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,7 +32,7 @@ extern "C" {
         unsigned int a_ssize);
 
     typedef struct {
-        TSK_IMG_INFO img_info;
+        IMG_INFO img_info;
         libqcow_file_t *handle;
         tsk_lock_t read_lock;   // Lock for reads since according to documentation libqcow is not fully thread safe yet
     } IMG_QCOW_INFO;

--- a/tsk/img/raw.h
+++ b/tsk/img/raw.h
@@ -15,6 +15,7 @@
 #define _RAW_H
 
 #include "img_writer.h"
+#include "tsk_img_i.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,7 @@ extern "C" {
     } IMG_SPLIT_CACHE;
 
     typedef struct {
-        TSK_IMG_INFO img_info;
+        IMG_INFO img_info;
         uint8_t is_winobj;
         TSK_IMG_WRITER *img_writer;
 

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -115,17 +115,7 @@ extern "C" {
         unsigned int page_size;         ///< page size of NAND page in bytes (defaults to 2048)
         unsigned int spare_size;        ///< spare or OOB size of NAND in bytes (defaults to 64)
 
-        // the following are protected by cache_lock in IMG_INFO
         TSK_TCHAR **images;    ///< Image names
-
-        void* cache_holder;
-        Stats stats;
-
-        ssize_t (*cache_read)(TSK_IMG_INFO* img, TSK_OFF_T off, char *buf, size_t len);
-
-        ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len);     ///< \internal External progs should call tsk_img_read()
-        void (*close) (TSK_IMG_INFO *); ///< \internal Progs should call tsk_img_close()
-        void (*imgstat) (TSK_IMG_INFO *, FILE *);       ///< Pointer to file type specific function
     };
 
     // open and close functions

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -234,10 +234,7 @@ extern "C" {
     };
 
     ~TskImgInfo() {
-        if (m_imgInfo == NULL) {
-            return;
-        }
-        m_imgInfo->close(m_imgInfo);
+        tsk_img_close(m_imgInfo);
     };
 
     TskImgInfo(TSK_IMG_INFO * a_imgInfo) {

--- a/tsk/img/tsk_img_i.h
+++ b/tsk/img/tsk_img_i.h
@@ -35,6 +35,20 @@ extern "C" {
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif
+
+struct IMG_INFO {
+  TSK_IMG_INFO img_info;
+
+  void* cache;
+  Stats stats;
+
+  ssize_t (*cache_read)(TSK_IMG_INFO* img, TSK_OFF_T off, char *buf, size_t len);
+
+  ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len);     ///< \internal External progs should call tsk_img_read()
+  void (*close) (TSK_IMG_INFO *); ///< \internal Progs should call tsk_img_close()
+  void (*imgstat) (TSK_IMG_INFO *, FILE *);       ///< Pointer to file type specific function
+};
+
 extern void *tsk_img_malloc(size_t);
 extern void tsk_img_free(void *);
 

--- a/tsk/img/vhd.cpp
+++ b/tsk/img/vhd.cpp
@@ -267,10 +267,12 @@ vhdi_open(int a_num_img,
     else {
         img_info->sector_size = 512;
     }
+
     img_info->itype = TSK_IMG_TYPE_VHD_VHD;
-    img_info->read = &vhdi_image_read;
-    img_info->close = &vhdi_image_close;
-    img_info->imgstat = &vhdi_image_imgstat;
+
+    vhdi_info->img_info.read = &vhdi_image_read;
+    vhdi_info->img_info.close = &vhdi_image_close;
+    vhdi_info->img_info.imgstat = &vhdi_image_imgstat;
 
     // initialize the read lock
     tsk_init_lock(&(vhdi_info->read_lock));

--- a/tsk/img/vhd.h
+++ b/tsk/img/vhd.h
@@ -22,6 +22,8 @@
 
 #include <libvhdi.h>
 
+#include "tsk_img_i.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,7 +32,7 @@ extern "C" {
         unsigned int a_ssize);
 
     typedef struct {
-        TSK_IMG_INFO img_info;
+        IMG_INFO img_info;
         libvhdi_file_t *handle;
         tsk_lock_t read_lock;   // Lock for reads since according to documentation libvhdi is not fully thread safe yet
     } IMG_VHDI_INFO;

--- a/tsk/img/vmdk.cpp
+++ b/tsk/img/vmdk.cpp
@@ -265,10 +265,12 @@ vmdk_open(int a_num_img,
     else {
         img_info->sector_size = 512;
     }
+
     img_info->itype = TSK_IMG_TYPE_VMDK_VMDK;
-    img_info->read = &vmdk_image_read;
-    img_info->close = &vmdk_image_close;
-    img_info->imgstat = &vmdk_image_imgstat;
+
+    vmdk_info->img_info.read = &vmdk_image_read;
+    vmdk_info->img_info.close = &vmdk_image_close;
+    vmdk_info->img_info.imgstat = &vmdk_image_imgstat;
 
     // initialize the read lock
     tsk_init_lock(&(vmdk_info->read_lock));

--- a/tsk/img/vmdk.h
+++ b/tsk/img/vmdk.h
@@ -22,6 +22,8 @@
 
 #include <libvmdk.h>
 
+#include "tsk_img_i.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,7 +32,7 @@ extern "C" {
         unsigned int a_ssize);
 
     typedef struct {
-        TSK_IMG_INFO img_info;
+        IMG_INFO img_info;
         libvmdk_handle_t *handle;
         tsk_lock_t read_lock;   // Lock for reads since according to documentation libvmdk is not fully thread safe yet
     } IMG_VMDK_INFO;

--- a/tsk/pool/apfs_pool.cpp
+++ b/tsk/pool/apfs_pool.cpp
@@ -147,7 +147,7 @@ const std::vector<APFSPool::range> APFSPool::unallocated_ranges() const {
 void APFSPool::clear_cache() noexcept {
   _block_cache.clear();
 
-  auto cache = static_cast<LegacyCache*>(_img->cache_holder);
+  auto cache = static_cast<LegacyCache*>(reinterpret_cast<IMG_INFO*>(_img)->cache);
   cache->lock();
   cache->clear();
   cache->unlock();


### PR DESCRIPTION
The non-metadata parts of `TSK_IMG_INFO` shouldn't be public. This PR moves them to an "inner" struct so they don't appear in any public headers.