### PR TITLE
label xfs and btrfs as experimental

### DIFF
--- a/tsk/fs/fs_types.c
+++ b/tsk/fs/fs_types.c
@@ -66,8 +66,8 @@ static FS_TYPES fs_type_table[] = {
     {"hfsl", TSK_FS_TYPE_HFS_LEGACY, "HFS (Legacy)"},
 #endif
     {"yaffs2", TSK_FS_TYPE_YAFFS2, "YAFFS2"},
-    {"xfs", TSK_FS_TYPE_XFS, "XFS"},
-    {"btrfs", TSK_FS_TYPE_BTRFS, "Btrfs"},
+    {"xfs", TSK_FS_TYPE_XFS, "XFS (experimental)"},
+    {"btrfs", TSK_FS_TYPE_BTRFS, "Btrfs (experimental)"},
     {0,0,""},
 };
 

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -120,31 +120,20 @@ extern "C" {
     };
 
     // open and close functions
-    extern TSK_IMG_INFO *tsk_img_open_sing(
-        const TSK_TCHAR * a_image,
-        TSK_IMG_TYPE_ENUM type,
-        unsigned int a_ssize
+    extern TSK_IMG_INFO *tsk_img_open_sing(const TSK_TCHAR * a_image,
+        TSK_IMG_TYPE_ENUM type, unsigned int a_ssize
     );
 
-    extern TSK_IMG_INFO *tsk_img_open(
-        int num_img,
-        const TSK_TCHAR * const images[],
-        TSK_IMG_TYPE_ENUM,
-        unsigned int a_ssize
-    );
+    extern TSK_IMG_INFO *tsk_img_open(int num_img,
+        const TSK_TCHAR * const images[], TSK_IMG_TYPE_ENUM,
+        unsigned int a_ssize);
 
-    extern TSK_IMG_INFO *tsk_img_open_utf8_sing(
-        const char *a_image,
-        TSK_IMG_TYPE_ENUM type,
-        unsigned int a_ssize
-    );
+    extern TSK_IMG_INFO *tsk_img_open_utf8_sing(const char *a_image,
+        TSK_IMG_TYPE_ENUM type, unsigned int a_ssize);
 
-    extern TSK_IMG_INFO *tsk_img_open_utf8(
-        int num_img,
-        const char *const images[],
-        TSK_IMG_TYPE_ENUM type,
-        unsigned int a_ssize
-    );
+    extern TSK_IMG_INFO *tsk_img_open_utf8(int num_img,
+        const char *const images[], TSK_IMG_TYPE_ENUM type,
+        unsigned int a_ssize);
 
     TSK_IMG_INFO *tsk_img_open_sing_opt(
         const TSK_TCHAR * a_image,
@@ -176,14 +165,11 @@ extern "C" {
         const TSK_IMG_OPTIONS* opts
     );
 
-    extern TSK_IMG_INFO *tsk_img_open_external(
-        void* ext_img_info,
-        TSK_OFF_T size,
-        unsigned int sector_size,
+    extern TSK_IMG_INFO *tsk_img_open_external(void* ext_img_info,
+        TSK_OFF_T size, unsigned int sector_size,
         ssize_t(*read) (TSK_IMG_INFO * img, TSK_OFF_T off, char *buf, size_t len),
         void (*close) (TSK_IMG_INFO *),
-        void (*imgstat) (TSK_IMG_INFO *, FILE *)
-    );
+        void (*imgstat) (TSK_IMG_INFO *, FILE *));
 
     extern void tsk_img_close(TSK_IMG_INFO *);
 


### PR DESCRIPTION
Also brings in some whitespace changes.

```
% tools/fstools/fls -f list                                                                                                                                                                                                  Supported file system types:
	ntfs (NTFS)
	fat (FAT (Auto Detection))
	ext (ExtX (Auto Detection))
	iso9660 (ISO9660 CD)
	hfs (HFS+ (Auto Detection))
	yaffs2 (YAFFS2)
	apfs (APFS)
	logical (Logical Directory)
	ufs (UFS (Auto Detection))
	raw (Raw Data)
	swap (Swap Space)
	fat12 (FAT12)
	fat16 (FAT16)
	fat32 (FAT32)
	exfat (exFAT)
	ext2 (Ext2)
	ext3 (Ext3)
	ext4 (Ext4)
	ufs1 (UFS1)
	ufs2 (UFS2)
	hfsp (HFS+)
	hfsl (HFS (Legacy))
	yaffs2 (YAFFS2)
	xfs (XFS (experimental))
	btrfs (Btrfs (experimental))
```