### PR TITLE
Create tsk_safeUTF16toUTF8 to Prevent Out of Bounds (OOB) read in ntfs_dent_copy_short_only and ntfs_proc_attrseq

### DIFF
--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -135,7 +135,7 @@ static const UTF8 firstByteMark[7] =
 /**
  * \ingroup baselib
  * Convert a UTF-16 string to UTF-8.
- * @param endian Endian ordering flag of UTF-16 text
+ * @param endian Byte ordering of UTF-16 text
  * @param sourceStart Pointer to pointer to start of UTF-16 string.  Will be updated to last char processed.
  * @param sourceEnd Pointer to one entry past end of UTF-16 string
  * @param targetStart Pointer to pointer to place where UTF-8 string should be written.  Will be updated to next place to write to.
@@ -250,6 +250,42 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
     *sourceStart = source;
     *targetStart = target;
     return result;
+}
+
+/**
+ * \ingroup baselib
+ * Wrapper around tsk_UTF16toUTF8 to ensure read of source remains in bounds.
+ * @param endian Byte ordering of UTF-16 text
+ * @param source Pointer to start of the buffer that contains the UTF-16 string.
+ * @param source_len Number of bytes in buffer that contains the UTF-16 string (source).
+ * @param number_of_characters Number of characters in the UTF-16 string to convert.
+ * @param targetStart Pointer to pointer to place where UTF-8 string should be written.  Will be updated to next place to write to.
+ * @param targetEnd Pointer to end of UTF-8 buffer
+ * @param flags Flags used during conversion
+ * @returns error code
+ */
+TSKConversionResult
+tsk_safeUTF16toUTF8(TSK_ENDIAN_ENUM endian, const uint8_t * source,
+    size_t source_len, size_t number_of_characters, UTF8 ** targetStart,
+    UTF8 * targetEnd, TSKConversionFlags flags)
+{
+	int retVal = TSKconversionOK;
+
+	if (source_len > 0 && source_len % 2 != 0) {
+		// source_len must be even, since UTF-16 uses 2 bytes per character
+		source_len -= 1;
+	}
+	source_len /= 2;
+
+	if (source_len < number_of_characters) {
+		number_of_characters = source_len;
+	}
+	const UTF16 *utf16_source = (const UTF16 *) source;
+
+	retVal = tsk_UTF16toUTF8(endian, &utf16_source,
+		utf16_source + number_of_characters, targetStart, targetEnd, flags);
+
+	return retVal;
 }
 
 

--- a/tsk/base/tsk_unicode.h
+++ b/tsk/base/tsk_unicode.h
@@ -139,6 +139,11 @@ extern "C" {
         const UTF16 ** sourceStart, const UTF16 * sourceEnd,
         UTF8 ** targetStart, UTF8 * targetEnd, TSKConversionFlags flags);
 
+    extern TSKConversionResult tsk_safeUTF16toUTF8(TSK_ENDIAN_ENUM,
+        const uint8_t *source, size_t source_len,
+	size_t number_of_characters,
+        UTF8 ** targetStart, UTF8 * targetEnd, TSKConversionFlags flags);
+
     extern TSKConversionResult
         tsk_UTF16toUTF8_lclorder(const UTF16 ** sourceStart,
         const UTF16 * sourceEnd, UTF8 ** targetStart,

--- a/tsk/fs/ntfs.cpp
+++ b/tsk/fs/ntfs.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "encryptionHelper.h"
+#include "tsk/base/tsk_unicode.h"
 
 /**
  * \file ntfs.c
@@ -2437,6 +2438,13 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
                 }
                 fs_name->next = NULL;
             }
+	    /* This check does not make sense
+	     * fname->nlen is number of UTF16 characters, 2 bytest per character
+	     * and attr_len is in bytes.
+	     *
+	     * Keeping it for review but recommend removing this in favor of
+	     * the checks doene inside tsk_safeUTF16toUTF8.
+	     *
             if (fname->nlen > attr_len - 66) {
                 tsk_error_reset();
                 tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
@@ -2444,16 +2452,17 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
                     ("proc_attrseq: invalid name value size out of bounds!");
                 return TSK_COR;
             }
-            UTF16 *name16 = (UTF16 *) & fname->name;
+	     */
             UTF8 *name8 = (UTF8 *) fs_name->name;
 
-            retVal =
-                tsk_UTF16toUTF8(fs->endian, (const UTF16 **) &name16,
-                (UTF16 *) ((uintptr_t) name16 +
-                    fname->nlen * 2),
+            retVal = tsk_safeUTF16toUTF8(
+                fs->endian,
+                & fname->name,
+                attr_len - attr_off - 66,
+                fname->nlen,
                 &name8,
-                (UTF8 *) ((uintptr_t) name8 +
-                    sizeof(fs_name->name)), TSKlenientConversion);
+                (UTF8 *) ((uintptr_t) name8 + sizeof(fs_name->name)),
+                TSKlenientConversion);
             if (retVal != TSKconversionOK) {
                 if (tsk_verbose)
                     tsk_fprintf(stderr,

--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -303,21 +303,26 @@ ntfs_dent_copy(NTFS_INFO * ntfs, ntfs_idxentry * idxe, uintptr_t endaddr,
  * No other fields are copied.  Just the name into shrt_name. */
 static uint8_t
 ntfs_dent_copy_short_only(NTFS_INFO * ntfs, ntfs_idxentry * idxe,
-    TSK_FS_NAME * fs_name)
+    uint32_t idxe_len, TSK_FS_NAME * fs_name)
 {
     ntfs_attr_fname *fname = (ntfs_attr_fname *) & idxe->stream;
     TSK_FS_INFO *fs = (TSK_FS_INFO *) & ntfs->fs_info;
-    UTF16 *name16;
     UTF8 *name8;
     int retVal;
 
-    name16 = (UTF16 *) & fname->name;
     name8 = (UTF8 *) fs_name->shrt_name;
 
-    retVal = tsk_UTF16toUTF8(fs->endian, (const UTF16 **) &name16,
-        (UTF16 *) ((uintptr_t) name16 +
-            fname->nlen * 2), &name8,
-        (UTF8 *) ((uintptr_t) name8 +
+    if (idxe_len < 16) {
+        *name8 = '\0';
+        if (tsk_verbose)
+            tsk_fprintf(stderr,
+                "Error converting NTFS 8.3 name to UTF8: remaining idxe_len too small.");
+	return 0;
+    }
+    // Note that NTFS uses UCS-2 (not UTF-16) hence lenient conversion is needed.
+    retVal = tsk_safeUTF16toUTF8(fs->endian,
+        &fname->name, (size_t) idxe_len - 16, fname->nlen,
+       	&name8, (UTF8 *) ((uintptr_t) name8 +
             fs_name->shrt_name_size), TSKlenientConversion);
 
     if (retVal != TSKconversionOK) {
@@ -370,8 +375,8 @@ is_time(uint64_t t)
  * Process a list of index entries and add to FS_DIR
  *
  * @param a_is_del Set to 1 if these entries are for a deleted directory
- * @param idxe Buffer with index entries to process
- * @param idxe_len Length of idxe buffer (in bytes)
+ * @param a_idxe Buffer with index entries to process
+ * @param a_idxe_len Length of idxe buffer (in bytes)
  * @param used_len Length of data as reported by idexlist header (everything
  * after which and less then idxe_len is considered deleted)
  *
@@ -475,9 +480,8 @@ ntfs_proc_idxentry(NTFS_INFO * a_ntfs, TSK_FS_DIR * a_fs_dir,
 
         /* do some sanity checks on the deleted entries
          */
-        if ((tsk_getu16(fs->endian, a_idxe->strlen) == 0) ||
-            (((uintptr_t) a_idxe + tsk_getu16(fs->endian,
-                        a_idxe->idxlen)) > endaddr_alloc)) {
+	uint16_t idxlen = tsk_getu16(fs->endian, a_idxe->idxlen);
+        if ((idxlen == 0) || (((uintptr_t) a_idxe + idxlen) > endaddr_alloc)) {
 
             /* name space checks */
             if ((fname->nspace != NTFS_FNAME_POSIX) &&
@@ -539,7 +543,10 @@ ntfs_proc_idxentry(NTFS_INFO * a_ntfs, TSK_FS_DIR * a_fs_dir,
             if (fs_name_preventry) {
                 // check its the same entry and if so, add short name
                 if (fs_name_preventry->meta_addr == tsk_getu48(fs->endian, a_idxe->file_ref)) {
-                    ntfs_dent_copy_short_only(a_ntfs, a_idxe, fs_name_preventry);
+		    if ((uintptr_t) a_idxe < endaddr_alloc) {
+		        size_t remaining_a_idxe_len = (size_t) ( endaddr_alloc - (uintptr_t) a_idxe );
+                        ntfs_dent_copy_short_only(a_ntfs, a_idxe, remaining_a_idxe_len, fs_name_preventry);
+		    }
                 }
 
                 // regardless, add preventry to dir and move on to next entry.


### PR DESCRIPTION
Introduces `tsk_safeUTF16toUTF8`
