### PR TITLE
Reverts the 'ant' requirement from #3217

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,10 +219,11 @@ AS_IF([test "x$enable_java" != "xno"], [
 ]) dnl test enable_java
 
 dnl Test is ant is available since we now use it for the build system
+dnl BC - TODO - Add this to the enable Java section and uncomment below
 AC_PATH_PROG([ANT], [ant], [no])
-if test "x$ANT" = "xno"; then
-   AC_MSG_ERROR([Apache Ant is required but was not found. Install Ant and try again.])
-fi
+dnl if test "x$ANT" = "xno"; then
+dnl    AC_MSG_ERROR([Apache Ant is required but was not found. Install Ant and try again.])
+dnl fi
 AC_SUBST(ANT)
 
 


### PR DESCRIPTION
Ant should not be a requirement unless the user wants to build Java. Someone should edit what is now there. I only commented out the error. 