### PR TITLE
Add btrfs zstd flag

### DIFF
--- a/tsk/fs/btrfs.cpp
+++ b/tsk/fs/btrfs.cpp
@@ -4253,7 +4253,7 @@ btrfs_fsstat_print_incompat_flags(FILE * a_file, uint64_t a_flags)
         "DEFAULT_SUBVOL",
         "MIXED_GROUPS",
         "COMPRESS_LZO",
-        "COMPRESS_LZOv2",
+        "COMPRESS_ZSTD",
         "BIG_METADATA",
         "EXTENDED_IREF",
         "RAID56",

--- a/tsk/fs/tsk_btrfs.h
+++ b/tsk/fs/tsk_btrfs.h
@@ -66,7 +66,7 @@ extern "C" {
 #define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_DEFAULT_SUBVOL  (1ULL << 1)     // supported (only for fsstat - we use FS_TREE as root!)
 #define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_MIXED_GROUPS    (1ULL << 2)     // not relevant
 #define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_COMPRESS_LZO    (1ULL << 3)     // TODO: not (yet) supported (but we handle this on EXTENT_DATA level)
-#define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_COMPRESS_LZOv2  (1ULL << 4)     // reserved flag so far
+#define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_COMPRESS_ZSTD   (1ULL << 4)     // TODO: not (yet) supported (but we handle this on EXTENT_DATA level)
 #define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_BIG_METADATA    (1ULL << 5)     // not relevant
 #define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_EXTENDED_IREF   (1ULL << 6)     // not relevant
 #define BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_RAID56          (1ULL << 7)     // not relevant
@@ -78,6 +78,7 @@ extern "C" {
      BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_DEFAULT_SUBVOL     | \
      BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_MIXED_GROUPS       | \
      BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_COMPRESS_LZO       | \
+     BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_COMPRESS_ZSTD      | \
      BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_BIG_METADATA       | \
      BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_EXTENDED_IREF      | \
      BTRFS_SUPERBLOCK_INCOMPAT_FLAGS_RAID56             | \


### PR DESCRIPTION
At the moment `fsstat` can't detect btrfs with zstd compression:

```
btrfs_open: Unsupported superblock incompat_flags:
COMPRESS_LZOv2
...
Cannot determine file system type
```

See https://github.com/torvalds/linux/blob/695caca9345a160ecd9645abab8e70cfe849e9ff/fs/btrfs/sysfs.c#L285C1-L285C25 and https://github.com/torvalds/linux/blob/695caca9345a160ecd9645abab8e70cfe849e9ff/fs/btrfs/compression.h#L119.