### PR TITLE
merged in changes from Eran-YT:speed-up-tsk_fs_path2inum

### DIFF
--- a/tsk/fs/fs_dir.cpp
+++ b/tsk/fs/fs_dir.cpp
@@ -431,8 +431,21 @@ tsk_fs_dir_getsize(const TSK_FS_DIR * a_fs_dir)
  * @param a_idx Index of file in directory to open (0-based)
  * @returns NULL on error
  */
+TSK_FS_FILE*
+tsk_fs_dir_get(const TSK_FS_DIR* a_fs_dir, size_t a_idx)
+{
+    return tsk_fs_dir_get2(a_fs_dir, a_idx, TRUE);
+}
+
+/** \ingroup fslib
+* Return a specific file or subdirectory from an open directory.
+ * @param a_fs_dir Directory to analyze
+ * @param a_idx Index of file in directory to open (0-based)
+ * @param load_attributes Boolean indicating if the file attributes should be loaded
+ * @returns NULL on error
+ */
 TSK_FS_FILE *
-tsk_fs_dir_get(const TSK_FS_DIR * a_fs_dir, size_t a_idx)
+tsk_fs_dir_get2(const TSK_FS_DIR * a_fs_dir, size_t a_idx, size_t load_attributes)
 {
     TSK_FS_NAME *fs_name;
     TSK_FS_FILE *fs_file;
@@ -470,8 +483,8 @@ tsk_fs_dir_get(const TSK_FS_DIR * a_fs_dir, size_t a_idx)
 
     /* load the fs_meta structure if possible.
      * Must have non-zero inode addr or have allocated name (if inode is 0) */
-    if (((fs_name->meta_addr)
-            || (fs_name->flags & TSK_FS_NAME_FLAG_ALLOC))) {
+    if (load_attributes && (((fs_name->meta_addr)
+            || (fs_name->flags & TSK_FS_NAME_FLAG_ALLOC)))) {
         if (a_fs_dir->fs_info->file_add_meta(a_fs_dir->fs_info, fs_file,
                 fs_name->meta_addr)) {
             if (tsk_verbose)

--- a/tsk/fs/tsk_fs.h
+++ b/tsk/fs/tsk_fs.h
@@ -676,6 +676,7 @@ extern "C" {
         void *a_ptr);
     extern size_t tsk_fs_dir_getsize(const TSK_FS_DIR *);
     extern TSK_FS_FILE *tsk_fs_dir_get(const TSK_FS_DIR *, size_t);
+    extern TSK_FS_FILE *tsk_fs_dir_get2(const TSK_FS_DIR *, size_t, size_t load_attributes);
     extern const TSK_FS_NAME *tsk_fs_dir_get_name(const TSK_FS_DIR * a_fs_dir, size_t a_idx);
     extern void tsk_fs_dir_close(TSK_FS_DIR *);
 


### PR DESCRIPTION
This takes over https://github.com/sleuthkit/sleuthkit/pull/2517
Closes #2517 

Adds a new function `tsk_fs_dir_get2()` which allows specifying if attributes should be loaded on get directory entries. `tsk_fs_dir_get()` modified to call `tsk_fs_dir_get2()` with `load_attributes` set to false.

From #2517:

> Currently tsk_fs_path2inum uses tsk_fs_dir_get which loads the attributes for the directory it gets, which tsk_fs_path2inum doesn't actually need in most cases, and this is very expensive (They are read from disk).
> This PR changes this behavior to only load the attributes if needed (only a very specific case involving NTFS), thus speeding up the function.
> By my benchmarks the speed up is about by a factor of >50.
> This also reduces the disk I/O.