### PR TITLE
Fixed usage messages to print command name only

### DIFF
--- a/tools/autotools/tsk_comparedir.cpp
+++ b/tools/autotools/tsk_comparedir.cpp
@@ -37,19 +37,16 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-n start_inum] [-vV] image [image] comparison_directory\n"),
-        progname);
-
+    tsk_fprintf(stderr,
+        "usage: tsk_comparedir [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-n start_inum] [-vV] image [image] comparison_directory\n");
+    tsk_fprintf(stderr,
+        "\t-f fstype: File system type (use '-f list' for supported types)\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
     tsk_fprintf(stderr,
         "\t-b dev_sector_size: The size (in bytes) of the device sectors\n");
     tsk_fprintf(stderr,
-        "\t-f fstype: The file system type (use '-f list' for supported types)\n");
-    tsk_fprintf(stderr,
-        "\t-o sector_offset: sector offset for file system to compare\n");
+        "\t-o sector_offset: The offset of the file system in the image (in sectors)\n");
     tsk_fprintf(stderr,
         "\t-P pooltype: Pool container type (use '-P list' for supported types)\n");
     tsk_fprintf(stderr,

--- a/tools/autotools/tsk_gettimes.cpp
+++ b/tools/autotools/tsk_gettimes.cpp
@@ -19,10 +19,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-vVm] [-i imgtype] [-b dev_sector_size] [-z zone] [-s seconds] image [image]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: tsk_gettimes [-vVm] [-i imgtype] [-b dev_sector_size] [-z zone] [-s seconds] image [image]\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
     tsk_fprintf(stderr,

--- a/tools/autotools/tsk_loaddb.cpp
+++ b/tools/autotools/tsk_loaddb.cpp
@@ -18,10 +18,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-ahkvV] [-i imgtype] [-b dev_sector_size] [-d database] [-z ZONE] image [image]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: tsk_loaddb [-ahkvV] [-i imgtype] [-b dev_sector_size] [-d database] [-z ZONE] image [image]\n");
     tsk_fprintf(stderr, "\t-a: Add image to existing database, instead of creating a new one (requires -d to specify database)\n");
     tsk_fprintf(stderr, "\t-k: Don't create block data table\n");
     tsk_fprintf(stderr, "\t-h: Calculate hash values for the files\n");

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -19,10 +19,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-vVae] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-d dir_inum] image [image] output_dir\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: tsk_recover [-vVae] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o sector_offset] [-P pooltype] [-B pool_volume_block] [-d dir_inum] image [image] output_dir\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
     tsk_fprintf(stderr,

--- a/tools/fstools/blkcalc.cpp
+++ b/tools/fstools/blkcalc.cpp
@@ -31,10 +31,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-dsu unit_addr] [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: blkcalc [-dsu unit_addr] [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images]\n");
     tsk_fprintf(stderr, "Slowly calculates the opposite block number\n");
     tsk_fprintf(stderr, "\tOne of the following must be given:\n");
     tsk_fprintf(stderr,

--- a/tools/fstools/blkcat.cpp
+++ b/tools/fstools/blkcat.cpp
@@ -32,10 +32,8 @@ static TSK_TCHAR *progname;
 void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-ahsvVw] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-k password] [-u usize] image [images] unit_addr [num]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: blkcat [-ahsvVw] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-k password] [-u usize] image [images] unit_addr [num]\n");
     tsk_fprintf(stderr, "\t-a: displays in all ASCII \n");
     tsk_fprintf(stderr, "\t-h: displays in hexdump-like fashion\n");
     tsk_fprintf(stderr,

--- a/tools/fstools/blkls.cpp
+++ b/tools/fstools/blkls.cpp
@@ -35,10 +35,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-aAelvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] [start-stop]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: blkls [-aAelvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] [start-stop]\n");
     tsk_fprintf(stderr, "\t-e: every block (including file system metadata blocks)\n");
     tsk_fprintf(stderr,
         "\t-l: print details in time machine list format\n");

--- a/tools/fstools/blkstat.cpp
+++ b/tools/fstools/blkstat.cpp
@@ -24,10 +24,8 @@ static TSK_TCHAR *progname;
 void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] addr\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: blkstat [-vV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] addr\n");
     tsk_fprintf(stderr,
         "\t-f fstype: File system type (use '-f list' for supported types)\n");
     tsk_fprintf(stderr, "\t-k password: Decryption password for encrypted volumes\n");

--- a/tools/fstools/fcat.cpp
+++ b/tools/fstools/fcat.cpp
@@ -22,10 +22,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-hRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] file_path image [images]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: fcat [-hRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] file_path image [images]\n");
     tsk_fprintf(stderr, "\t-h: Do not display holes in sparse files\n");
     tsk_fprintf(stderr,
         "\t-R: Suppress recovery errors\n");

--- a/tools/fstools/ffind.cpp
+++ b/tools/fstools/ffind.cpp
@@ -28,10 +28,8 @@ static TSK_TCHAR *progname;
 void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-aduvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] inode\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: ffind [-aduvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] image [images] inode\n");
     tsk_fprintf(stderr, "\t-a: Find all occurrences\n");
     tsk_fprintf(stderr, "\t-d: Find deleted entries ONLY\n");
     tsk_fprintf(stderr, "\t-u: Find undeleted entries ONLY\n");

--- a/tools/fstools/fsstat.cpp
+++ b/tools/fstools/fsstat.cpp
@@ -22,10 +22,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-tvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: fsstat [-tvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n");
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");

--- a/tools/fstools/icat.cpp
+++ b/tools/fstools/icat.cpp
@@ -34,10 +34,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-hrRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image [images] inum[-typ[-id]]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: icat [-hrRsvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image [images] inum[-typ[-id]]\n");
     tsk_fprintf(stderr, "\t-h: Do not display holes in sparse files\n");
     tsk_fprintf(stderr, "\t-r: Recover deleted file\n");
     tsk_fprintf(stderr,

--- a/tools/fstools/ifind.cpp
+++ b/tools/fstools/ifind.cpp
@@ -32,10 +32,8 @@ static uint8_t localflags;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-alvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-d unit_addr] [-n file] [-p par_addr] [-z ZONE] image [images]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: ifind [-alvV] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-d unit_addr] [-n file] [-p par_addr] [-z ZONE] image [images]\n");
     tsk_fprintf(stderr, "\t-a: find all inodes\n");
     tsk_fprintf(stderr,
         "\t-d unit_addr: Find the meta data given the data unit\n");

--- a/tools/fstools/ils.cpp
+++ b/tools/fstools/ils.cpp
@@ -34,10 +34,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-emOpvV] [-aAlLzZ] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-s seconds] image [images] [inum[-end]]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: ils [-emOpvV] [-aAlLzZ] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-s seconds] image [images] [inum[-end]]\n");
     tsk_fprintf(stderr, "\t-e: Display all inodes\n");
     tsk_fprintf(stderr, "\t-m: Display output in the mactime format\n");
     tsk_fprintf(stderr,

--- a/tools/fstools/istat.cpp
+++ b/tools/fstools/istat.cpp
@@ -31,10 +31,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-N num] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-z zone] [-s seconds] [-rvV] image inum\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: istat [-N num] [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-P pooltype] [-B pool_volume_block] [-z zone] [-s seconds] [-rvV] image inum\n");
     tsk_fprintf(stderr,
         "\t-N num: force the display of NUM address of block pointers\n");
     tsk_fprintf(stderr, "\t-r: display run list instead of list of block addresses\n");

--- a/tools/fstools/jcat.cpp
+++ b/tools/fstools/jcat.cpp
@@ -24,10 +24,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [images] [inode] blk\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: jcat [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [images] [inode] blk\n");
     tsk_fprintf(stderr, "\tblk: The journal block to view\n");
     tsk_fprintf(stderr,
         "\tinode: The file system inode where the journal is located\n");

--- a/tools/fstools/jls.cpp
+++ b/tools/fstools/jls.cpp
@@ -20,16 +20,14 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [inode]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: jls [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] image [inode]\n");
+    tsk_fprintf(stderr,
+        "\t-f fstype: File system type (use '-f list' for supported types)\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
     tsk_fprintf(stderr,
         "\t-b dev_sector_size: The size (in bytes) of the device sectors\n");
-    tsk_fprintf(stderr,
-        "\t-f fstype: File system type (use '-f list' for supported types)\n");
     tsk_fprintf(stderr,
         "\t-o imgoffset: The offset of the file system in the image (in sectors)\n");
     tsk_fprintf(stderr, "\t-v: verbose output to stderr\n");

--- a/tools/fstools/usnjls.cpp
+++ b/tools/fstools/usnjls.cpp
@@ -25,11 +25,8 @@ static const char *usnjrnl_path = "$Extend/$UsnJrnl";
 static void
 usage()
 {
-    TFPRINTF(stderr,
-             _TSK_T
-             ("usage: %" PRIttocTSK " [-f fstype] [-i imgtype] [-b dev_sector_size]"
-              " [-o imgoffset] [-lmvV] image [inode]\n"),
-             progname);
+    tsk_fprintf(stderr,
+        "usage: usnjls [-f fstype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-lmvV] image [inode]\n");
     tsk_fprintf(stderr,
                 "\t-i imgtype: The format of the image file "
                 "(use '-i list' for supported types)\n");

--- a/tools/hashtools/hfind.cpp
+++ b/tools/hashtools/hfind.cpp
@@ -22,27 +22,25 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-             _TSK_T
-             ("usage: %" PRIttocTSK " [-eqVa] [-c] [-f lookup_file] [-i db_type] db_file [hashes]\n"),
-             progname);
     tsk_fprintf(stderr,
-                "\t-e: Extended mode - where values other than just the name are printed\n");
+        "usage: hfind [-eqVa] [-c] [-f lookup_file] [-i db_type] db_file [hashes]\n");
     tsk_fprintf(stderr,
-                "\t-q: Quick mode - where a 1 is printed if it is found, else 0\n");
+        "\t-e: Extended mode - where values other than just the name are printed\n");
+    tsk_fprintf(stderr,
+        "\t-q: Quick mode - where a 1 is printed if it is found, else 0\n");
     tsk_fprintf(stderr, "\t-V: Print version to STDOUT\n");
     tsk_fprintf(stderr, "\t-c db_name: Create new database with the given name.\n");
     tsk_fprintf(stderr, "\t-a: Add given hashes to the database.\n");
     tsk_fprintf(stderr,
-                "\t-f lookup_file: File with one hash per line to lookup\n");
+        "\t-f lookup_file: File with one hash per line to lookup\n");
     tsk_fprintf(stderr,
-                "\t-i db_type: Create index file for a given hash database type\n");
+        "\t-i db_type: Create index file for a given hash database type\n");
     tsk_fprintf(stderr,
-                "\tdb_file: The path of the hash database, must have .kdb extension for -c option\n");
+        "\tdb_file: The path of the hash database, must have .kdb extension for -c option\n");
     tsk_fprintf(stderr,
-                "\t[hashes]: hashes to lookup (STDIN is used otherwise)\n");
+        "\t[hashes]: hashes to lookup (STDIN is used otherwise)\n");
     tsk_fprintf(stderr, "\n\tSupported index types: %s\n",
-                TSK_HDB_DBTYPE_SUPPORT_STR);
+        TSK_HDB_DBTYPE_SUPPORT_STR);
     exit(1);
 }
 

--- a/tools/imgtools/img_cat.cpp
+++ b/tools/imgtools/img_cat.cpp
@@ -21,12 +21,10 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-vV] [-i imgtype] [-b dev_sector_size] [-s start_sector] [-e stop_sector] image\n"),
-        progname);
     tsk_fprintf(stderr,
-        "\t-i imgtype: The format of the image file (use 'i list' for supported types)\n");
+        "usage: img_cat [-vV] [-i imgtype] [-b dev_sector_size] [-s start_sector] [-e stop_sector] image\n");
+    tsk_fprintf(stderr,
+        "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");
     tsk_fprintf(stderr,
         "\t-b dev_sector_size: The size (in bytes) of the device sectors\n");
     tsk_fprintf(stderr,

--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -18,10 +18,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-tvV] [-i imgtype] [-b dev_sector_size] image\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: img_stat [-tvV] [-i imgtype] [-b dev_sector_size] image\n");
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for list of supported types)\n");

--- a/tools/logicalimager/tsk_logical_imager.cpp
+++ b/tools/logicalimager/tsk_logical_imager.cpp
@@ -396,10 +396,8 @@ static void reportUsers(const std::string &sessionDir, const std::string &driveN
 
 
 static void usage() {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-c configPath]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: tsk_logical_imager [-c configPath]\n");
     tsk_fprintf(stderr, "\t-c configPath: The configuration file. Default is logical-imager-config.json\n");
     tsk_fprintf(stderr, "\t-v: verbose output to stderr\n");
     tsk_fprintf(stderr, "\t-V: Print version\n");

--- a/tools/pooltools/pstat.cpp
+++ b/tools/pooltools/pstat.cpp
@@ -8,10 +8,8 @@ static TSK_TCHAR *progname;
 static void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-tvV] [-p pooltype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: pstat [-tvV] [-p pooltype] [-i imgtype] [-b dev_sector_size] [-o imgoffset] image\n");
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for supported types)\n");

--- a/tools/vstools/mmcat.cpp
+++ b/tools/vstools/mmcat.cpp
@@ -22,10 +22,8 @@ static TSK_TCHAR *progname;
 void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images] part_num\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: mmcat [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images] part_num\n");
     tsk_fprintf(stderr,
         "\t-t vstype: The type of partition system (use '-t list' for list of supported types)\n");
     tsk_fprintf(stderr,

--- a/tools/vstools/mmstat.cpp
+++ b/tools/vstools/mmstat.cpp
@@ -19,10 +19,8 @@ static TSK_TCHAR *progname;
 void
 usage()
 {
-    TFPRINTF(stderr,
-        _TSK_T
-        ("usage: %" PRIttocTSK " [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images]\n"),
-        progname);
+    tsk_fprintf(stderr,
+        "usage: mmstat [-i imgtype] [-b dev_sector_size] [-o imgoffset] [-vV] [-t vstype] image [images]\n");
     tsk_fprintf(stderr,
         "\t-t vstype: The volume system type (use '-t list' for list of supported types)\n");
     tsk_fprintf(stderr,


### PR DESCRIPTION
Updated usage message to print only command name instead of full path printing. (tools)