### PR TITLE
ossfuzz: fix build

### DIFF
--- a/ossfuzz/fls_apfs_fuzzer.cc
+++ b/ossfuzz/fls_apfs_fuzzer.cc
@@ -23,21 +23,18 @@
 #include "mem_img.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_close)> img{
-    mem_open(data, size);
-    tsk_img_close
-  };
-
+  IMG_INFO *img = mem_open(data, size);
   if (!img) {
     return 0;
   }
 
   std::unique_ptr<const TSK_POOL_INFO, decltype(&tsk_pool_close)> pool{
-    tsk_pool_open_img_sing(img.get(), 0, TSK_POOL_TYPE_APFS),
+    tsk_pool_open_img_sing((TSK_IMG_INFO *)img, 0, TSK_POOL_TYPE_APFS),
     tsk_pool_close
   };
 
   if (!pool) {
+    tsk_img_close((TSK_IMG_INFO*)img);
     return 0;
   }
 
@@ -48,6 +45,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   };
 
   if (!pool_img) {
+     tsk_img_close((TSK_IMG_INFO*)img);
     return 0;
   }
 
@@ -59,6 +57,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (fs) {
     tsk_fs_fls(fs.get(), TSK_FS_FLS_FULL, fs->root_inum, TSK_FS_DIR_WALK_FLAG_RECURSE, nullptr, 0);
   }
+
+  tsk_img_close((TSK_IMG_INFO*)img);
 
   return 0;
 }

--- a/ossfuzz/fls_fuzzer.cc
+++ b/ossfuzz/fls_fuzzer.cc
@@ -25,19 +25,13 @@
 #endif
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  TSK_FS_INFO *fs;
-
-  std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_close)> img{
-    mem_open(data, size),
-    tsk_img_close
-  };
-
+  IMG_INFO *img = mem_open(data, size);
   if (!img) {
     return 0;
   }
 
   std::unique_ptr<TSK_FS_INFO, decltype(&tsk_fs_close)> fs{
-    tsk_fs_open_img(img.get(), 0, FSTYPE),
+    tsk_fs_open_img(reinterpret_cast<TSK_IMG_INFO *>(img), 0, FSTYPE),
     tsk_fs_close
   };
 
@@ -45,6 +39,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     tsk_fs_fls(fs.get(), TSK_FS_FLS_FULL, fs->root_inum, TSK_FS_DIR_WALK_FLAG_RECURSE,
                nullptr, 0);
   }
+
+  tsk_img_close((TSK_IMG_INFO*)img);
 
   return 0;
 }

--- a/ossfuzz/mem_img.h
+++ b/ossfuzz/mem_img.h
@@ -53,7 +53,7 @@ static void mem_close(TSK_IMG_INFO *img_info) {
 
 static void mem_imgstat(TSK_IMG_INFO *, FILE *) {}
 
-TSK_IMG_INFO *mem_open(const uint8_t *data, size_t size) {
+IMG_INFO *mem_open(const uint8_t *data, size_t size) {
   IMG_MEM_INFO *inmemory_img =
       reinterpret_cast<IMG_MEM_INFO *>(malloc(sizeof(IMG_MEM_INFO)));
   TSK_IMG_INFO *img;
@@ -64,7 +64,7 @@ TSK_IMG_INFO *mem_open(const uint8_t *data, size_t size) {
   inmemory_img->data = data;
   inmemory_img->size = size;
 
-  auto base = inmemory_img->img_info.img_info;
+  auto base = &(inmemory_img->img_info.img_info);
   base->itype = TSK_IMG_TYPE_RAW;
   base->size = size;
   base->sector_size = 512;
@@ -76,7 +76,7 @@ TSK_IMG_INFO *mem_open(const uint8_t *data, size_t size) {
   inmemory_img->img_info.cache = new LegacyCache();
   inmemory_img->img_info.cache_read = tsk_img_read_legacy;
 
-  return base;
+  return (IMG_INFO*)inmemory_img;
 }
 
 #endif // # MEM_IMG_H

--- a/ossfuzz/mmls_fuzzer.cc
+++ b/ossfuzz/mmls_fuzzer.cc
@@ -30,24 +30,20 @@ static TSK_WALK_RET_ENUM part_act(TSK_VS_INFO *vs, const TSK_VS_PART_INFO *part,
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_close)> img{
-    mem_open(data, size);
-    tsk_img_close
-  };
-
+  TSK_VS_INFO *img = (TSK_VS_INFO*)mem_open(data, size);
   if (!img) {
     return 0;
   }
 
   std::unique_ptr<TSK_VS_INFO, decltype(&tsk_vs_close)> vs{
-    tsk_vs_open(img.get(), 0, VSTYPE);
+    tsk_vs_open((TSK_IMG_INFO *)img, 0, VSTYPE),
     tsk_vs_close
   };
 
   if (vs) {
-    tsk_vs_part_walk(vs, 0, vs->part_count - 1, TSK_VS_PART_FLAG_ALL, part_act,
+    tsk_vs_part_walk(vs.get(), 0, vs->part_count - 1, TSK_VS_PART_FLAG_ALL, part_act,
                      nullptr);
   }
-
+  tsk_img_close((TSK_IMG_INFO*)img);
   return 0;
 }


### PR DESCRIPTION
The changes from https://github.com/sleuthkit/sleuthkit/pull/3178 broke the fuzzing build, and this fixes it. 

See here for a full recent build log: https://oss-fuzz-build-logs.storage.googleapis.com/log-7a701235-2e5f-4b3d-8374-19d13c497756.txt

Snippet from the build log:

```
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                                               ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:27:76: [0m[0;1;35mwarning: [0m[1munused parameter 'part' [-Wunused-parameter][0m
Step #3 - "compile-afl-address-x86_64":    27 | static TSK_WALK_RET_ENUM part_act(TSK_VS_INFO *vs, const TSK_VS_PART_INFO *part,[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                                                                           ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:28:41: [0m[0;1;35mwarning: [0m[1munused parameter 'ptr' [-Wunused-parameter][0m
Step #3 - "compile-afl-address-x86_64":    28 |                                   void *ptr) {[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                                        ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:34:25: [0m[0;1;31merror: [0m[1mexpected '}'[0m
Step #3 - "compile-afl-address-x86_64":    34 |     mem_open(data, size);[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                        ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:33:62: [0m[0;1;36mnote: [0mto match this '{'[0m
Step #3 - "compile-afl-address-x86_64":    33 |   std::unique_ptr<TSK_IMG_INFO, decltype(&tsk_img_close)> img{[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                                                             ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:35:18: [0m[0;1;31merror: [0m[1mexpected ';' after expression[0m
Step #3 - "compile-afl-address-x86_64":    35 |     tsk_img_close[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                 ^
Step #3 - "compile-afl-address-x86_64": [0m      | [0;32m                 ;
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:35:5: [0m[0;1;35mwarning: [0m[1mexpression result unused [-Wunused-value][0m
Step #3 - "compile-afl-address-x86_64":    35 |     tsk_img_close[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m    ^~~~~~~~~~~~~
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:38:3: [0m[0;1;31merror: [0m[1mexpected unqualified-id[0m
Step #3 - "compile-afl-address-x86_64":    38 |   if (!img) {[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m  ^
Step #3 - "compile-afl-address-x86_64": [0mmake: *** [Makefile:3892: ossfuzz/mmls_gpt_fuzzer-mmls_fuzzer.o] Error 1
Step #3 - "compile-afl-address-x86_64": [1mossfuzz/mmls_fuzzer.cc:43:17: [0m[0;1;31merror: [0m[1muse of undeclared identifier 'img'[0m
Step #3 - "compile-afl-address-x86_64":    43 |     tsk_vs_open(img.get(), 0, VSTYPE);[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m                ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:47:3: [0m[0;1;31merror: [0m[1mexpected unqualified-id[0m
Step #3 - "compile-afl-address-x86_64":    47 |   if (vs) {[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m  ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:52:3: [0m[0;1;31merror: [0m[1mexpected unqualified-id[0m
Step #3 - "compile-afl-address-x86_64":    52 |   return 0;[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m  ^
Step #3 - "compile-afl-address-x86_64": [0m[1mossfuzz/mmls_fuzzer.cc:53:1: [0m[0;1;31merror: [0m[1mextraneous closing brace ('}')[0m
Step #3 - "compile-afl-address-x86_64":    53 | }[0m
Step #3 - "compile-afl-address-x86_64":       | [0;1;32m^
Step #3 - "compile-afl-address-x86_64": [0m4 warnings and 11 errors generated.
```