### PR TITLE
Comment out reference to internal `__tzinfo` symbol and fix AppVeyor redundancy 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 version: 4.6.0.{build}
 
+# Run on all pull requests to any branch
+# Skip branch builds when there are PRs to prevent duplicates
+skip_branch_with_pr: true
+
 environment:
   matrix:
   - job_name: Windows Build
@@ -10,7 +14,6 @@ environment:
     appveyor_build_worker_image: macos-sonoma
 
 matrix:
-
   fast_finish: true
 
 

--- a/tsk/fs/fs_name.cpp
+++ b/tsk/fs/fs_name.cpp
@@ -27,9 +27,10 @@
 
 #include <time.h>
 
-#ifndef TZNAME
-#define TZNAME __tzname
-#endif
+// 2025-07-01 - commented out; do not use an internal structure
+// #ifndef TZNAME
+// #define TZNAME __tzname
+// #endif
 
 char tsk_fs_name_type_str[TSK_FS_NAME_TYPE_STR_MAX][2] =
     { "-", "p", "c", "d", "b", "r",


### PR DESCRIPTION
1. `tsk/fs/fs_name.cpp` should not be referencing the internal symbol `__tzinfo`.
2. Update AppVeyor to only run once on PRs, not twice.