### PR TITLE
AppVeyor Test Data Directory Fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 version: 4.6.0.{build}
 
+# Run on all pull requests to any branch
+# Skip branch builds when there are PRs to prevent duplicates
+skip_branch_with_pr: true
+
 environment:
   matrix:
   - job_name: Windows Build
@@ -10,7 +14,6 @@ environment:
     appveyor_build_worker_image: macos-sonoma
 
 matrix:
-
   fast_finish: true
 
 
@@ -90,4 +93,4 @@ for:
       - cd ..
 
     test_script:
-      - SLEUTHKIT_TEST_DATA=$(pwd)/sleuthkit_test_data V=0 make -j check VERBOSE=1
+      - SLEUTHKIT_TEST_DATA_DIR=$(pwd)/sleuthkit_test_data V=0 make -j check VERBOSE=1


### PR DESCRIPTION
Ensures make unpack is run after unzipping test data and sets `SLEUTHKIT_TEST_DATA_DIR` before running `make check`. Fixes missing test input issues in CI.