### PR TITLE
Added Unicode Tests including OOB Buffer Tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -756,6 +756,7 @@ test_catch_runner_LDADD = $(TSK_LIBS)
 test_catch_runner_SOURCES = \
 	test/tsk/img/test_img.h \
 	test/tsk/base/test_tsk_error.cpp \
+	test/tsk/base/test_tsk_unicode.cpp \
 	test/tsk/img/test_aff4.cpp \
 	test/tsk/img/test_ewf.cpp \
 	test/tsk/img/test_img_io.cpp \

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -139,7 +139,6 @@ TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lcl
 }
 
 #ifndef __MINGW32__
-#warning Skipping wchar_t UTF-16W test on MinGW due to platform-specific behavior
 TEST_CASE("UTF-16W to UTF-8 local order: emoji surrogate", "[utf16to8][wchar]") {
     const wchar_t input[] = { 0xD83D, 0xDE80 };  // 🚀 = \U0001F680
     const wchar_t *src = input;

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -1,0 +1,153 @@
+/*
+ * test_tsk_unicode.cpp
+ * Author: Taha Ebrahim @Taha-Ebrahim
+ * Unit Tests for tsk/base/tsk_unicode.c
+ */
+#include "tsk/tsk_config.h"
+#include "tsk/libtsk.h"
+#include "tsk/base/tsk_base_i.h"
+#include "tsk/base/tsk_unicode.h"
+
+
+#include <cstring>
+
+#include "catch.hpp"
+
+TEST_CASE("UTF-8 to UTF-16 happy path", "[utf8to16]") {
+    const UTF8 *src = (const UTF8 *)"hello €世界";
+    const UTF8 *src_end = src + strlen((const char *)src);
+
+    UTF16 output[64];
+    UTF16 *out_start = output;
+    UTF16 *out_end = output + 64;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKconversionOK);
+}
+
+TEST_CASE("UTF-16 to UTF-8 happy path", "[utf16to8]") {
+    UTF16 input[] = { 'h', 'e', 'l', 'l', 'o', 0x20AC, 0x4E16, 0x754C };
+    const UTF16 *src = input;
+    const UTF16 *src_end = input + sizeof(input) / sizeof(input[0]);
+
+    UTF8 output[64];
+    UTF8 *out_start = output;
+    UTF8 *out_end = output + 64;
+
+    TSKConversionResult res = tsk_UTF16toUTF8(TSK_LIT_ENDIAN, &src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKconversionOK);
+}
+
+TEST_CASE("UTF-16 to UTF-8 fails when buffer is 1 byte short", "[utf16to8][shortbuffer]") {
+    UTF16 input[] = { 'A', 0x20AC };
+    const UTF16 *src = input;
+    const UTF16 *src_end = input + 2;
+
+    UTF8 output[3]; // only enough for 'A' + partial €
+    UTF8 *out_start = output;
+    UTF8 *out_end = output + 3;
+
+    TSKConversionResult res = tsk_UTF16toUTF8(TSK_LIT_ENDIAN, &src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKtargetExhausted);
+}
+
+TEST_CASE("UTF-16 surrogate pair is correctly converted to UTF-8", "[utf16to8][surrogate]") {
+    UTF16 surrogate_pair[] = { 0xD852, 0xDF62 }; // 🚀 = U+1F680
+
+    const UTF16* src = surrogate_pair;
+    const UTF16* src_end = surrogate_pair + 2;
+
+    UTF8 output[5] = {}; // 4 bytes + null terminator (optional for testing convenience)
+    UTF8* tgt = output;
+    UTF8* tgt_end = output + 4;
+
+    TSKConversionResult res = tsk_UTF16toUTF8(
+        TSK_LIT_ENDIAN,
+        &src,
+        src_end,
+        &tgt,
+        tgt_end,
+        TSKlenientConversion 
+    );
+
+    REQUIRE(res == TSKconversionOK);
+}
+
+TEST_CASE("UTF-16 surrogate pair fails with 1-3 byte output buffers", "[utf16to8][surrogate][targetExhausted]") {
+    UTF16 surrogate_pair[] = { 0xD852, 0xDF62 }; // 𤭢 (U+24B62), valid surrogate pair
+
+    for (int buffer_size = 1; buffer_size <= 3; ++buffer_size) {
+        INFO("Testing with output buffer of " << buffer_size << " bytes");
+
+        const UTF16* src = surrogate_pair;
+        const UTF16* src_end = surrogate_pair + 2;
+
+        UTF8 output[4] = {};  // Large enough array, but we simulate smaller buffers
+        UTF8* tgt = output;
+        UTF8* tgt_end = output + buffer_size;
+
+        TSKConversionResult res = tsk_UTF16toUTF8(
+            TSK_LIT_ENDIAN,
+            &src,
+            src_end,
+            &tgt,
+            tgt_end,
+            TSKlenientConversion
+        );
+
+        REQUIRE(res == TSKtargetExhausted);
+    }
+}
+
+TEST_CASE("UTF-8 to UTF-16 detects malformed sequence", "[utf8to16][malformed]") {
+    UTF8 input[] = { 0xC0, 0xAF };  // overlong encoding
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + sizeof(input);
+
+    UTF16 output[4];
+    UTF16 *out_start = output;
+    UTF16 *out_end = output + 4;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceIllegal);
+}
+
+TEST_CASE("UTF-16 to UTF-8 fails on unpaired high surrogate", "[utf16to8][unpaired]") {
+    UTF16 input[] = { 0xD83D };  // unpaired high surrogate
+    const UTF16 *src = input;
+    const UTF16 *src_end = input + 1;
+
+    UTF8 output[8];
+    UTF8 *out_start = output;
+    UTF8 *out_end = output + 8;
+
+    TSKConversionResult res = tsk_UTF16toUTF8(TSK_LIT_ENDIAN, &src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceExhausted);
+}
+
+TEST_CASE("UTF-16 to UTF-8 fails on unpaired low surrogate", "[utf16to8][unpaired]") {
+    UTF16 input[] = { 0xDC00 };  // unpaired low surrogate
+    const UTF16 *src = input;
+    const UTF16 *src_end = input + 1;
+
+    UTF8 output[8];
+    UTF8 *out_start = output;
+    UTF8 *out_end = output + 8;
+
+    TSKConversionResult res = tsk_UTF16toUTF8(TSK_LIT_ENDIAN, &src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceIllegal);
+}
+
+TEST_CASE("UTF-8 to UTF-16 fails when target buffer is too small", "[utf8to16][targetExhausted]") {
+    const UTF8 *src = (const UTF8 *)"€";  // U+20AC, needs 1 UTF-16 unit
+    const UTF8 *src_end = src + strlen((const char *)src);
+
+    UTF16 output[0];  // no room at all
+    UTF16 *out_start = output;
+    UTF16 *out_end = output;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKtargetExhausted);
+}
+
+

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -125,29 +125,57 @@ TEST_CASE("UTF-16 to UTF-8 fails on unpaired high surrogate", "[utf16to8][unpair
     REQUIRE(res == TSKsourceExhausted);
 }
 
-TEST_CASE("UTF-16 to UTF-8 fails on unpaired low surrogate", "[utf16to8][unpaired]") {
-    UTF16 input[] = { 0xDC00 };  // unpaired low surrogate
+TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lclorder]") {
+    UTF16 input[] = { 'T', 'e', 's', 't', 0x20AC };  // "Test€"
     const UTF16 *src = input;
-    const UTF16 *src_end = input + 1;
+    const UTF16 *src_end = input + 5;
+
+    UTF8 output[16];
+    UTF8 *tgt = output;
+    UTF8 *tgt_end = output + 16;
+
+    TSKConversionResult res = tsk_UTF16toUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKconversionOK);
+}
+
+TEST_CASE("UTF-16W to UTF-8 local order: emoji surrogate", "[utf16to8][wchar]") {
+    const wchar_t input[] = { 0xD83D, 0xDE80 };  // 🚀 = \U0001F680
+    const wchar_t *src = input;
+    const wchar_t *src_end = input + 2;
 
     UTF8 output[8];
-    UTF8 *out_start = output;
-    UTF8 *out_end = output + 8;
+    UTF8 *tgt = output;
+    UTF8 *tgt_end = output + 8;
 
-    TSKConversionResult res = tsk_UTF16toUTF8(TSK_LIT_ENDIAN, &src, src_end, &out_start, out_end, TSKstrictConversion);
-    REQUIRE(res == TSKsourceIllegal);
+    TSKConversionResult res = tsk_UTF16WtoUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKconversionOK);
 }
 
-TEST_CASE("UTF-8 to UTF-16 fails when target buffer is too small", "[utf8to16][targetExhausted]") {
-    const UTF8 *src = (const UTF8 *)"€";  // U+20AC, needs 1 UTF-16 unit
-    const UTF8 *src_end = src + strlen((const char *)src);
-
-    UTF16 output[0];  // no room at all
-    UTF16 *out_start = output;
-    UTF16 *out_end = output;
-
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
-    REQUIRE(res == TSKtargetExhausted);
+TEST_CASE("tsk_cleanupUTF8 replaces invalid UTF-8 with replacement char", "[cleanup][utf8]") {
+    char input[] = { (char)0xC0, (char)0xAF, 'X', '\0' }; // overlong encoding of '/'
+    tsk_cleanupUTF8(input, '?');
+    REQUIRE(input[0] == '?');
+    REQUIRE(input[1] == '?');
+    REQUIRE(input[2] == 'X');
 }
+
+TEST_CASE("tsk_cleanupUTF16 replaces unpaired surrogate with replacement", "[cleanup][utf16]") {
+    wchar_t input[] = { 0xD800, 0x0041 }; // unpaired high surrogate + 'A'
+    tsk_cleanupUTF16(TSK_LIT_ENDIAN, input, 2, L'?');
+    REQUIRE(input[0] == L'?');
+    REQUIRE(input[1] == L'A');
+}
+
+TEST_CASE("tsk_isLegalUTF8Sequence detects legal and illegal UTF-8", "[validation][utf8]") {
+    UTF8 valid[] = { 0xE2, 0x82, 0xAC }; // €
+    UTF8 *valid_end = valid + 3;
+
+    UTF8 invalid[] = { 0xC0, 0xAF }; // overlong '/'
+    UTF8 *invalid_end = invalid + 2;
+
+    REQUIRE(tsk_isLegalUTF8Sequence(valid, valid_end) == true);
+    REQUIRE(tsk_isLegalUTF8Sequence(invalid, invalid_end) == false);
+}
+
 
 

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -9,7 +9,6 @@
 #include "tsk/base/tsk_unicode.h"
 #include "tsk/fs/tsk_fs_i.h"
 #include "tsk/fs/tsk_ntfs.h"
-#include "tsk/fs/fs_name.cpp"
 
 #include <iostream>
 #include <cstring>

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -53,6 +53,19 @@ TEST_CASE("UTF-16 to UTF-8 fails when buffer is 1 byte short", "[utf16to8][short
     REQUIRE(res == TSKtargetExhausted);
 }
 
+TEST_CASE("UTF-8 to UTF-16: incomplete multibyte sequence (sourceExhausted)", "[utf8to16][exhausted]") {
+    UTF8 input[] = { 0xE2, 0x82 }; // partial €
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + sizeof(input);
+
+    UTF16 output[4];
+    UTF16 *tgt = output;
+    UTF16 *tgt_end = output + 4;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceExhausted);
+}
+
 TEST_CASE("UTF-16 surrogate pair is correctly converted to UTF-8", "[utf16to8][surrogate]") {
     // The correct UTF-16 surrogate pair for U+1F60E is D83D DE0E.
     // We'll create the UTF-16 values directly.
@@ -85,6 +98,85 @@ TEST_CASE("UTF-16 surrogate pair is correctly converted to UTF-8", "[utf16to8][s
     REQUIRE(output[3] == 0x8E);
 }
 
+TEST_CASE("UTF-16 surrogate pair fails with 1-3 byte output buffers", "[utf16to8][surrogate][targetExhausted]") {
+    UTF16 surrogate_pair[] = { 0xD852, 0xDF62 }; // 𤭢 (U+24B62)
+
+    for (int buffer_size = 1; buffer_size <= 3; ++buffer_size) {
+        INFO("Testing with output buffer of " << buffer_size << " bytes");
+
+        const UTF16* src = surrogate_pair;
+        const UTF16* src_end = surrogate_pair + 2;
+
+        UTF8 output[4] = {};
+        UTF8* tgt = output;
+        UTF8* tgt_end = output + buffer_size;
+
+        TSKConversionResult res = tsk_UTF16toUTF8(
+            TSK_LIT_ENDIAN, &src, src_end, &tgt, tgt_end, TSKlenientConversion);
+
+        REQUIRE(res == TSKtargetExhausted);
+    }
+}
+
+TEST_CASE("UTF-16 to UTF-8 decoding with boundary fuzzing", "[utf16to8][fuzz][surrogates]") {
+    UTF16 full_input[] = {0x0041, 0x00E9, 0x6C34, 0xD83D, 0xDE80, 0xD83C, 0xDF0D};
+    const UTF16* full_end = full_input + sizeof(full_input) / sizeof(UTF16);
+
+    for (int in_len = 0; in_len <= (full_end - full_input); ++in_len) {
+        UTF16* input = new UTF16[in_len];
+        std::memcpy(input, full_input, in_len * sizeof(UTF16));
+        const UTF16* src = input;
+        const UTF16* src_end = input + in_len;
+
+        int max_utf8_len = 4 * in_len;
+
+        for (int out_len = std::max(0, max_utf8_len - 2); out_len <= max_utf8_len + 2; ++out_len) {
+            UTF8* output = new UTF8[out_len];
+            UTF8* tgt = output;
+            UTF8* tgt_end = output + out_len;
+
+            TSKConversionResult res = tsk_UTF16toUTF8(
+                TSK_LIT_ENDIAN, &src, src_end, &tgt, tgt_end, TSKstrictConversion);
+
+            if (res != TSKconversionOK && res != TSKtargetExhausted &&
+                res != TSKsourceIllegal && res != TSKsourceExhausted) {
+                FAIL("Unexpected conversion result: " << res);
+            }
+            delete[] output;
+        }
+        delete[] input;
+    }
+}
+
+TEST_CASE("UTF-8 to UTF-16 decoding with boundary fuzzing", "[utf8to16][fuzz]") {
+    const UTF8 full_input[] = {0x41, 0xC3, 0xA9, 0xE6, 0xB0, 0xB4, 0xF0, 0x9F, 0x9A, 0x80, 0xF0, 0x9F, 0x8C, 0x8D};
+    const size_t input_len = sizeof(full_input);
+
+    for (size_t in_len = 0; in_len <= input_len; ++in_len) {
+        UTF8* input = new UTF8[in_len];
+        std::memcpy(input, full_input, in_len);
+        const UTF8* src = input;
+        const UTF8* src_end = input + in_len;
+
+        int max_utf16_len = 2 * in_len;
+
+        for (int out_len = std::max(0, max_utf16_len - 2); out_len <= max_utf16_len + 2; ++out_len) {
+            UTF16* output = new UTF16[out_len];
+            UTF16* tgt = output;
+            UTF16* tgt_end = output + out_len;
+
+            TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+            if (res != TSKconversionOK && res != TSKtargetExhausted &&
+                res != TSKsourceIllegal && res != TSKsourceExhausted) {
+                FAIL("Unexpected conversion result: " << res);
+            }
+            delete[] output;
+        }
+        delete[] input;
+    }
+}
+
+
 TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lclorder]") {
     UTF16 input[] = { 'T', 'e', 's', 't', 0x20AC };  // "Test€"
     const UTF16 *src = input;
@@ -97,6 +189,21 @@ TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lcl
     TSKConversionResult res = tsk_UTF16toUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
     REQUIRE(res == TSKconversionOK);
 }
+
+#ifndef __MINGW32__
+TEST_CASE("UTF-16W to UTF-8 local order: emoji surrogate", "[utf16to8][wchar]") {
+    const wchar_t input[] = { 0xD83D, 0xDE80 };  // 🚀 = \U0001F680
+    const wchar_t *src = input;
+    const wchar_t *src_end = input + 2;
+
+    UTF8 output[8];
+    UTF8 *tgt = output;
+    UTF8 *tgt_end = output + 8;
+
+    TSKConversionResult res = tsk_UTF16WtoUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKconversionOK);
+}
+#endif
 
 TEST_CASE("tsk_cleanupUTF8 replaces invalid UTF-8 with replacement char", "[cleanup][utf8]") {
     char input[] = { (char)0xC0, (char)0xAF, 'X', '\0' }; // overlong encoding of '/'
@@ -122,19 +229,6 @@ TEST_CASE("tsk_isLegalUTF8Sequence detects legal and illegal UTF-8", "[validatio
 
     REQUIRE(tsk_isLegalUTF8Sequence(valid, valid_end) == true);
     REQUIRE(tsk_isLegalUTF8Sequence(invalid, invalid_end) == false);
-}
-
-TEST_CASE("UTF-8 to UTF-16: incomplete multibyte sequence (sourceExhausted)", "[utf8to16][exhausted]") {
-    UTF8 input[] = { 0xE2, 0x82 }; // partial €
-    const UTF8 *src = input;
-    const UTF8 *src_end = input + sizeof(input);
-
-    UTF16 output[4];
-    UTF16 *tgt = output;
-    UTF16 *tgt_end = output + 4;
-
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
-    REQUIRE(res == TSKsourceExhausted);
 }
 
 TEST_CASE("UTF-8 to UTF-16: decode character > 0x10FFFF should fail in strict mode", "[utf8to16][invalid]") {

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -138,6 +138,8 @@ TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lcl
     REQUIRE(res == TSKconversionOK);
 }
 
+#ifndef __MINGW32__
+#warning Skipping wchar_t UTF-16W test on MinGW due to platform-specific behavior
 TEST_CASE("UTF-16W to UTF-8 local order: emoji surrogate", "[utf16to8][wchar]") {
     const wchar_t input[] = { 0xD83D, 0xDE80 };  // 🚀 = \U0001F680
     const wchar_t *src = input;
@@ -150,6 +152,7 @@ TEST_CASE("UTF-16W to UTF-8 local order: emoji surrogate", "[utf16to8][wchar]") 
     TSKConversionResult res = tsk_UTF16WtoUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
     REQUIRE(res == TSKconversionOK);
 }
+#endif
 
 TEST_CASE("tsk_cleanupUTF8 replaces invalid UTF-8 with replacement char", "[cleanup][utf8]") {
     char input[] = { (char)0xC0, (char)0xAF, 'X', '\0' }; // overlong encoding of '/'
@@ -177,5 +180,83 @@ TEST_CASE("tsk_isLegalUTF8Sequence detects legal and illegal UTF-8", "[validatio
     REQUIRE(tsk_isLegalUTF8Sequence(invalid, invalid_end) == false);
 }
 
+TEST_CASE("UTF-8 to UTF-16: incomplete multibyte sequence (sourceExhausted)", "[utf8to16][exhausted]") {
+    UTF8 input[] = { 0xE2, 0x82 }; // partial €
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + sizeof(input);
 
+    UTF16 output[4];
+    UTF16 *tgt = output;
+    UTF16 *tgt_end = output + 4;
 
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceExhausted);
+}
+
+TEST_CASE("UTF-8 to UTF-16: decode character > 0x10FFFF should fail in strict mode", "[utf8to16][invalid]") {
+    UTF8 input[] = { 0xF4, 0x90, 0x80, 0x80 }; // > U+10FFFF
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + 4;
+
+    UTF16 output[4];
+    UTF16 *tgt = output;
+    UTF16 *tgt_end = output + 4;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceIllegal);
+}
+
+TEST_CASE("UTF-8 to UTF-16: target buffer exhausted while writing surrogate pair", "[utf8to16][targetExhausted]") {
+    UTF8 input[] = { 0xF0, 0x9F, 0x9A, 0x80 }; // 🚀
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + 4;
+
+    UTF16 output[1]; // not enough space for surrogate pair
+    UTF16 *tgt = output;
+    UTF16 *tgt_end = output + 1;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKtargetExhausted);
+}
+
+TEST_CASE("UTF-8 to UTF-16: illegal continuation byte", "[utf8to16][illegal]") {
+    UTF8 input[] = { 0xE2, 0x28, 0xA1 }; // invalid second byte
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + sizeof(input);
+
+    UTF16 output[4];
+    UTF16 *tgt = output;
+    UTF16 *tgt_end = output + 4;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKsourceIllegal);
+}
+
+TEST_CASE("UTF-8 to UTF-16: valid 4-byte input into surrogate pair", "[utf8to16][surrogate]") {
+    UTF8 input[] = { 0xF0, 0x9F, 0x92, 0x96 }; // 💖 = U+1F496
+    const UTF8 *src = input;
+    const UTF8 *src_end = input + sizeof(input);
+
+    UTF16 output[4];
+    UTF16 *tgt = output;
+    UTF16 *tgt_end = output + 4;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
+    REQUIRE(res == TSKconversionOK);
+    REQUIRE(output[0] >= 0xD800);
+    REQUIRE(output[0] <= 0xDBFF); // high surrogate
+    REQUIRE(output[1] >= 0xDC00);
+    REQUIRE(output[1] <= 0xDFFF); // low surrogate
+}
+
+TEST_CASE("UTF-8 to UTF-16 fails due to short target buffer", "[utf8to16][targetExhausted]") {
+    const UTF8 *src = (const UTF8 *)"\xF0\x9F\x9A\x80"; // 🚀 = U+1F680
+    const UTF8 *src_end = src + 4;
+
+    UTF16 output[1]; // only 1 space, but 2 needed for surrogate pair
+    UTF16 *out_start = output;
+    UTF16 *out_end = output + 1;
+
+    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
+    REQUIRE(res == TSKtargetExhausted);
+}

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -8,7 +8,7 @@
 #include "tsk/base/tsk_base_i.h"
 #include "tsk/base/tsk_unicode.h"
 
-
+#include <iostream>
 #include <cstring>
 
 #include "catch.hpp"
@@ -99,30 +99,108 @@ TEST_CASE("UTF-16 surrogate pair fails with 1-3 byte output buffers", "[utf16to8
     }
 }
 
-TEST_CASE("UTF-8 to UTF-16 detects malformed sequence", "[utf8to16][malformed]") {
-    UTF8 input[] = { 0xC0, 0xAF };  // overlong encoding
-    const UTF8 *src = input;
-    const UTF8 *src_end = input + sizeof(input);
+TEST_CASE("UTF-16 to UTF-8 decoding with boundary fuzzing", "[utf16to8][fuzz][surrogates]") {
+    UTF16 full_input[] = {
+        0x0041,               // 'A' (1-byte UTF-8)
+        0x00E9,               // 'é' (2-byte UTF-8)
+        0x6C34,               // '水' (3-byte UTF-8)
+        0xD83D, 0xDE80,       // 🚀 (4-byte UTF-8 surrogate pair)
+        0xD83C, 0xDF0D        // 🌍 (4-byte UTF-8 surrogate pair)
+    };
 
-    UTF16 output[4];
-    UTF16 *out_start = output;
-    UTF16 *out_end = output + 4;
+    const UTF16* full_end = full_input + sizeof(full_input) / sizeof(UTF16);
 
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
-    REQUIRE(res == TSKsourceIllegal);
+    for (int in_len = 0; in_len <= (full_end - full_input); ++in_len) {
+        UTF16* input = new UTF16[in_len];
+        std::memcpy(input, full_input, in_len * sizeof(UTF16));
+        const UTF16* src = input;
+        const UTF16* src_end = input + in_len;
+
+        // Estimate worst-case output size (4 bytes per UTF-16 code unit)
+        int max_utf8_len = 4 * in_len;
+
+        for (int out_len = std::max(0, max_utf8_len - 2); out_len <= max_utf8_len + 2; ++out_len) {
+            UTF8* output = new UTF8[out_len];
+            UTF8* tgt = output;
+            UTF8* tgt_end = output + out_len;
+
+            TSKConversionResult res = tsk_UTF16toUTF8(
+                TSK_LIT_ENDIAN,
+                &src,
+                src_end,
+                &tgt,
+                tgt_end,
+                TSKstrictConversion
+            );
+
+            if (res != TSKconversionOK &&
+                res != TSKtargetExhausted &&
+                res != TSKsourceIllegal &&
+                res != TSKsourceExhausted)
+            {
+                FAIL("Unexpected conversion result: " << res
+                    << " (in_len=" << in_len
+                    << ", out_len=" << out_len << ")");
+            }
+
+            delete[] output;
+        }
+
+        delete[] input;
+    }
 }
 
-TEST_CASE("UTF-16 to UTF-8 fails on unpaired high surrogate", "[utf16to8][unpaired]") {
-    UTF16 input[] = { 0xD83D };  // unpaired high surrogate
-    const UTF16 *src = input;
-    const UTF16 *src_end = input + 1;
+TEST_CASE("UTF-8 to UTF-16 decoding with boundary fuzzing", "[utf8to16][fuzz]") {
+    // UTF-8 string: "Aé水🚀🌍"
+    const UTF8 full_input[] = {
+        0x41,                         // 'A' (1 byte)
+        0xC3, 0xA9,                   // 'é' (2 bytes)
+        0xE6, 0xB0, 0xB4,             // '水' (3 bytes)
+        0xF0, 0x9F, 0x9A, 0x80,       // 🚀 (4 bytes)
+        0xF0, 0x9F, 0x8C, 0x8D        // 🌍 (4 bytes)
+    };
+    const size_t input_len = sizeof(full_input);
+    
+    for (size_t in_len = 0; in_len <= input_len; ++in_len) {
+        UTF8* input = new UTF8[in_len];
+        std::memcpy(input, full_input, in_len);
+        const UTF8* src = input;
+        const UTF8* src_end = input + in_len;
 
-    UTF8 output[8];
-    UTF8 *out_start = output;
-    UTF8 *out_end = output + 8;
+        // Estimate max number of UTF-16 code units (max 2 per character)
+        int max_utf16_len = 2 * in_len;
 
-    TSKConversionResult res = tsk_UTF16toUTF8(TSK_LIT_ENDIAN, &src, src_end, &out_start, out_end, TSKstrictConversion);
-    REQUIRE(res == TSKsourceExhausted);
+        for (int out_len = std::max(0, max_utf16_len - 2); out_len <= max_utf16_len + 2; ++out_len) {
+            UTF16* output = new UTF16[out_len];
+            UTF16* tgt = output;
+            UTF16* tgt_end = output + out_len;
+
+            TSKConversionResult res = tsk_UTF8toUTF16(
+                &src,
+                src_end,
+                &tgt,
+                tgt_end,
+                TSKstrictConversion
+            );
+
+            std::cout << "Input: " << in_len << ", Output: " << out_len << ", Result: " << res << '\n';
+
+
+            if (res != TSKconversionOK &&
+                res != TSKtargetExhausted &&
+                res != TSKsourceIllegal &&
+                res != TSKsourceExhausted)
+            {
+                FAIL("Unexpected conversion result: " << res
+                    << " (in_len=" << in_len
+                    << ", out_len=" << out_len << ")");
+            }
+
+            delete[] output;
+        }
+
+        delete[] input;
+    }
 }
 
 TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lclorder]") {
@@ -203,59 +281,4 @@ TEST_CASE("UTF-8 to UTF-16: decode character > 0x10FFFF should fail in strict mo
 
     TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
     REQUIRE(res == TSKsourceIllegal);
-}
-
-TEST_CASE("UTF-8 to UTF-16: target buffer exhausted while writing surrogate pair", "[utf8to16][targetExhausted]") {
-    UTF8 input[] = { 0xF0, 0x9F, 0x9A, 0x80 }; // 🚀
-    const UTF8 *src = input;
-    const UTF8 *src_end = input + 4;
-
-    UTF16 output[1]; // not enough space for surrogate pair
-    UTF16 *tgt = output;
-    UTF16 *tgt_end = output + 1;
-
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
-    REQUIRE(res == TSKtargetExhausted);
-}
-
-TEST_CASE("UTF-8 to UTF-16: illegal continuation byte", "[utf8to16][illegal]") {
-    UTF8 input[] = { 0xE2, 0x28, 0xA1 }; // invalid second byte
-    const UTF8 *src = input;
-    const UTF8 *src_end = input + sizeof(input);
-
-    UTF16 output[4];
-    UTF16 *tgt = output;
-    UTF16 *tgt_end = output + 4;
-
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
-    REQUIRE(res == TSKsourceIllegal);
-}
-
-TEST_CASE("UTF-8 to UTF-16: valid 4-byte input into surrogate pair", "[utf8to16][surrogate]") {
-    UTF8 input[] = { 0xF0, 0x9F, 0x92, 0x96 }; // 💖 = U+1F496
-    const UTF8 *src = input;
-    const UTF8 *src_end = input + sizeof(input);
-
-    UTF16 output[4];
-    UTF16 *tgt = output;
-    UTF16 *tgt_end = output + 4;
-
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
-    REQUIRE(res == TSKconversionOK);
-    REQUIRE(output[0] >= 0xD800);
-    REQUIRE(output[0] <= 0xDBFF); // high surrogate
-    REQUIRE(output[1] >= 0xDC00);
-    REQUIRE(output[1] <= 0xDFFF); // low surrogate
-}
-
-TEST_CASE("UTF-8 to UTF-16 fails due to short target buffer", "[utf8to16][targetExhausted]") {
-    const UTF8 *src = (const UTF8 *)"\xF0\x9F\x9A\x80"; // 🚀 = U+1F680
-    const UTF8 *src_end = src + 4;
-
-    UTF16 output[1]; // only 1 space, but 2 needed for surrogate pair
-    UTF16 *out_start = output;
-    UTF16 *out_end = output + 1;
-
-    TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &out_start, out_end, TSKstrictConversion);
-    REQUIRE(res == TSKtargetExhausted);
 }

--- a/test/tsk/base/test_tsk_unicode.cpp
+++ b/test/tsk/base/test_tsk_unicode.cpp
@@ -7,6 +7,9 @@
 #include "tsk/libtsk.h"
 #include "tsk/base/tsk_base_i.h"
 #include "tsk/base/tsk_unicode.h"
+#include "tsk/fs/tsk_fs_i.h"
+#include "tsk/fs/tsk_ntfs.h"
+#include "tsk/fs/fs_name.cpp"
 
 #include <iostream>
 #include <cstring>
@@ -52,12 +55,15 @@ TEST_CASE("UTF-16 to UTF-8 fails when buffer is 1 byte short", "[utf16to8][short
 }
 
 TEST_CASE("UTF-16 surrogate pair is correctly converted to UTF-8", "[utf16to8][surrogate]") {
-    UTF16 surrogate_pair[] = { 0xD852, 0xDF62 }; // 🚀 = U+1F680
+    // The correct UTF-16 surrogate pair for U+1F60E is D83D DE0E.
+    // We'll create the UTF-16 values directly.
+    UTF16 surrogate_pair[] = { 0xD83D, 0xDE0E };
 
     const UTF16* src = surrogate_pair;
     const UTF16* src_end = surrogate_pair + 2;
 
-    UTF8 output[5] = {}; // 4 bytes + null terminator (optional for testing convenience)
+    // The UTF-8 representation of U+1F60E is F0 9F 98 8E.
+    UTF8 output[5] = {0};
     UTF8* tgt = output;
     UTF8* tgt_end = output + 4;
 
@@ -67,140 +73,17 @@ TEST_CASE("UTF-16 surrogate pair is correctly converted to UTF-8", "[utf16to8][s
         src_end,
         &tgt,
         tgt_end,
-        TSKlenientConversion 
+        TSKlenientConversion
     );
 
+    // Assert that the conversion was successful.
     REQUIRE(res == TSKconversionOK);
-}
-
-TEST_CASE("UTF-16 surrogate pair fails with 1-3 byte output buffers", "[utf16to8][surrogate][targetExhausted]") {
-    UTF16 surrogate_pair[] = { 0xD852, 0xDF62 }; // 𤭢 (U+24B62), valid surrogate pair
-
-    for (int buffer_size = 1; buffer_size <= 3; ++buffer_size) {
-        INFO("Testing with output buffer of " << buffer_size << " bytes");
-
-        const UTF16* src = surrogate_pair;
-        const UTF16* src_end = surrogate_pair + 2;
-
-        UTF8 output[4] = {};  // Large enough array, but we simulate smaller buffers
-        UTF8* tgt = output;
-        UTF8* tgt_end = output + buffer_size;
-
-        TSKConversionResult res = tsk_UTF16toUTF8(
-            TSK_LIT_ENDIAN,
-            &src,
-            src_end,
-            &tgt,
-            tgt_end,
-            TSKlenientConversion
-        );
-
-        REQUIRE(res == TSKtargetExhausted);
-    }
-}
-
-TEST_CASE("UTF-16 to UTF-8 decoding with boundary fuzzing", "[utf16to8][fuzz][surrogates]") {
-    UTF16 full_input[] = {
-        0x0041,               // 'A' (1-byte UTF-8)
-        0x00E9,               // 'é' (2-byte UTF-8)
-        0x6C34,               // '水' (3-byte UTF-8)
-        0xD83D, 0xDE80,       // 🚀 (4-byte UTF-8 surrogate pair)
-        0xD83C, 0xDF0D        // 🌍 (4-byte UTF-8 surrogate pair)
-    };
-
-    const UTF16* full_end = full_input + sizeof(full_input) / sizeof(UTF16);
-
-    for (int in_len = 0; in_len <= (full_end - full_input); ++in_len) {
-        UTF16* input = new UTF16[in_len];
-        std::memcpy(input, full_input, in_len * sizeof(UTF16));
-        const UTF16* src = input;
-        const UTF16* src_end = input + in_len;
-
-        // Estimate worst-case output size (4 bytes per UTF-16 code unit)
-        int max_utf8_len = 4 * in_len;
-
-        for (int out_len = std::max(0, max_utf8_len - 2); out_len <= max_utf8_len + 2; ++out_len) {
-            UTF8* output = new UTF8[out_len];
-            UTF8* tgt = output;
-            UTF8* tgt_end = output + out_len;
-
-            TSKConversionResult res = tsk_UTF16toUTF8(
-                TSK_LIT_ENDIAN,
-                &src,
-                src_end,
-                &tgt,
-                tgt_end,
-                TSKstrictConversion
-            );
-
-            if (res != TSKconversionOK &&
-                res != TSKtargetExhausted &&
-                res != TSKsourceIllegal &&
-                res != TSKsourceExhausted)
-            {
-                FAIL("Unexpected conversion result: " << res
-                    << " (in_len=" << in_len
-                    << ", out_len=" << out_len << ")");
-            }
-
-            delete[] output;
-        }
-
-        delete[] input;
-    }
-}
-
-TEST_CASE("UTF-8 to UTF-16 decoding with boundary fuzzing", "[utf8to16][fuzz]") {
-    // UTF-8 string: "Aé水🚀🌍"
-    const UTF8 full_input[] = {
-        0x41,                         // 'A' (1 byte)
-        0xC3, 0xA9,                   // 'é' (2 bytes)
-        0xE6, 0xB0, 0xB4,             // '水' (3 bytes)
-        0xF0, 0x9F, 0x9A, 0x80,       // 🚀 (4 bytes)
-        0xF0, 0x9F, 0x8C, 0x8D        // 🌍 (4 bytes)
-    };
-    const size_t input_len = sizeof(full_input);
     
-    for (size_t in_len = 0; in_len <= input_len; ++in_len) {
-        UTF8* input = new UTF8[in_len];
-        std::memcpy(input, full_input, in_len);
-        const UTF8* src = input;
-        const UTF8* src_end = input + in_len;
-
-        // Estimate max number of UTF-16 code units (max 2 per character)
-        int max_utf16_len = 2 * in_len;
-
-        for (int out_len = std::max(0, max_utf16_len - 2); out_len <= max_utf16_len + 2; ++out_len) {
-            UTF16* output = new UTF16[out_len];
-            UTF16* tgt = output;
-            UTF16* tgt_end = output + out_len;
-
-            TSKConversionResult res = tsk_UTF8toUTF16(
-                &src,
-                src_end,
-                &tgt,
-                tgt_end,
-                TSKstrictConversion
-            );
-
-            std::cout << "Input: " << in_len << ", Output: " << out_len << ", Result: " << res << '\n';
-
-
-            if (res != TSKconversionOK &&
-                res != TSKtargetExhausted &&
-                res != TSKsourceIllegal &&
-                res != TSKsourceExhausted)
-            {
-                FAIL("Unexpected conversion result: " << res
-                    << " (in_len=" << in_len
-                    << ", out_len=" << out_len << ")");
-            }
-
-            delete[] output;
-        }
-
-        delete[] input;
-    }
+    // Verify the output UTF-8 sequence.
+    REQUIRE(output[0] == 0xF0);
+    REQUIRE(output[1] == 0x9F);
+    REQUIRE(output[2] == 0x98);
+    REQUIRE(output[3] == 0x8E);
 }
 
 TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lclorder]") {
@@ -215,21 +98,6 @@ TEST_CASE("UTF-16 to UTF-8 local order: valid basic conversion", "[utf16to8][lcl
     TSKConversionResult res = tsk_UTF16toUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
     REQUIRE(res == TSKconversionOK);
 }
-
-#ifndef __MINGW32__
-TEST_CASE("UTF-16W to UTF-8 local order: emoji surrogate", "[utf16to8][wchar]") {
-    const wchar_t input[] = { 0xD83D, 0xDE80 };  // 🚀 = \U0001F680
-    const wchar_t *src = input;
-    const wchar_t *src_end = input + 2;
-
-    UTF8 output[8];
-    UTF8 *tgt = output;
-    UTF8 *tgt_end = output + 8;
-
-    TSKConversionResult res = tsk_UTF16WtoUTF8_lclorder(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
-    REQUIRE(res == TSKconversionOK);
-}
-#endif
 
 TEST_CASE("tsk_cleanupUTF8 replaces invalid UTF-8 with replacement char", "[cleanup][utf8]") {
     char input[] = { (char)0xC0, (char)0xAF, 'X', '\0' }; // overlong encoding of '/'
@@ -281,4 +149,38 @@ TEST_CASE("UTF-8 to UTF-16: decode character > 0x10FFFF should fail in strict mo
 
     TSKConversionResult res = tsk_UTF8toUTF16(&src, src_end, &tgt, tgt_end, TSKstrictConversion);
     REQUIRE(res == TSKsourceIllegal);
+}
+
+TEST_CASE("tsk_safeUTF16toUTF8 prevents out-of-bounds read", "[unicode][safe]") {
+    // 1. Set up a small, fixed-size source buffer.
+    // The buffer is 4 bytes and can hold 2 UTF-16 characters.
+    const size_t source_buffer_len = 4;
+    uint8_t source_buffer[source_buffer_len];
+    // Fill the buffer with valid UTF-16 characters: "AB"
+    source_buffer[0] = 'A'; source_buffer[1] = 0;
+    source_buffer[2] = 'B'; source_buffer[3] = 0;
+    
+    // 2. Set up the target buffer.
+    const size_t target_buffer_len = 10;
+    UTF8 target_buffer[target_buffer_len] = {0};
+    UTF8 *target_ptr = target_buffer;
+    UTF8 *target_end_ptr = target_buffer + target_buffer_len;
+
+    // 3. Deliberately provide a malformed number_of_characters.
+    // We claim there are 3 characters, but the buffer only holds 2.
+    const size_t malformed_num_chars = 3;
+
+    // 4. Call the fixed function with the malformed input.
+    // The function is expected to correct the input before any unsafe access occurs.
+    SECTION("Function call with malformed input") {
+        REQUIRE_NOTHROW(tsk_safeUTF16toUTF8(TSK_LIT_ENDIAN, source_buffer, source_buffer_len,
+                                            malformed_num_chars, &target_ptr, target_end_ptr,
+                                            TSKlenientConversion));
+
+        // 5. Verify the function's behavior.
+        // The function should return TSKconversionOK as it safely converted the available data.
+        REQUIRE(tsk_safeUTF16toUTF8(TSK_LIT_ENDIAN, source_buffer, source_buffer_len,
+                                    malformed_num_chars, &target_ptr, target_end_ptr,
+                                    TSKlenientConversion) == TSKconversionOK);
+    }
 }

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -166,7 +166,7 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-            if (source < sourceEnd) { /* we need two bytes */
+	    if ( ((const char *)(source))+1 < (const char *)(sourceEnd)) { /* we need two bytes */
                 // Need at least 2 bytes
                 UTF32 ch2 = tsk_getu16(endian, (uint8_t *) source);
                 ++source;

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -152,7 +152,7 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
     const UTF16 *source = *sourceStart;
     UTF8 *target = *targetStart;
 
-    while (source < sourceEnd) {
+    while ( (const char *)(source)+1 < (const char *)sourceEnd) { /* we need two bytes */
         UTF32 ch;
         unsigned short bytesToWrite = 0;
         const UTF32 byteMask = 0xBF;
@@ -166,7 +166,7 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-            if (source < sourceEnd) {
+            if (source < sourceEnd) { /* we need two bytes */
                 // Need at least 2 bytes
                 UTF32 ch2 = tsk_getu16(endian, (uint8_t *) source);
                 ++source;
@@ -271,7 +271,7 @@ tsk_UTF16toUTF8_lclorder(const UTF16 ** sourceStart,
     TSKConversionResult result = TSKconversionOK;
     const UTF16 *source = *sourceStart;
     UTF8 *target = *targetStart;
-    while (source < sourceEnd) {
+    while ((const char *)(source)+1 < (const char *)sourceEnd) { /* we need two bytes */
         UTF32 ch;
         unsigned short bytesToWrite = 0;
         const UTF32 byteMask = 0xBF;
@@ -282,7 +282,7 @@ tsk_UTF16toUTF8_lclorder(const UTF16 ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-            if (source < sourceEnd) {
+	  if ((const char *)(source)+3 < (const char *)sourceEnd) { /* we need 4 bytes */
                 UTF32 ch2 = *source;
                 source++;
                 /* If it's a low surrogate, convert to UTF32. */
@@ -374,7 +374,7 @@ tsk_UTF16WtoUTF8_lclorder(const wchar_t ** sourceStart,
     TSKConversionResult result = TSKconversionOK;
     const wchar_t *source = *sourceStart;
     UTF8 *target = *targetStart;
-    while (source < sourceEnd) {
+    while ((const char *)(source)+1 < (const char *)sourceEnd) { /* we need two bytes */
         UTF32 ch;
         unsigned short bytesToWrite = 0;
         const UTF32 byteMask = 0xBF;
@@ -385,7 +385,7 @@ tsk_UTF16WtoUTF8_lclorder(const wchar_t ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-            if (source < sourceEnd) {
+	  if ((const char *)(source)+3 < (const char *)sourceEnd) { /* we need 3 bytes */
                 UTF32 ch2 = *source;
                 source++;
                 /* If it's a low surrogate, convert to UTF32. */
@@ -737,4 +737,3 @@ tsk_UTF8toUTF16(const UTF8 ** sourceStart,
     *targetStart = target;
     return result;
 }
-

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -278,7 +278,7 @@ tsk_safeUTF16toUTF8(TSK_ENDIAN_ENUM endian, const uint8_t * source,
 	if (source_len < (number_of_characters * 2)) {
 		number_of_characters = source_len / 2;
 	}
-	retVal = tsk_UTF16toUTF8(endian, (const UTF16 **) &source,
+	retVal = tsk_UTF16toUTF8(endian, (const UTF16 **) source,
 		(const UTF16 *) (*source + (number_of_characters * 2)), targetStart, targetEnd, flags);
 
 	return retVal;

--- a/tsk/base/tsk_unicode.c
+++ b/tsk/base/tsk_unicode.c
@@ -135,7 +135,7 @@ static const UTF8 firstByteMark[7] =
 /**
  * \ingroup baselib
  * Convert a UTF-16 string to UTF-8.
- * @param endian Endian ordering flag of UTF-16 text
+ * @param endian Byte ordering of UTF-16 text
  * @param sourceStart Pointer to pointer to start of UTF-16 string.  Will be updated to last char processed.
  * @param sourceEnd Pointer to one entry past end of UTF-16 string
  * @param targetStart Pointer to pointer to place where UTF-8 string should be written.  Will be updated to next place to write to.
@@ -152,7 +152,7 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
     const UTF16 *source = *sourceStart;
     UTF8 *target = *targetStart;
 
-    while ( (const char *)(source)+1 < (const char *)sourceEnd) { /* we need two bytes */
+    while (source < sourceEnd) {
         UTF32 ch;
         unsigned short bytesToWrite = 0;
         const UTF32 byteMask = 0xBF;
@@ -166,7 +166,7 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-	    if ( ((const char *)(source))+1 < (const char *)(sourceEnd)) { /* we need two bytes */
+            if (source < sourceEnd) {
                 // Need at least 2 bytes
                 UTF32 ch2 = tsk_getu16(endian, (uint8_t *) source);
                 ++source;
@@ -252,6 +252,38 @@ tsk_UTF16toUTF8(TSK_ENDIAN_ENUM endian, const UTF16 ** sourceStart,
     return result;
 }
 
+/**
+ * \ingroup baselib
+ * Wrapper around tsk_UTF16toUTF8 to ensure read of source remains in bounds.
+ * @param endian Byte ordering of UTF-16 text
+ * @param source Pointer to start of the buffer that contains the UTF-16 string.
+ * @param source_len Number of bytes in buffer that contains the UTF-16 string (source).
+ * @param number_of_characters Number of characters in the UTF-16 string to convert.
+ * @param targetStart Pointer to pointer to place where UTF-8 string should be written.  Will be updated to next place to write to.
+ * @param targetEnd Pointer to end of UTF-8 buffer
+ * @param flags Flags used during conversion
+ * @returns error code
+ */
+TSKConversionResult
+tsk_safeUTF16toUTF8(TSK_ENDIAN_ENUM endian, const uint8_t * source,
+    size_t source_len, size_t number_of_characters, UTF8 ** targetStart,
+    UTF8 * targetEnd, TSKConversionFlags flags)
+{
+	int retVal = TSKconversionOK;
+
+	if (source_len > 0 && source_len % 2 != 0) {
+		// source_len must be even, since UTF-16 uses 2 bytes per character
+		source_len -= 1;
+	}
+	if (source_len < (number_of_characters * 2)) {
+		number_of_characters = source_len / 2;
+	}
+	retVal = tsk_UTF16toUTF8(endian, (const UTF16 **) &source,
+		(const UTF16 *) (*source + (number_of_characters * 2)), targetStart, targetEnd, flags);
+
+	return retVal;
+}
+
 
 /**
 * \ingroup baselib
@@ -271,7 +303,7 @@ tsk_UTF16toUTF8_lclorder(const UTF16 ** sourceStart,
     TSKConversionResult result = TSKconversionOK;
     const UTF16 *source = *sourceStart;
     UTF8 *target = *targetStart;
-    while ((const char *)(source)+1 < (const char *)sourceEnd) { /* we need two bytes */
+    while (source < sourceEnd) {
         UTF32 ch;
         unsigned short bytesToWrite = 0;
         const UTF32 byteMask = 0xBF;
@@ -282,7 +314,7 @@ tsk_UTF16toUTF8_lclorder(const UTF16 ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-	  if ((const char *)(source)+3 < (const char *)sourceEnd) { /* we need 4 bytes */
+            if (source < sourceEnd) {
                 UTF32 ch2 = *source;
                 source++;
                 /* If it's a low surrogate, convert to UTF32. */
@@ -374,7 +406,7 @@ tsk_UTF16WtoUTF8_lclorder(const wchar_t ** sourceStart,
     TSKConversionResult result = TSKconversionOK;
     const wchar_t *source = *sourceStart;
     UTF8 *target = *targetStart;
-    while ((const char *)(source)+1 < (const char *)sourceEnd) { /* we need two bytes */
+    while (source < sourceEnd) {
         UTF32 ch;
         unsigned short bytesToWrite = 0;
         const UTF32 byteMask = 0xBF;
@@ -385,7 +417,7 @@ tsk_UTF16WtoUTF8_lclorder(const wchar_t ** sourceStart,
         /* If we have a surrogate pair, convert to UTF32 first. */
         if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_HIGH_END) {
             /* If the 16 bits following the high surrogate are in the source buffer... */
-	  if ((const char *)(source)+3 < (const char *)sourceEnd) { /* we need 3 bytes */
+            if (source < sourceEnd) {
                 UTF32 ch2 = *source;
                 source++;
                 /* If it's a low surrogate, convert to UTF32. */
@@ -737,3 +769,4 @@ tsk_UTF8toUTF16(const UTF8 ** sourceStart,
     *targetStart = target;
     return result;
 }
+

--- a/tsk/base/tsk_unicode.h
+++ b/tsk/base/tsk_unicode.h
@@ -139,6 +139,11 @@ extern "C" {
         const UTF16 ** sourceStart, const UTF16 * sourceEnd,
         UTF8 ** targetStart, UTF8 * targetEnd, TSKConversionFlags flags);
 
+    extern TSKConversionResult tsk_safeUTF16toUTF8(TSK_ENDIAN_ENUM,
+        const uint8_t *source, size_t source_len,
+	size_t number_of_characters,
+        UTF8 ** targetStart, UTF8 * targetEnd, TSKConversionFlags flags);
+
     extern TSKConversionResult
         tsk_UTF16toUTF8_lclorder(const UTF16 ** sourceStart,
         const UTF16 * sourceEnd, UTF8 ** targetStart,

--- a/tsk/fs/ntfs_dent.cpp
+++ b/tsk/fs/ntfs_dent.cpp
@@ -303,21 +303,20 @@ ntfs_dent_copy(NTFS_INFO * ntfs, ntfs_idxentry * idxe, uintptr_t endaddr,
  * No other fields are copied.  Just the name into shrt_name. */
 static uint8_t
 ntfs_dent_copy_short_only(NTFS_INFO * ntfs, ntfs_idxentry * idxe,
-    TSK_FS_NAME * fs_name)
+    uint32_t idxe_len, TSK_FS_NAME * fs_name)
 {
     ntfs_attr_fname *fname = (ntfs_attr_fname *) & idxe->stream;
     TSK_FS_INFO *fs = (TSK_FS_INFO *) & ntfs->fs_info;
-    UTF16 *name16;
     UTF8 *name8;
     int retVal;
 
-    name16 = (UTF16 *) & fname->name;
     name8 = (UTF8 *) fs_name->shrt_name;
 
-    retVal = tsk_UTF16toUTF8(fs->endian, (const UTF16 **) &name16,
-        (UTF16 *) ((uintptr_t) name16 +
-            fname->nlen * 2), &name8,
-        (UTF8 *) ((uintptr_t) name8 +
+    // Note that NTFS uses UCS-2 (not UTF-16) hence lenient conversion is needed.
+    // See: https://osdfir.blogspot.com/2023/07/whats-in-file-path.html
+    retVal = tsk_safeUTF16toUTF8(fs->endian,
+        &fname->name, (size_t) idxe_len - 16, fname->nlen,
+       	&name8, (UTF8 *) ((uintptr_t) name8 +
             fs_name->shrt_name_size), TSKlenientConversion);
 
     if (retVal != TSKconversionOK) {
@@ -370,8 +369,8 @@ is_time(uint64_t t)
  * Process a list of index entries and add to FS_DIR
  *
  * @param a_is_del Set to 1 if these entries are for a deleted directory
- * @param idxe Buffer with index entries to process
- * @param idxe_len Length of idxe buffer (in bytes)
+ * @param a_idxe Buffer with index entries to process
+ * @param a_idxe_len Length of idxe buffer (in bytes)
  * @param used_len Length of data as reported by idexlist header (everything
  * after which and less then idxe_len is considered deleted)
  *
@@ -475,9 +474,8 @@ ntfs_proc_idxentry(NTFS_INFO * a_ntfs, TSK_FS_DIR * a_fs_dir,
 
         /* do some sanity checks on the deleted entries
          */
-        if ((tsk_getu16(fs->endian, a_idxe->strlen) == 0) ||
-            (((uintptr_t) a_idxe + tsk_getu16(fs->endian,
-                        a_idxe->idxlen)) > endaddr_alloc)) {
+	uint16_t idxlen = tsk_getu16(fs->endian, a_idxe->idxlen);
+        if ((idxlen == 0) || (((uintptr_t) a_idxe + idxlen) > endaddr_alloc)) {
 
             /* name space checks */
             if ((fname->nspace != NTFS_FNAME_POSIX) &&
@@ -539,7 +537,7 @@ ntfs_proc_idxentry(NTFS_INFO * a_ntfs, TSK_FS_DIR * a_fs_dir,
             if (fs_name_preventry) {
                 // check its the same entry and if so, add short name
                 if (fs_name_preventry->meta_addr == tsk_getu48(fs->endian, a_idxe->file_ref)) {
-                    ntfs_dent_copy_short_only(a_ntfs, a_idxe, fs_name_preventry);
+                    ntfs_dent_copy_short_only(a_ntfs, a_idxe, a_idxe_len, fs_name_preventry);
                 }
 
                 // regardless, add preventry to dir and move on to next entry.


### PR DESCRIPTION
This PR attempts to test the sanitizer crashes around UTF-16 to UTF-8 conversion.

The current  #3199  does not seem to resolve the issue based on my testing. I still get an address sanitizer issue. 

This PR contains all of the changes that were made in #3199 and also contains the new `test_tsk_unicode.cpp` and corresponding updates to `Makefile.am`.

```c++
FAIL: test/catch_runner
=======================

=================================================================
==6121==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00016d3ae160 at pc 0x0001031553ac bp 0x00016d3ae0d0 sp 0x00016d3ae0c8
READ of size 8 at 0x00016d3ae160 thread T0
    #0 0x0001031553a8 in tsk_UTF16toUTF8 tsk_unicode.c:152
    #1 0x000102a5a990 in ____C_A_T_C_H____T_E_S_T____29() test_tsk_unicode.cpp:269
    #2 0x000102aefb24 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:12989
    #3 0x000102aef208 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12750
    #4 0x000102af4820 in Catch::Session::runInternal() catch.hpp:13549
    #5 0x000102af3da8 in Catch::Session::run() catch.hpp:13505
    #6 0x000102b0a3ec in main catch.hpp:17504
    #7 0x0001930f6b94 in start+0x17b8 (dyld:arm64e+0xfffffffffff3ab94)

Address 0x00016d3ae160 is located in stack of thread T0 at offset 64 in frame
    #0 0x000102a5a680 in ____C_A_T_C_H____T_E_S_T____29() test_tsk_unicode.cpp:247

  This frame has 19 object(s):
    [32, 48) 'agg.tmp.i'
    [64, 68) 'source_buffer' (line 251) <== Memory access at offset 64 partially overflows this variable
    [80, 90) 'target_buffer' (line 258)
    [112, 120) 'target_ptr' (line 259)
    [144, 280) 'ref.tmp' (line 268)
    [352, 416) 'ref.tmp5' (line 268)
    [448, 464) 'ref.tmp6' (line 268)
    [480, 504) 'ref.tmp7' (line 268)
    [544, 616) 'catchAssertionHandler' (line 269)
    [656, 672) 'ref.tmp23' (line 269)
    [688, 704) 'ref.tmp25' (line 269)
    [720, 736) 'agg.tmp' (line 269)
    [752, 824) 'catchAssertionHandler50' (line 275)
    [864, 880) 'ref.tmp51' (line 275)
    [896, 912) 'ref.tmp53' (line 275)
    [928, 944) 'agg.tmp55' (line 275)
    [960, 1008) 'ref.tmp62' (line 275)
    [1040, 1044) 'ref.tmp65' (line 275)
    [1056, 1060) 'ref.tmp72' (line 275)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow tsk_unicode.c:152 in tsk_UTF16toUTF8
Shadow bytes around the buggy address:
  0x00016d3ade80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016d3adf00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016d3adf80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016d3ae000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00016d3ae080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x00016d3ae100: 00 00 00 00 f1 f1 f1 f1 f8 f8 f2 f2[04]f2 00 02
  0x00016d3ae180: f2 f2 00 f2 f2 f2 00 00 00 00 00 00 00 00 00 00
  0x00016d3ae200: 00 00 00 00 00 00 00 f2 f2 f2 f2 f2 f2 f2 f2 f2
  0x00016d3ae280: f8 f8 f8 f8 f8 f8 f8 f8 f2 f2 f2 f2 f8 f8 f2 f2
  0x00016d3ae300: f8 f8 f8 f2 f2 f2 f2 f2 00 00 00 00 00 00 00 00
  0x00016d3ae380: 00 f2 f2 f2 f2 f2 f8 f8 f2 f2 f8 f8 f2 f2 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==6121==ABORTING
```