### PR TITLE
Fix syntax for function calls in mactime.base

### DIFF
--- a/tools/timeline/mactime.base
+++ b/tools/timeline/mactime.base
@@ -149,7 +149,7 @@ while ((scalar(@ARGV) > 0) && (($_ = $ARGV[0]) =~ /^-(.)(.*)/)) {
     elsif (/^-g$/) {
         shift(@ARGV);
         if (defined $ARGV[0]) {
-            &'load_group_info($ARGV[0]);
+            &load_group_info($ARGV[0]);
             $GROUP = $ARGV[0];
         }
         else {
@@ -162,7 +162,7 @@ while ((scalar(@ARGV) > 0) && (($_ = $ARGV[0]) =~ /^-(.)(.*)/)) {
     elsif (/^-p$/) {
         shift(@ARGV);
         if (defined $ARGV[0]) {
-            &'load_passwd_info($ARGV[0]);
+            &load_passwd_info($ARGV[0]);
             $PASSWD = $ARGV[0];
         }
         else {


### PR DESCRIPTION
This PR suppresses warning messages about old package separator characters.

```
$ mactime -b bodyfile.txt -d -y | head
Old package separator "'" deprecated at /usr/local/bin/mactime line 154.
Old package separator "'" deprecated at /usr/local/bin/mactime line 167.
Date,Size,Type,Mode,UID,GID,Meta,File Name
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/lib/firmware/qca/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/lib/firmware/rtl_bt/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/lib/grub/i386-pc/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/lib/python3/dist-packages/cloudinit/config/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/share/doc/linux-firmware/licenses/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/share/icons/HighContrast/16x16/actions/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/share/icons/HighContrast/22x22/actions/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/share/icons/HighContrast/24x24/actions/^ (deleted-realloc)"
0000-00-00T00:00:00Z,0,...b,-/----------,0,0,1,"/usr/share/icons/HighContrast/256x256/actions/^ (deleted-realloc)"
```
