### PR TITLE
ntfs: fix heap-buffer-overflow in FILE_NAME attribute processing

### DIFF
--- a/tsk/fs/ntfs.cpp
+++ b/tsk/fs/ntfs.cpp
@@ -2378,8 +2378,8 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
                     ("proc_attrseq: resident data offset of File Name Attribute is out of bounds!");
                 return TSK_COR;
             }
-            // A File Name Attribute should be at least 66 bytes in size
-            if ((attr_len < 66) || (attr_off > attr_len - 66)) {
+            // A File Name Attribute must be large enough to hold the fixed fields.
+            if (attr_off + (uint32_t)offsetof(ntfs_attr_fname, name) > attr_len) {
                 tsk_error_reset();
                 tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
                 tsk_error_set_errstr
@@ -2440,7 +2440,7 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
                 }
                 fs_name->next = NULL;
             }
-            if ((uint32_t)fname->nlen * 2 > attr_len - attr_off - 66) {
+			if (attr_off + (uint32_t)offsetof(ntfs_attr_fname, name) + (uint32_t)fname->nlen * 2 > attr_len) {
                 tsk_error_reset();
                 tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
                 tsk_error_set_errstr

--- a/tsk/fs/ntfs.cpp
+++ b/tsk/fs/ntfs.cpp
@@ -2440,7 +2440,7 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
                 }
                 fs_name->next = NULL;
             }
-            if (fname->nlen > attr_len - 66) {
+            if ((uint32_t)fname->nlen * 2 > attr_len - attr_off - 66) {
                 tsk_error_reset();
                 tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
                 tsk_error_set_errstr


### PR DESCRIPTION
OSSFuzz initially reported [sleuthkit:fls_ntfs_fuzzer: Heap-buffer-overflow in tsk_UTF16toUTF8](https://issues.oss-fuzz.com/issues/471336361#comment1) late last year. The disclosure deadline for that particular report has passed and as such I figured I'd post [the report](https://issues.oss-fuzz.com/issues/471336361#comment1) again as well as a patch (this PR).

AI DISCLAIMER: We ran CodeMender against the report in an agent+fuzzer feedback loop until we arrived at this simple patch which was then reviewed by several humans here at Google. If this patch 1) doesn't meet sleuthkit's coding standards or 2) is not actually correct then please let me know and I (human) will fix it :)


---

Fix a heap-buffer-overflow in `tsk_UTF16toUTF8` triggered by `ntfs_proc_attrseq` when processing NTFS `$FILE_NAME` attributes.

The previous bounds check was insufficient:
`if (fname->nlen > attr_len - 66)`

This check failed to account for two factors:
1. `fname->nlen` represents the number of characters, but UTF-16 characters occupy 2 bytes each.
2. The check did not subtract `attr_off` (the offset to the resident data), which reduces the actual space available for the name string within the attribute buffer.

In cases where `attr_off` was large, the remaining buffer space could be significantly smaller than the check assumed, leading to an out-of-bounds read when `tsk_UTF16toUTF8` was called.

The fix updates the logic to correctly calculate the required byte size and the actual available space: `if ((uint32_t)fname->nlen * 2 > attr_len - attr_off - 66)`

This ensures that the UTF-16 string fits within the resident attribute data before processing.

Co-authored-by: CodeMender <codemender-patching@google.com>
Reviewed-by: Oliver Chang <ochang@google.com>
Signed-off-by: Justin Stitt <justinstitt@google.com>
Fixes: https://issues.oss-fuzz.com/issues/471336361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced validation of NTFS file system file name attributes during parsing. Improved error detection for edge-case and corrupted structures to increase reliability and prevent potential issues when handling unusual file system scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->