### PR TITLE
Pass in application name so locking works

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -3352,7 +3352,7 @@ public class SleuthkitCase {
 	 */
 	@Beta
 	public static SleuthkitCase newCase(String dbPath, ContentStreamProvider contentProvider, String lockingApplicationName) throws TskCoreException {
-		return newCase(dbPath, contentProvider, null, false);
+		return newCase(dbPath, contentProvider, lockingApplicationName, false);
 	}
 	
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -3216,7 +3216,7 @@ public class SleuthkitCase {
 	 */
 	@Beta
 	public static SleuthkitCase openCase(String dbPath, ContentStreamProvider contentProvider, String lockingApplicationName) throws TskCoreException {
-		return openCase(dbPath, contentProvider, null, false);
+		return openCase(dbPath, contentProvider, lockingApplicationName, false);
 	}
 	
 	/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the locking application name was ignored when opening or creating case databases; the provided name is now honored to ensure proper case-lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->