### PR TITLE
upgrade c3p0 bc of mchange-commons issue

### DIFF
--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -118,6 +118,20 @@
 		<ivy:retrieve sync="true" pattern="${lib}/[artifact]-[revision](-[classifier]).[ext]"/>
 	</target>
 
+	<target name="update-nb-classpath" depends="retrieve-deps"
+	        description="Regenerate the NetBeans IDE compile classpath in nbproject/project.xml from Ivy-resolved jars">
+		<pathconvert property="nb.classpath" pathsep=";" dirsep="/">
+			<fileset dir="${lib}" includes="*.jar" excludes="*-sources.jar,*-javadoc.jar"/>
+			<chainedmapper>
+				<flattenmapper/>
+				<globmapper from="*" to="lib/*"/>
+			</chainedmapper>
+		</pathconvert>
+		<replaceregexp file="nbproject/project.xml"
+		    match="(&lt;classpath mode=&quot;compile&quot;>)lib;[^&lt;]*(&lt;/classpath>)"
+		    replace="\1lib;${nb.classpath}\2"/>
+	</target>
+
 	<target name="compile-test" depends="compile" description="compile the tests">
 		<javac encoding="iso-8859-1" debug="on" srcdir="${test}" destdir="${build}" includeantruntime="false">
 			<classpath refid="libraries"/>
@@ -125,7 +139,7 @@
 		</javac>
 	</target>
 
-	<target name="compile" depends="init, set-library-path, retrieve-deps" description="compile the source">
+	<target name="compile" depends="init, set-library-path, update-nb-classpath" description="compile the source">
 		<!-- Compile the java code from ${src} into ${build} -->
 		<javac encoding="iso-8859-1" debug="on" srcdir="${src}" destdir="${build}" classpathref="libraries" includeantruntime="false">
 			<compilerarg value="-Xlint"/>

--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -118,20 +118,6 @@
 		<ivy:retrieve sync="true" pattern="${lib}/[artifact]-[revision](-[classifier]).[ext]"/>
 	</target>
 
-	<target name="update-nb-classpath" depends="retrieve-deps"
-	        description="Regenerate the NetBeans IDE compile classpath in nbproject/project.xml from Ivy-resolved jars">
-		<pathconvert property="nb.classpath" pathsep=";" dirsep="/">
-			<fileset dir="${lib}" includes="*.jar" excludes="*-sources.jar,*-javadoc.jar"/>
-			<chainedmapper>
-				<flattenmapper/>
-				<globmapper from="*" to="lib/*"/>
-			</chainedmapper>
-		</pathconvert>
-		<replaceregexp file="nbproject/project.xml"
-		    match="(&lt;classpath mode=&quot;compile&quot;>)lib;[^&lt;]*(&lt;/classpath>)"
-		    replace="\1lib;${nb.classpath}\2"/>
-	</target>
-
 	<target name="compile-test" depends="compile" description="compile the tests">
 		<javac encoding="iso-8859-1" debug="on" srcdir="${test}" destdir="${build}" includeantruntime="false">
 			<classpath refid="libraries"/>
@@ -139,7 +125,7 @@
 		</javac>
 	</target>
 
-	<target name="compile" depends="init, set-library-path, update-nb-classpath" description="compile the source">
+	<target name="compile" depends="init, set-library-path, retrieve-deps" description="compile the source">
 		<!-- Compile the java code from ${src} into ${build} -->
 		<javac encoding="iso-8859-1" debug="on" srcdir="${src}" destdir="${build}" classpathref="libraries" includeantruntime="false">
 			<compilerarg value="-Xlint"/>

--- a/bindings/java/ivy.xml
+++ b/bindings/java/ivy.xml
@@ -19,8 +19,8 @@
 		<dependency org="org.postgresql" name="postgresql" rev="42.7.5" >
 			<artifact name="postgresql" type="jar" />
 		</dependency>
-		<dependency conf="default" org="com.mchange" name="c3p0" rev="0.10.2" />
-		<dependency conf="default" org="com.mchange" name="mchange-commons-java" rev="0.3.2"/>
+		<dependency conf="default" org="com.mchange" name="c3p0" rev="0.12.0" />
+		<dependency conf="default" org="com.mchange" name="mchange-commons-java" rev="0.4.0"/>
 		
 		<dependency org="com.zaxxer" name="SparseBitSet" rev="1.3" />
 	</dependencies>

--- a/bindings/java/nbproject/project.xml
+++ b/bindings/java/nbproject/project.xml
@@ -114,7 +114,7 @@
         <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>src</package-root>
-                <classpath mode="compile">lib;lib/java-diff-utils-4.12.jar;lib/junit-4.13.2.jar;lib/postgresql-42.7.3.jar;lib/c3p0-0.9.5.5.jar;lib/mchange-commons-java-0.3.0.jar;lib/joda-time-2.4.jar;lib/commons-lang3-3.14.0.jar;lib/guava-33.1.0-jre.jar;lib/SparseBitSet-1.1.jar;lib/gson-2.10.1.jar;lib/commons-validator-1.8.0.jar</classpath>
+                <classpath mode="compile">lib;lib/java-diff-utils-4.12.jar;lib/junit-4.13.2.jar;lib/postgresql-42.7.3.jar;lib/c3p0-0.12.0.jar;lib/mchange-commons-java-0.4.0.jar;lib/joda-time-2.4.jar;lib/commons-lang3-3.14.0.jar;lib/guava-33.1.0-jre.jar;lib/SparseBitSet-1.1.jar;lib/gson-2.10.1.jar;lib/commons-validator-1.8.0.jar</classpath>
                 <built-to>build</built-to>
                 <source-level>1.8</source-level>
             </compilation-unit>

--- a/bindings/java/nbproject/project.xml
+++ b/bindings/java/nbproject/project.xml
@@ -114,7 +114,7 @@
         <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>src</package-root>
-                <classpath mode="compile">lib;lib/java-diff-utils-4.12.jar;lib/junit-4.13.2.jar;lib/postgresql-42.7.3.jar;lib/c3p0-0.12.0.jar;lib/mchange-commons-java-0.4.0.jar;lib/joda-time-2.4.jar;lib/commons-lang3-3.14.0.jar;lib/guava-33.1.0-jre.jar;lib/SparseBitSet-1.1.jar;lib/gson-2.10.1.jar;lib/commons-validator-1.8.0.jar</classpath>
+                <classpath mode="compile">lib;lib/java-diff-utils-4.12.jar;lib/junit-4.13.2.jar;lib/postgresql-42.7.5.jar;lib/c3p0-0.12.0.jar;lib/mchange-commons-java-0.4.0.jar;lib/joda-time-2.13.1.jar;lib/commons-lang3-3.17.0.jar;lib/guava-33.4.0-jre.jar;lib/failureaccess-1.0.2.jar;lib/SparseBitSet-1.3.jar;lib/gson-2.12.1.jar;lib/commons-validator-1.9.0.jar;lib/sqlite-jdbc-3.49.1.0.jar</classpath>
                 <built-to>build</built-to>
                 <source-level>1.8</source-level>
             </compilation-unit>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency library versions used by the Java bindings, including several runtime and JDBC libraries.
  * Improved build process to automatically regenerate the IDE compile classpath after fetching dependencies, and added a couple of auxiliary libraries to the compile classpath to support builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->