### PR TITLE
Fix for issue in #3476 - tsk_recover escape sequences

### DIFF
--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -11,6 +11,7 @@
 
 #include "tsk/tsk_tools_i.h"
 #include <locale.h>
+#include <stdio.h>
 #include <sys/stat.h>
 #include <errno.h>
 
@@ -141,8 +142,10 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     
     // combine the volume name and path
     char path8[FILENAME_MAX];
-    strncpy(path8, m_vsName, FILENAME_MAX);
-    strncat(path8, a_path, FILENAME_MAX-strlen(path8)); 
+    if (snprintf(path8, FILENAME_MAX, "%s%s", m_vsName, a_path) >= FILENAME_MAX) {
+        fprintf(stderr, "Error: output path too long\n");
+        return 1;
+    }
     size_t ilen = strlen(path8);
     
     // clean up any control characters
@@ -154,9 +157,12 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
         if (path8[i] == '/')
             path8[i] = '\\';
 
-        // make sure there is no \..\ path traversal
-        if (i + 4 < ilen) {
-            if ((path8[i] == '\\') && (path8[i+1] == '.') && (path8[i+2] == '.') && (path8[i+3] == '\\')) {
+        // make sure there is no \..\ or trailing \.. path traversal
+        // note: i+3 == ilen is intentional — path8[ilen] is the null terminator,
+        // which matches '\0' to catch \.. at end-of-string as well as \..\
+        if (i + 3 <= ilen) {
+            if ((path8[i] == '\\') && (path8[i+1] == '.') && (path8[i+2] == '.') &&
+                (path8[i+3] == '\\' || path8[i+3] == '\0')) {
                 path8[i+1] = '^';
                 path8[i+2] = '^';
             }
@@ -288,9 +294,12 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
         if (TSK_IS_CNTRL(fbuf[i]))
             fbuf[i] = '^';
 
-        // make sure there is no /../ path traversal 
-        if (i + 4 < strlen(fbuf)) {
-            if ((fbuf[i] == '/') && (fbuf[i+1] == '.') && (fbuf[i+2] == '.') && (fbuf[i+3] == '/')) {
+        // make sure there is no /../ or trailing /.. path traversal
+        // note: i+3 == strlen(fbuf) is intentional — fbuf[strlen(fbuf)] is the null terminator,
+        // which matches '\0' to catch /.. at end-of-string as well as /../
+        if (i + 3 <= strlen(fbuf)) {
+            if ((fbuf[i] == '/') && (fbuf[i+1] == '.') && (fbuf[i+2] == '.') &&
+                (fbuf[i+3] == '/' || fbuf[i+3] == '\0')) {
                 fbuf[i+1] = '^';
                 fbuf[i+2] = '^';
             }

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -147,7 +147,13 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
         return 1;
     }
     size_t ilen = strlen(path8);
-    
+
+    // check for .. at start of path (no preceding separator to trigger the loop check)
+    if (ilen >= 2 && path8[0] == '.' && path8[1] == '.' && (ilen == 2 || path8[2] == '\\')) {
+        path8[0] = '^';
+        path8[1] = '^';
+    }
+
     // clean up any control characters
     for (size_t i = 0; i < ilen; i++) {
         if (TSK_IS_CNTRL(path8[i])) {
@@ -159,7 +165,7 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
 
         // make sure there is no \..\ or trailing \.. path traversal
         // note: i+3 == ilen is intentional — path8[ilen] is the null terminator,
-        // which matches '\0' to catch \.. at end-of-string as well as \..\
+        // which matches '\0' to catch \.. at end-of-string as well as \..\ scenario
         if (i + 3 <= ilen) {
             if ((path8[i] == '\\') && (path8[i+1] == '.') && (path8[i+2] == '.') &&
                 (path8[i+3] == '\\' || path8[i+3] == '\0')) {

--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -142,11 +142,12 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     
     // combine the volume name and path
     char path8[FILENAME_MAX];
-    if (snprintf(path8, FILENAME_MAX, "%s%s", m_vsName, a_path) >= FILENAME_MAX) {
+    int path8_len = snprintf(path8, sizeof(path8), "%s%s", m_vsName, a_path);
+    if (path8_len < 0 || path8_len >= (int)sizeof(path8)) {
         fprintf(stderr, "Error: output path too long\n");
         return 1;
     }
-    size_t ilen = strlen(path8);
+    size_t ilen = (size_t)path8_len;
 
     // check for .. at start of path (no preceding separator to trigger the loop check)
     if (ilen >= 2 && path8[0] == '.' && path8[1] == '.' && (ilen == 2 || path8[2] == '\\')) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error reporting when an output path is too long, preventing silent truncation.
  * Strengthened directory-traversal protection: improved sanitization detects and neutralizes leading/traversal patterns and trailing traversal fragments on both Windows and non-Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->