### PR TITLE
Add bounds check to address #3465

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -2333,7 +2333,11 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
             fs_file->meta->crtime_nano =
                 nt2nano(tsk_getu64(fs->endian, si->crtime));
 
-            fs_file->meta->uid = tsk_getu32(fs->endian, si->own_id);
+            // own_id is only present in the 72-byte (NTFS 3.x) variant;
+            // a 48-byte SI attribute is valid NTFS 1.x and lacks this field.
+            if (attr_off + offsetof(ntfs_attr_si, own_id) + sizeof(si->own_id) <= attr_len) {
+                fs_file->meta->uid = tsk_getu32(fs->endian, si->own_id);
+            }
             fs_file->meta->mode |=
                 (TSK_FS_META_MODE_IXUSR | TSK_FS_META_MODE_IXGRP |
                 TSK_FS_META_MODE_IXOTH);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect file metadata reading for NTFS file systems. The system now properly handles different NTFS version formats when processing file information, preventing data from being read from incorrect locations in older NTFS variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->