### PR TITLE
Add lengh sanity check to address #3437

### DIFF
--- a/tsk/fs/fatfs_dent.cpp
+++ b/tsk/fs/fatfs_dent.cpp
@@ -279,6 +279,16 @@ TSK_RETVAL_ENUM
     }
 
     size = fs_dir->fs_file->meta->size;
+
+    /* A directory cannot be larger than the entire image */
+    if (size > a_fs->img_info->size) {
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
+        tsk_error_set_errstr("%s: directory size %" PRIdOFF
+            " exceeds image size", func_name, size);
+        return TSK_COR;
+    }
+
     len = roundup(size, fatfs->ssize);
 
     if (tsk_verbose) {

--- a/tsk/fs/fatfs_dent.cpp
+++ b/tsk/fs/fatfs_dent.cpp
@@ -280,12 +280,21 @@ TSK_RETVAL_ENUM
 
     size = fs_dir->fs_file->meta->size;
 
-    /* A directory cannot be larger than the entire image */
-    if (size > a_fs->img_info->size) {
+    /* A negative size from corrupt metadata would wrap to a huge unsigned
+     * value in roundup() and the subsequent tsk_malloc call. */
+    if (size < 0) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
         tsk_error_set_errstr("%s: directory size %" PRIdOFF
-            " exceeds image size", func_name, size);
+            " is negative", func_name, size);
+        return TSK_COR;
+    }
+    /* A directory cannot exceed the filesystem's usable data area. */
+    else if (size > (TSK_OFF_T)(a_fs->block_count * a_fs->block_size)) {
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
+        tsk_error_set_errstr("%s: directory size %" PRIdOFF
+            " exceeds filesystem size", func_name, size);
         return TSK_COR;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for directory metadata to detect corrupted size values (negative or unreasonably large). The system now avoids processing such entries, prevents related allocation/behavior issues, and surfaces a clearer error instead of continuing on invalid data, improving stability and reliability when scanning file systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->