### PR TITLE
Fix #3434 with better bounds check

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -3308,7 +3308,7 @@ ntfs_load_bmap(NTFS_INFO * ntfs)
         goto on_error;
     }
     attr_len = tsk_getu32(fs->endian, data_attr->len);
-    if (attr_len > ntfs->mft_rsize_b) {
+    if ((uintptr_t) data_attr + attr_len > (uintptr_t) mft + ntfs->mft_rsize_b) {
         goto on_error;
     }
 

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -3309,6 +3309,9 @@ ntfs_load_bmap(NTFS_INFO * ntfs)
     }
     attr_len = tsk_getu32(fs->endian, data_attr->len);
     if ((uintptr_t) data_attr + attr_len > (uintptr_t) mft + ntfs->mft_rsize_b) {
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
+        tsk_error_set_errstr("Error Finding Bitmap Data Attribute: attr_len extends past end of MFT record");
         goto on_error;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of NTFS bitmap data to prevent potential out-of-bounds memory access.
  * Enhanced error handling and reporting when bitmap validation fails to ensure clearer, consistent error state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->