### PR TITLE
Fixes #3395 by allowing more non-spec FAT ASCII values in known direc…

### DIFF
--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -48,8 +48,12 @@ is_83_name(FATXXFS_DENTRY * de, uint8_t strict)
     if (!de)
         return 0;
 
-    /* The IS_OK macro will fail if the value is 0x05, which is only
-     * valid in name[0], similarly with '.' */
+    /* name[0] has two special on-disk values that are not valid elsewhere:
+     * 0x05 (FATXXFS_SLOT_E5) represents a real 0xE5 byte in the filename,
+     * and 0x2E ('.') is the directory self/parent entry marker.  Both strict
+     * and relaxed modes would otherwise reject 0x05 (a control character) and
+     * 0x2E (period), so they are exempted for name[0] only before calling
+     * IS_OK. */
     if ((de->name[0] != FATXXFS_SLOT_E5) && (de->name[0] != '.') &&
         (IS_OK(de->name[0]) == 0)) {
         if (tsk_verbose)
@@ -167,6 +171,9 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
     const char *func_name = "fatxxfs_is_dentry";
     TSK_FS_INFO *fs = (TSK_FS_INFO *) & a_fatfs->fs_info;
     FATXXFS_DENTRY *dentry = (FATXXFS_DENTRY*)a_dentry;
+    /* a_do_basic_tests_only is inverted: 0 means in-depth (carving), which
+     * requires strict name validation to avoid false positives. */
+    uint8_t strict = (a_do_basic_tests_only == 0);
 
     if (!a_dentry)
         return 0;
@@ -187,7 +194,7 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
     }
     else {
         // the basic test is only for the 'essential data'.
-        if (a_do_basic_tests_only == 0) {
+        if (strict) {
             if (dentry->lowercase & ~(FATXXFS_CASE_LOWER_ALL)) {
                 if (tsk_verbose)
                     fprintf(stderr, "%s: lower case all\n", func_name);
@@ -286,7 +293,7 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
         }
 		
 		else if((a_fatfs->subtype == TSK_FATFS_SUBTYPE_SPEC) &&
-                (is_83_name(dentry, a_do_basic_tests_only == 0) == 0))
+                (is_83_name(dentry, strict) == 0))
 			return 0;
 
         // basic sanity check on values

--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -29,20 +29,29 @@
 #include <assert.h>
 
 /*
- * Identify if the dentry is a valid 8.3 name
+ * Identify if the dentry has a valid 8.3 name.
  *
- * returns 1 if it is, 0 if it does not
+ * @param de     Directory entry to check.
+ * @param strict Non-zero to use strict validation (carving / unallocated
+ *               space), zero to use relaxed validation (known directory).
+ *               See FATXXFS_IS_83_NAME_STRICT / FATXXFS_IS_83_NAME_RELAXED
+ *               in tsk_fatxxfs.h for the character sets each mode accepts.
+ *
+ * Returns 1 if the name is valid, 0 otherwise.
  */
 static uint8_t
-is_83_name(FATXXFS_DENTRY * de)
+is_83_name(FATXXFS_DENTRY * de, uint8_t strict)
 {
+/* Dispatch to the correct character-validation macro based on mode. */
+#define IS_OK(c)  (strict ? FATXXFS_IS_83_NAME_STRICT(c) : FATXXFS_IS_83_NAME_RELAXED(c))
+
     if (!de)
         return 0;
 
-    /* The IS_NAME macro will fail if the value is 0x05, which is only
+    /* The IS_OK macro will fail if the value is 0x05, which is only
      * valid in name[0], similarly with '.' */
     if ((de->name[0] != FATXXFS_SLOT_E5) && (de->name[0] != '.') &&
-        (FATXXFS_IS_83_NAME(de->name[0]) == 0)) {
+        (IS_OK(de->name[0]) == 0)) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[0] is invalid\n");
         return 0;
@@ -63,53 +72,53 @@ is_83_name(FATXXFS_DENTRY * de)
             return 0;
         }
     }
-    else if (FATXXFS_IS_83_NAME(de->name[1]) == 0) {
+    else if (IS_OK(de->name[1]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[1] is invalid\n");
         return 0;
     }
 
-    if (FATXXFS_IS_83_NAME(de->name[2]) == 0) {
+    if (IS_OK(de->name[2]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[2] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->name[3]) == 0) {
+    else if (IS_OK(de->name[3]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[3] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->name[4]) == 0) {
+    else if (IS_OK(de->name[4]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[4] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->name[5]) == 0) {
+    else if (IS_OK(de->name[5]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[5] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->name[6]) == 0) {
+    else if (IS_OK(de->name[6]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[6] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->name[7]) == 0) {
+    else if (IS_OK(de->name[7]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: name[7] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->ext[0]) == 0) {
+    else if (IS_OK(de->ext[0]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: ext[0] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->ext[1]) == 0) {
+    else if (IS_OK(de->ext[1]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: ext[1] is invalid\n");
         return 0;
     }
-    else if (FATXXFS_IS_83_NAME(de->ext[2]) == 0) {
+    else if (IS_OK(de->ext[2]) == 0) {
         if (tsk_verbose)
             fprintf(stderr, "fatfs_is_83_name: ext[2] is invalid\n");
         return 0;
@@ -136,6 +145,8 @@ is_83_name(FATXXFS_DENTRY * de)
     }
 
     return 1;
+
+#undef IS_OK
 }
 
 /**
@@ -274,7 +285,8 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
             return 0;
         }
 		
-		else if((a_fatfs->subtype == TSK_FATFS_SUBTYPE_SPEC) && (is_83_name(dentry) == 0))
+		else if((a_fatfs->subtype == TSK_FATFS_SUBTYPE_SPEC) &&
+                (is_83_name(dentry, a_do_basic_tests_only == 0) == 0))
 			return 0;
 
         // basic sanity check on values

--- a/tsk/fs/tsk_fatxxfs.h
+++ b/tsk/fs/tsk_fatxxfs.h
@@ -109,10 +109,6 @@
 /* Legacy alias — strict validation, same as FATXXFS_IS_83_NAME_STRICT. */
 #define FATXXFS_IS_83_NAME(c)		FATXXFS_IS_83_NAME_STRICT(c)
 
-// extensions are to be ascii / latin
-#define FATXXFS_IS_83_EXT(c)		\
-    (FATXXFS_IS_83_NAME((c)) && ((c) < 0x7f))
-
 /* flags for lowercase field */
 #define FATXXFS_CASE_LOWER_BASE	0x08    /* base is lower case */
 #define FATXXFS_CASE_LOWER_EXT	0x10    /* extension is lower case */

--- a/tsk/fs/tsk_fatxxfs.h
+++ b/tsk/fs/tsk_fatxxfs.h
@@ -42,21 +42,72 @@
 	((name[0] == 0) && (name[1] == 0)) : \
 	(name[0] == FATXXFS_SLOT_DELETED) 
 
-/* 
- *Return 1 if c is an valid character for a short file name 
+/*
+ * Return 1 if c is a valid character for a short file name — strict mode.
+ *
+ * Used during carving (scanning unallocated space) where a permissive check
+ * risks accepting random data as a valid directory entry.
  *
  * NOTE: 0x05 is allowed in name[0], and 0x2e (".") is allowed for name[0]
- * and name[1] and 0xe5 is allowed for name[0]
+ * and name[1] and 0xe5 is allowed for name[0].
+ *
+ * The MS FAT spec forbids values below 0x20 and: 0x22 " 0x2a * 0x2b +
+ * 0x2c , 0x2e . 0x2f / 0x3a : 0x3b ; 0x3c < 0x3d = 0x3e > 0x3f ? 0x5b [
+ * 0x5c \ 0x5d ] 0x7c |.  This macro relaxes two of those:
+ *
+ * 0x2b (+) allowed: low-risk printable character observed in real embedded
+ *   Linux FAT filesystems (e.g. directory names like "7+1_MODE"). Linux's
+ *   FAT driver does not validate characters when reading short names, so
+ *   entries with + can be read back correctly on Linux devices.
+ * 0x3d (=) allowed: low-risk printable character; MS spec forbids it as
+ *   part of the 0x3a-0x3f range, but Linux can read it and it has low
+ *   false-positive risk when carving.
+ *
+ * All other MS-forbidden characters remain forbidden to minimise false
+ * positives during carving.
  */
-#define FATXXFS_IS_83_NAME(c)		\
+#define FATXXFS_IS_83_NAME_STRICT(c)	\
 	((((c) < 0x20) || \
 	  ((c) == 0x22) || \
-	  (((c) >= 0x2a) && ((c) <= 0x2c)) || \
+	  ((c) == 0x2a) || \
+	  ((c) == 0x2c) || \
 	  ((c) == 0x2e) || \
 	  ((c) == 0x2f) || \
-	  (((c) >= 0x3a) && ((c) <= 0x3f)) || \
+	  ((c) == 0x3a) || \
+	  ((c) == 0x3b) || \
+	  ((c) == 0x3c) || \
+	  ((c) == 0x3e) || \
+	  ((c) == 0x3f) || \
 	  (((c) >= 0x5b) && ((c) <= 0x5d)) || \
 	  ((c) == 0x7c)) == 0)
+
+/*
+ * Return 1 if c is a valid character for a short file name — relaxed mode.
+ *
+ * Used when traversing a known allocated directory.  Because we have
+ * structural confidence in the entry we can accept characters that the MS
+ * FAT spec forbids but that Linux's FAT driver can read without validation.
+ * Only the highest-risk characters remain forbidden:
+ *
+ * 0x00-0x1f (control chars): never valid.
+ * 0x2a (*): glob wildcard — high false-positive risk even in known dirs.
+ * 0x2e (.): period — handled by caller special-cases; not generically valid.
+ * 0x2f (/): path separator — security risk.
+ * 0x3f (?): glob wildcard — high false-positive risk.
+ *
+ * Characters not in the MS spec but allowed here because Linux can read them:
+ * 0x22 " 0x2b + 0x2c , 0x3a : 0x3b ; 0x3c < 0x3d = 0x3e > 0x5b [
+ * 0x5c \ 0x5d ] 0x7c |
+ */
+#define FATXXFS_IS_83_NAME_RELAXED(c)	\
+	((((c) < 0x20) || \
+	  ((c) == 0x2a) || \
+	  ((c) == 0x2e) || \
+	  ((c) == 0x2f) || \
+	  ((c) == 0x3f)) == 0)
+
+/* Legacy alias — strict validation, same as FATXXFS_IS_83_NAME_STRICT. */
+#define FATXXFS_IS_83_NAME(c)		FATXXFS_IS_83_NAME_STRICT(c)
 
 // extensions are to be ascii / latin
 #define FATXXFS_IS_83_EXT(c)		\


### PR DESCRIPTION
…tories. Orphan file carving is still more strict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved FAT short-name validation by introducing separate strict and relaxed validation modes.
  * Validation behavior adjusted to better handle special short-name cases and to apply mode-specific checks where appropriate, resulting in more accurate filename recognition during filesystem operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->