### PR TITLE
added check before calling unicode conversion. Point fix part of #3199

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -4835,6 +4835,14 @@ ntfs_istat(TSK_FS_INFO * fs, TSK_FS_ISTAT_FLAG_ENUM istat_flags, FILE * hFile,
         name16 = (UTF16 *) & fname->name;
         name8 = (UTF8 *) name8buf;
 
+        /* Verify fname->nlen doesn't extend past the attribute buffer */
+        if (fs_attr->rd.buf_size < offsetof(ntfs_attr_fname, name) + (size_t) fname->nlen * 2) {
+            if (tsk_verbose)
+                tsk_fprintf(stderr,
+                    "ntfs_istat: $FILE_NAME name length extends past end of attribute buffer\n");
+            continue;
+        }
+
         retVal =
             tsk_UTF16toUTF8(fs->endian, (const UTF16 **) &name16,
             (UTF16 *) ((uintptr_t) name16 +

--- a/tsk/fs/tsk_ntfs.h
+++ b/tsk/fs/tsk_ntfs.h
@@ -614,6 +614,26 @@ extern "C" {
 /************************************************************************
 */
 
+    /* On-disk layout of a USN journal V2 record (little-endian). */
+    typedef struct {
+        uint8_t length[4];          /* 0:  RecordLength */
+        uint8_t major_version[2];   /* 4:  MajorVersion */
+        uint8_t minor_version[2];   /* 6:  MinorVersion */
+        uint8_t file_ref[6];        /* 8:  FileReferenceNumber (MFT entry) */
+        uint8_t file_ref_seq[2];    /* 14: FileReferenceNumber (sequence) */
+        uint8_t par_ref[6];         /* 16: ParentFileReferenceNumber (MFT entry) */
+        uint8_t par_ref_seq[2];     /* 22: ParentFileReferenceNumber (sequence) */
+        uint8_t usn[8];             /* 24: Usn */
+        uint8_t timestamp[8];       /* 32: TimeStamp */
+        uint8_t reason[4];          /* 40: Reason */
+        uint8_t source_info[4];     /* 44: SourceInfo */
+        uint8_t security_id[4];     /* 48: SecurityId */
+        uint8_t attributes[4];      /* 52: FileAttributes */
+        uint8_t fname_length[2];    /* 56: FileNameLength */
+        uint8_t fname_offset[2];    /* 58: FileNameOffset */
+        /* FileName (UTF-16LE) follows immediately at offset 60 */
+    } ntfs_usn_v2_rec;
+
 
     enum TSK_FS_USN_REASON {
         TSK_FS_USN_REASON_DATA_OVERWRITE = 0x00000001,

--- a/tsk/fs/usn_journal.c
+++ b/tsk/fs/usn_journal.c
@@ -75,9 +75,13 @@ static void
 parse_record_header(const unsigned char *buf, TSK_USN_RECORD_HEADER *header,
                     TSK_ENDIAN_ENUM endian)
 {
-    header->length = tsk_getu32(endian, &buf[0]);
-    header->major_version = tsk_getu16(endian, &buf[4]);
-    header->minor_version = tsk_getu16(endian, &buf[6]);
+    /* Cast to ntfs_usn_v2_rec to use named fields, even though only the
+     * first three fields (length, major_version, minor_version) are read
+     * here. These fields are shared across all USN record versions. */
+    const ntfs_usn_v2_rec *rec = (const ntfs_usn_v2_rec *) buf;
+    header->length = tsk_getu32(endian, rec->length);
+    header->major_version = tsk_getu16(endian, rec->major_version);
+    header->minor_version = tsk_getu16(endian, rec->minor_version);
 }
 
 
@@ -89,28 +93,40 @@ static uint8_t
 parse_v2_record(const unsigned char *buf, TSK_USN_RECORD_HEADER *header,
                 TSK_USN_RECORD_V2 *record, TSK_ENDIAN_ENUM endian)
 {
+    const ntfs_usn_v2_rec *rec = (const ntfs_usn_v2_rec *) buf;
     uint64_t timestamp = 0;
-    uint16_t name_offset = 0, name_length = 0;
+    uint16_t name_length = 0, name_offset = 0;
 
-    record->refnum = tsk_getu48(endian, &buf[8]);
-    record->refnum_seq = tsk_getu16(endian, &buf[14]);
-    record->parent_refnum = tsk_getu48(endian, &buf[16]);
-    record->parent_refnum_seq = tsk_getu16(endian, &buf[22]);
-    record->usn = tsk_getu64(endian, &buf[24]);
+    record->refnum = tsk_getu48(endian, rec->file_ref);
+    record->refnum_seq = tsk_getu16(endian, rec->file_ref_seq);
+    record->parent_refnum = tsk_getu48(endian, rec->par_ref);
+    record->parent_refnum_seq = tsk_getu16(endian, rec->par_ref_seq);
+    record->usn = tsk_getu64(endian, rec->usn);
 
     /* Convert NT timestamp into Unix */
-    timestamp = tsk_getu64(endian, &buf[32]);
+    timestamp = tsk_getu64(endian, rec->timestamp);
     record->time_sec = nt2unixtime(timestamp);
     record->time_nsec = nt2nano(timestamp);
 
-    record->reason = tsk_getu32(endian, &buf[40]);
-    record->source_info = tsk_getu32(endian, &buf[44]);
-    record->security = tsk_getu32(endian, &buf[48]);
-    record->attributes = tsk_getu32(endian, &buf[52]);
+    record->reason = tsk_getu32(endian, rec->reason);
+    record->source_info = tsk_getu32(endian, rec->source_info);
+    record->security = tsk_getu32(endian, rec->security_id);
+    record->attributes = tsk_getu32(endian, rec->attributes);
 
     /* Extract file name */
-    name_length = tsk_getu16(endian, &buf[56]);
-    name_offset = tsk_getu16(endian, &buf[58]);
+    name_length = tsk_getu16(endian, rec->fname_length);
+    name_offset = tsk_getu16(endian, rec->fname_offset);
+
+    /* Validate that the name falls within the record bounds.
+     * name_offset must point past the fixed header (sizeof(ntfs_usn_v2_rec) == 60). */
+    if (name_offset < sizeof(ntfs_usn_v2_rec) ||
+        (uint32_t) name_offset + name_length > header->length) {
+        if (tsk_verbose)
+            tsk_fprintf(stderr,
+                "parse_v2_record: file name out of record bounds\n");
+        record->fname = NULL;
+        return 0;
+    }
 
     return parse_fname(&buf[name_offset], name_length, record, endian);
 }

--- a/tsk/fs/usn_journal.c
+++ b/tsk/fs/usn_journal.c
@@ -97,6 +97,13 @@ parse_v2_record(const unsigned char *buf, TSK_USN_RECORD_HEADER *header,
     uint64_t timestamp = 0;
     uint16_t name_length = 0, name_offset = 0;
 
+    if (header->length < sizeof(ntfs_usn_v2_rec)) {
+        if (tsk_verbose)
+            tsk_fprintf(stderr,
+                "parse_v2_record: record too short for fixed fields\n");
+        return 1;
+    }
+
     record->refnum = tsk_getu48(endian, rec->file_ref);
     record->refnum_seq = tsk_getu16(endian, rec->file_ref_seq);
     record->parent_refnum = tsk_getu48(endian, rec->par_ref);


### PR DESCRIPTION
This was from Claude on analysis of the open #3199 PR. 

It's analysis was that the problematic callers to the unicode conversion method had been fixed except for this one.  I'll add its analysis to that story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved structured parsing of change journal records for more reliable record handling.

* **Bug Fixes**
  * Added defensive checks when processing on-disk filename fields; out-of-range or malformed name data is now skipped and (when verbose) logged to prevent invalid conversions or crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->