### PR TITLE
Added verbose statement for FAT failing 8.3 name check

### DIFF
--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -293,8 +293,14 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
         }
 		
 		else if((a_fatfs->subtype == TSK_FATFS_SUBTYPE_SPEC) &&
-                (is_83_name(dentry, strict) == 0))
-			return 0;
+                (is_83_name(dentry, strict) == 0)) {
+            if (!strict) {
+                tsk_fprintf(stderr,
+                    "%s: skipping entry in allocated directory with invalid 8.3 name\n",
+                    func_name);
+            }
+            return 0;
+        }
 
         // basic sanity check on values
         else if ((tsk_getu16(fs->endian, dentry->ctime) == 0)

--- a/tsk/fs/fatxxfs_meta.c
+++ b/tsk/fs/fatxxfs_meta.c
@@ -294,7 +294,7 @@ fatxxfs_is_dentry(FATFS_INFO *a_fatfs, FATFS_DENTRY *a_dentry, FATFS_DATA_UNIT_A
 		
 		else if((a_fatfs->subtype == TSK_FATFS_SUBTYPE_SPEC) &&
                 (is_83_name(dentry, strict) == 0)) {
-            if (!strict) {
+            if (!strict && tsk_verbose) {
                 tsk_fprintf(stderr,
                     "%s: skipping entry in allocated directory with invalid 8.3 name\n",
                     func_name);


### PR DESCRIPTION
Adds verbose statement for ##3495 and #3395. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic output: when verbose mode is enabled, the tool now emits a warning for certain rejected legacy-style filenames, aiding analysis while preserving existing validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->