### PR TITLE
[main] Backport CVE-2026-40024: tsk_recover path traversal sanitization

### DIFF
--- a/tools/autotools/tsk_recover.cpp
+++ b/tools/autotools/tsk_recover.cpp
@@ -47,6 +47,17 @@ usage()
     exit(1);
 }
 
+
+// special characters we do not want to have in the name when writing out. 
+#ifdef TSK_WIN32
+#define TSK_IS_SPL_FILE_CHAR(x) \
+    (((x) == 0x3A) || ((x) == 0x5C))
+#else
+#define TSK_IS_SPL_FILE_CHAR(x) \
+    ((x) == 0x2F) 
+#endif
+
+
 #ifdef TSK_WIN32
 #include <windows.h>
 #include "shlobj.h"
@@ -142,8 +153,20 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
 
     // clean up any control characters
     for (size_t i = 0; i < ilen; i++) {
-        if (TSK_IS_CNTRL(path8[i]))
+        if (TSK_IS_CNTRL(path8[i])) {
             path8[i] = '^';
+        }
+
+        if (path8[i] == '/')
+            path8[i] = '\\';
+
+        // make sure there is no \..\ path traversal
+        if (i + 4 < ilen) {
+            if ((path8[i] == '\\') && (path8[i+1] == '.') && (path8[i+2] == '.') && (path8[i+3] == '\\')) {
+                path8[i+1] = '^';
+                path8[i+2] = '^';
+            }
+        }
     }
 
     //convert path from utf8 to utf16
@@ -175,6 +198,8 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     for (size_t i = 0; i < len; i++) {
         if (path16full[i] == L'/')
             path16full[i] = L'\\';
+
+        // break at path seperator to make that directory
         if (((i > 0) && (path16full[i] == L'\\') && (path16full[i - 1] != L'\\'))
             || ((path16full[i] != L'\\') && (i == len - 1))) {
             uint8_t
@@ -204,8 +229,10 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     char name8[FILENAME_MAX + 1];
     strncpy(name8, a_fs_file->name->name, FILENAME_MAX);
     for (int i = 0; name8[i] != '\0'; i++) {
-        if (TSK_IS_CNTRL(name8[i]))
+        //make sure there is no slash, which could lead to path traversal
+        if (TSK_IS_CNTRL(name8[i]) || TSK_IS_SPL_FILE_CHAR(name8[i])) {
             name8[i] = '^';
+        }
     }
 
     //convert file name from utf8 to utf16
@@ -266,13 +293,23 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     for (size_t i = 0; i < strlen(fbuf); i++) {
         if (TSK_IS_CNTRL(fbuf[i]))
             fbuf[i] = '^';
+
+        // make sure there is no /../ path traversal 
+        if (i + 4 < strlen(fbuf)) {
+            if ((fbuf[i] == '/') && (fbuf[i+1] == '.') && (fbuf[i+2] == '.') && (fbuf[i+3] == '/')) {
+                fbuf[i+1] = '^';
+                fbuf[i+2] = '^';
+            }
+        }
     }
 
     // see if the directory already exists. Create, if not.
+    // and all of the missing layers
     if (0 != lstat(fbuf, &statds)) {
         size_t
             len = strlen(fbuf);
         for (size_t i = 0; i < len; i++) {
+            // stop if we are at a path separator to make that folder
             if (((i > 0) && (fbuf[i] == '/') && (fbuf[i - 1] != '/'))
                 || ((fbuf[i] != '/') && (i == len - 1))) {
                 uint8_t
@@ -299,14 +336,16 @@ uint8_t TskRecover::writeFile(TSK_FS_FILE * a_fs_file, const char *a_path)
     if (fbuf[strlen(fbuf) - 1] != '/')
         strncat(fbuf, "/", PATH_MAX - strlen(fbuf)-1);
 
+    int nstart = strlen(fbuf);
     strncat(fbuf, a_fs_file->name->name, PATH_MAX - strlen(fbuf)-1);
 
     //do name mangling of the file name that was just added
-    for (int i = strlen(fbuf)-1; fbuf[i] != '/'; i--) {
-        if (TSK_IS_CNTRL(fbuf[i]))
+    for (int i = nstart; fbuf[i] != '\0'; i++) {
+        // need to make sure it doesn't have any slashes in it, which could lead 
+        // to path traversal
+        if (TSK_IS_CNTRL(fbuf[i]) || TSK_IS_SPL_FILE_CHAR(fbuf[i]))
             fbuf[i] = '^';
     }
-
 
     // open the file
     if ((hFile = fopen(fbuf, "w+")) == NULL) {


### PR DESCRIPTION
backports `a3f96b3bc36a` to `main` for CVE-2026-40024 (refs #3500).

see #3500 for Docker A/B: raw-edited ext2 image with `../../../tmp/evil` as on-disk dirent name. pre-fix tsk_recover writes outside export dir; post-fix sanitizes path components.

upstream: https://github.com/sleuthkit/sleuthkit/commit/a3f96b3bc36a
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-40024

clean cherry-pick. no local test run.