### PR TITLE
 TSK batch insert: CaseDbAccessManager.addToBatch/insertBatch, Blackboard.newDataArtifacts, SleuthkitCase.addFileSystemFiles

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
@@ -20,15 +20,18 @@ package org.sleuthkit.datamodel;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -40,8 +43,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.sleuthkit.datamodel.BlackboardAttribute.TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE;
 import org.sleuthkit.datamodel.SleuthkitCase.CaseDbConnection;
 import org.sleuthkit.datamodel.SleuthkitCase.CaseDbTransaction;
+import org.sleuthkit.datamodel.TskData.DbType;
+import org.sleuthkit.datamodel.TskData.ObjectType;
 import static org.sleuthkit.datamodel.SleuthkitCase.closeConnection;
 import static org.sleuthkit.datamodel.SleuthkitCase.closeResultSet;
 import static org.sleuthkit.datamodel.SleuthkitCase.closeStatement;
@@ -67,6 +73,27 @@ public final class Blackboard {
 	private final Map<String, BlackboardAttribute.Type> typeNameToAttributeTypeMap = new ConcurrentHashMap<>();
 
 	static final int MIN_USER_DEFINED_TYPE_ID = 10000;
+
+	/**
+	 * Maximum number of artifacts per PostgreSQL batch chunk in
+	 * {@link #newDataArtifacts}. Internal chunking unit; callers may pass any
+	 * size and the method partitions internally.
+	 *
+	 * Sized to keep all per-chunk INSERTs well under PostgreSQL's 65,535
+	 * bind-parameter ceiling: blackboard_artifacts has 5 bind columns, so
+	 * 9000 rows = 45,000 parameters per batched statement.
+	 */
+	static final int PG_CHUNK_SIZE = 9000;
+
+	/**
+	 * Maximum number of attributes per PostgreSQL batch chunk in the
+	 * per-value-type attribute INSERT loop. Independent of
+	 * {@link #PG_CHUNK_SIZE}.
+	 *
+	 * Sized for attribute INSERTs (7 bind columns per row): 5000 rows =
+	 * 35,000 parameters, well under the 65,535 ceiling.
+	 */
+	static final int PG_ATTR_CHUNK_SIZE = 5000;
 
 	private final SleuthkitCase caseDb;
 
@@ -1080,7 +1107,7 @@ public final class Blackboard {
 	}
 	
 	/**
-	 * Ignore the score of the specified analysis result.Updates “ignore_score”
+	 * Ignore the score of the specified analysis result.Updates ï¿½ignore_scoreï¿½
 	 * field in tsk_analysis_results table, and recalculates and updates the
 	 * aggregate score of the content.
 	 *
@@ -1113,7 +1140,7 @@ public final class Blackboard {
 	/**
 	 * Ignore the score of the specified analysis result.
 	 *
-	 * Updates “ignore_score” field in tsk_analysis_results table,
+	 * Updates ï¿½ignore_scoreï¿½ field in tsk_analysis_results table,
 	 * and recalculates and updates the aggregate score of the content. Fires an
 	 * event to indicate that the analysis result score is being ignored and that the
 	 * score of the item has changed.
@@ -1140,7 +1167,7 @@ public final class Blackboard {
 	/**
 	 * Ignore the score of the specified analysis result.
 	 *
-	 * Updates “ignore_score” field in tsk_analysis_results table,
+	 * Updates ï¿½ignore_scoreï¿½ field in tsk_analysis_results table,
 	 * and recalculates and updates the aggregate score of the content. Fires an
 	 * event to indicate that the analysis result score is being ignored and that the
 	 * score of the item has changed.
@@ -2459,9 +2486,7 @@ public final class Blackboard {
 
 				// Add a row in tsk_data_artifact if the os account is present
 				if (osAccountObjId != null) {
-					String insertDataArtifactSQL = "INSERT INTO tsk_data_artifacts (artifact_obj_id, os_account_obj_id) VALUES (?, ?)";
-
-					statement = connection.getPreparedStatement(insertDataArtifactSQL, Statement.NO_GENERATED_KEYS);
+					statement = caseDb.getInsertDataArtifactStatement(connection);
 					statement.clearParameters();
 
 					statement.setLong(1, artifact_obj_id);
@@ -2483,6 +2508,391 @@ public final class Blackboard {
 			}
 		} catch (SQLException ex) {
 			throw new TskCoreException(String.format("Error creating a data artifact with type id = %d, objId = %d, and data source oj id = %d ", artifactType.getTypeID(), sourceObjId, dataSourceObjId), ex);
+		}
+	}
+
+	/**
+	 * Bulk variant of {@link #newDataArtifact}: creates many DataArtifacts
+	 * under one caller-managed transaction.
+	 *
+	 * <p><strong>PostgreSQL behavior:</strong> partitions the input at
+	 * {@value #PG_CHUNK_SIZE} and uses sequence pre-allocation plus batched
+	 * INSERTs to amortize round trips across many artifacts. Each chunk runs
+	 * a fixed handful of round trips regardless of chunk size (1 ID reserve,
+	 * 1 tsk_objects batch, 1 blackboard_artifacts batch, optionally 1
+	 * tsk_data_artifacts batch, plus one batch per attribute value type).</p>
+	 *
+	 * <p><strong>SQLite behavior:</strong> delegates to the single-row
+	 * {@link #newDataArtifact} for each request. SQLite's in-process driver
+	 * makes cross-row batching unprofitable.</p>
+	 *
+	 * <p><strong>Return order:</strong> the returned list matches input order
+	 * element-for-element.</p>
+	 *
+	 * <p><strong>Attribute handling:</strong> attributes (if any) are
+	 * persisted in blackboard_attributes and added to each artifact's
+	 * in-memory attribute cache â€” identical to the single-row contract.</p>
+	 *
+	 * <p><strong>Failure semantics:</strong> on a
+	 * {@link java.sql.BatchUpdateException} mid-batch the exception is
+	 * wrapped in {@link TskCoreException} and the caller's transaction
+	 * should be rolled back. Individual-row attribution within a failed
+	 * batch is not preserved: with {@code reWriteBatchedInserts=true} the
+	 * driver sends the batch as one wire-level statement which is
+	 * all-or-nothing.</p>
+	 *
+	 * @param requests    Per-artifact request data. May be empty (returns an
+	 *                    empty list immediately). Must not be null.
+	 * @param transaction Caller-managed transaction. Must not be null.
+	 *
+	 * @return DataArtifacts in input order; same size as {@code requests}.
+	 *
+	 * @throws TskCoreException If any request has a non-DATA_ARTIFACT
+	 *                          category, or on any underlying SQL failure.
+	 */
+	@Beta
+	public List<DataArtifact> newDataArtifacts(List<NewDataArtifactRequest> requests, final CaseDbTransaction transaction) throws TskCoreException {
+
+		if (requests == null) {
+			throw new TskCoreException("requests list is required");
+		}
+		if (transaction == null) {
+			throw new TskCoreException("transaction is required");
+		}
+		if (requests.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		for (NewDataArtifactRequest r : requests) {
+			if (r.artifactType.getCategory() != BlackboardArtifact.Category.DATA_ARTIFACT) {
+				throw new TskCoreException(String.format("Artifact type (name = %s) is not of Data Artifact category. ", r.artifactType.getTypeName()));
+			}
+		}
+
+		if (caseDb.getDatabaseType() == DbType.POSTGRESQL) {
+			List<DataArtifact> out = new ArrayList<>(requests.size());
+			for (List<NewDataArtifactRequest> chunk : Lists.partition(requests, PG_CHUNK_SIZE)) {
+				out.addAll(newDataArtifactsBatchedPostgres(chunk, transaction));
+			}
+			return out;
+		}
+
+		// SQLite: per-row delegation against the same caller-owned transaction.
+		List<DataArtifact> out = new ArrayList<>(requests.size());
+		for (NewDataArtifactRequest r : requests) {
+			out.add(newDataArtifact(r.artifactType, r.sourceObjId, r.dataSourceObjId, r.attributes, r.osAccountObjId, r.osAccountInstanceType, transaction));
+		}
+		return out;
+	}
+
+	/**
+	 * PostgreSQL-only batched implementation of {@link #newDataArtifacts}.
+	 *
+	 * <p>Does NOT acquire {@code acquireSingleUserCaseWriteLock}. That lock
+	 * historically serializes API calls against a shared SleuthkitCase
+	 * instance, motivated by single-user SQLite-mode process concurrency. On
+	 * PostgreSQL with a caller-owned {@link CaseDbTransaction} the connection
+	 * already serializes its own writes and PostgreSQL sequence atomicity
+	 * handles cross-connection concurrency. Reintroducing the lock here would
+	 * serialize concurrent batched calls and defeat the throughput win.</p>
+	 *
+	 * @param requests    Pre-chunked to size &le; {@link #PG_CHUNK_SIZE}.
+	 *                    Must be non-empty.
+	 * @param transaction Caller-managed transaction.
+	 */
+	private List<DataArtifact> newDataArtifactsBatchedPostgres(List<NewDataArtifactRequest> requests, CaseDbTransaction transaction) throws TskCoreException {
+
+		int n = requests.size();
+		CaseDbConnection connection = transaction.getConnection();
+		long[] objIds = new long[n];
+		long[] artifactIds = new long[n];
+
+		try {
+			// Step 1: reserve N obj_ids + N artifact_ids in one round trip.
+			PreparedStatement reserveStmt = caseDb.getReserveArtifactIdsStatement(connection);
+			reserveStmt.clearParameters();
+			reserveStmt.setInt(1, n);
+			try (ResultSet rs = reserveStmt.executeQuery()) {
+				int i = 0;
+				while (rs.next()) {
+					if (i >= n) {
+						throw new TskCoreException("Reserve query returned more than " + n + " rows");
+					}
+					objIds[i] = rs.getLong("obj_id");
+					artifactIds[i] = rs.getLong("artifact_id");
+					i++;
+				}
+				if (i != n) {
+					throw new TskCoreException("Reserve query returned " + i + " rows, expected " + n);
+				}
+			}
+
+			// Step 2: batch INSERT into tsk_objects with explicit obj_ids.
+			// Null-on-zero parent mirrors SleuthkitCase.addObject:6747-6751.
+			PreparedStatement objStmt = caseDb.getInsertObjectWithIdStatement(connection);
+			objStmt.clearBatch();
+			for (int i = 0; i < n; i++) {
+				NewDataArtifactRequest r = requests.get(i);
+				objStmt.clearParameters();
+				objStmt.setLong(1, objIds[i]);
+				if (r.sourceObjId != 0) {
+					objStmt.setLong(2, r.sourceObjId);
+				} else {
+					objStmt.setNull(2, Types.BIGINT);
+				}
+				objStmt.setInt(3, ObjectType.ARTIFACT.getObjectType());
+				objStmt.addBatch();
+			}
+			try {
+				objStmt.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("Batched newDataArtifacts: tsk_objects INSERT failed (chunk size " + n + ")", ex);
+			}
+
+			// Step 3: batch INSERT into blackboard_artifacts with explicit artifact_ids.
+			// Reuses INSERT_ARTIFACT (the SQLite-shape entry); BIGSERIAL columns accept explicit values.
+			PreparedStatement artStmt = caseDb.getInsertArtifactStatement(connection);
+			artStmt.clearBatch();
+			for (int i = 0; i < n; i++) {
+				NewDataArtifactRequest r = requests.get(i);
+				artStmt.clearParameters();
+				artStmt.setLong(1, artifactIds[i]);
+				artStmt.setLong(2, r.sourceObjId);
+				artStmt.setLong(3, objIds[i]);
+				if (r.dataSourceObjId != null) {
+					artStmt.setLong(4, r.dataSourceObjId);
+				} else {
+					artStmt.setNull(4, Types.BIGINT);
+				}
+				artStmt.setInt(5, r.artifactType.getTypeID());
+				artStmt.addBatch();
+			}
+			try {
+				artStmt.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("Batched newDataArtifacts: blackboard_artifacts INSERT failed (chunk size " + n + ")", ex);
+			}
+
+			// Step 4: batch INSERT into tsk_data_artifacts for requests with an osAccountObjId.
+			PreparedStatement daStmt = null;
+			int daCount = 0;
+			for (int i = 0; i < n; i++) {
+				NewDataArtifactRequest r = requests.get(i);
+				if (r.osAccountObjId == null) {
+					continue;
+				}
+				if (daStmt == null) {
+					daStmt = caseDb.getInsertDataArtifactStatement(connection);
+					daStmt.clearBatch();
+				}
+				daStmt.clearParameters();
+				daStmt.setLong(1, objIds[i]);
+				daStmt.setLong(2, r.osAccountObjId);
+				daStmt.addBatch();
+				daCount++;
+			}
+			if (daStmt != null) {
+				try {
+					daStmt.executeBatch();
+				} catch (SQLException ex) {
+					throw new TskCoreException("Batched newDataArtifacts: tsk_data_artifacts INSERT failed (rows: " + daCount + ")", ex);
+				}
+			}
+
+			// Step 5: OS account instance side-effect, per row. CT hot paths pass
+			// null osAccountInstanceType, making this loop a no-op. Kept for parity
+			// with the single-row contract.
+			for (int i = 0; i < n; i++) {
+				NewDataArtifactRequest r = requests.get(i);
+				if (r.osAccountObjId != null && r.osAccountInstanceType != null) {
+					caseDb.getOsAccountManager().newOsAccountInstance(r.osAccountObjId, r.dataSourceObjId, r.osAccountInstanceType, connection);
+				}
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("Batched newDataArtifacts: SQL error during chunk of size " + n, ex);
+		}
+
+		// Step 6: update the parent-has-children bitset for unique parents.
+		Set<Long> uniqueParents = new HashSet<>();
+		for (NewDataArtifactRequest r : requests) {
+			uniqueParents.add(r.sourceObjId);
+		}
+		caseDb.markParentsHaveChildren(uniqueParents);
+
+		// Step 7: construct DataArtifact result list. isNew=true sets
+		// loadedCacheFromDb=true on each artifact so the attribute cache is
+		// authoritative (never lazy-loaded from DB).
+		List<DataArtifact> out = new ArrayList<>(n);
+		for (int i = 0; i < n; i++) {
+			NewDataArtifactRequest r = requests.get(i);
+			out.add(new DataArtifact(caseDb, artifactIds[i], r.sourceObjId, objIds[i], r.dataSourceObjId, r.artifactType.getTypeID(), r.artifactType.getTypeName(), r.artifactType.getDisplayName(), BlackboardArtifact.ReviewStatus.UNDECIDED, r.osAccountObjId, true));
+		}
+
+		// Step 8: batched attribute INSERTs + cache update.
+		addAttributesBatched(out, requests, connection);
+
+		return out;
+	}
+
+	/**
+	 * Persists attributes from {@code requests} in batches and updates each
+	 * artifact's in-memory attribute cache.
+	 *
+	 * <p>Attributes are grouped by
+	 * {@link TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE} so each bucket can be
+	 * INSERTed against a single prepared statement. Bucket size is
+	 * inner-capped at {@link #PG_ATTR_CHUNK_SIZE} for bind-parameter safety.
+	 * Within a bucket, attribute order across artifacts is not preserved â€”
+	 * row order in {@code blackboard_attributes} is not part of any API
+	 * contract.</p>
+	 *
+	 * <p>After successful persistence, calls
+	 * {@link BlackboardArtifact#markAttributesAdded} on each artifact with
+	 * non-empty attributes â€” mirroring the cache mutation in
+	 * {@link BlackboardArtifact#addAttributes}.</p>
+	 *
+	 * <p>For CT hot paths (windowsEvent / logonSession) the per-request
+	 * attribute list is empty, so this method allocates nothing and returns
+	 * immediately.</p>
+	 *
+	 * @param artifacts  Just-created artifacts, one per request, in input order.
+	 * @param requests   Original chunk of requests (carries the attribute lists).
+	 * @param connection Case DB connection bound to the caller's transaction.
+	 */
+	private void addAttributesBatched(List<DataArtifact> artifacts, List<NewDataArtifactRequest> requests, CaseDbConnection connection) throws TskCoreException {
+
+		// Lazy allocation: skip all heap work when no request has attributes.
+		EnumMap<TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE, List<PendingAttr>> grouped = null;
+
+		for (int i = 0; i < requests.size(); i++) {
+			Collection<BlackboardAttribute> attrs = requests.get(i).attributes;
+			if (attrs == null || attrs.isEmpty()) {
+				continue;
+			}
+			long artifactId = artifacts.get(i).getArtifactID();
+			int artifactTypeId = requests.get(i).artifactType.getTypeID();
+			if (grouped == null) {
+				grouped = new EnumMap<>(TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.class);
+			}
+			for (BlackboardAttribute a : attrs) {
+				a.setArtifactId(artifactId);
+				a.setCaseDatabase(caseDb);
+				TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE valueType = a.getAttributeType().getValueType();
+				grouped.computeIfAbsent(valueType, k -> new ArrayList<>()).add(new PendingAttr(artifactId, artifactTypeId, a));
+			}
+		}
+
+		if (grouped == null) {
+			return;
+		}
+
+		try {
+			for (Map.Entry<TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE, List<PendingAttr>> entry : grouped.entrySet()) {
+				TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE valueType = entry.getKey();
+				List<PendingAttr> bucket = entry.getValue();
+				PreparedStatement ps = caseDb.getInsertAttributeStatement(connection, valueType);
+
+				// Inner-chunk to stay safely under PostgreSQL's bind-param ceiling.
+				for (List<PendingAttr> chunk : Lists.partition(bucket, PG_ATTR_CHUNK_SIZE)) {
+					ps.clearBatch();
+					for (PendingAttr p : chunk) {
+						BlackboardAttribute a = p.attr;
+						ps.clearParameters();
+						ps.setLong(1, p.artifactId);
+						ps.setInt(2, p.artifactTypeId);
+						ps.setString(3, a.getSourcesCSV());
+						ps.setString(4, "");
+						ps.setInt(5, a.getAttributeType().getTypeID());
+						ps.setLong(6, a.getAttributeType().getValueType().getType());
+						switch (valueType) {
+							case STRING:
+							case JSON:
+								ps.setString(7, a.getValueString());
+								break;
+							case BYTE:
+								ps.setBytes(7, a.getValueBytes());
+								break;
+							case INTEGER:
+								ps.setInt(7, a.getValueInt());
+								break;
+							case LONG:
+							case DATETIME:
+								ps.setLong(7, a.getValueLong());
+								break;
+							case DOUBLE:
+								ps.setDouble(7, a.getValueDouble());
+								break;
+							default:
+								throw new TskCoreException("Unrecognized attribute value type: " + valueType);
+						}
+						ps.addBatch();
+					}
+					try {
+						ps.executeBatch();
+					} catch (SQLException ex) {
+						throw new TskCoreException("Batched newDataArtifacts: blackboard_attributes INSERT failed (value type " + valueType + ", rows " + chunk.size() + ")", ex);
+					}
+				}
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("Batched newDataArtifacts: SQL error during attribute INSERTs", ex);
+		}
+
+		// Cache update mirrors BlackboardArtifact.addAttributes line 520.
+		for (int i = 0; i < requests.size(); i++) {
+			Collection<BlackboardAttribute> attrs = requests.get(i).attributes;
+			if (attrs != null && !attrs.isEmpty()) {
+				artifacts.get(i).markAttributesAdded(attrs);
+			}
+		}
+	}
+
+	/**
+	 * Per-artifact request data for {@link Blackboard#newDataArtifacts}.
+	 *
+	 * Field semantics match the parameters of the 7-arg single-row
+	 * {@link Blackboard#newDataArtifact(BlackboardArtifact.Type, long, Long,
+	 * Collection, Long, OsAccountInstance.OsAccountInstanceType,
+	 * CaseDbTransaction)}.
+	 */
+	public static final class NewDataArtifactRequest {
+
+		public final BlackboardArtifact.Type artifactType;
+		public final long sourceObjId;
+		public final Long dataSourceObjId;
+		public final Collection<BlackboardAttribute> attributes;
+		public final Long osAccountObjId;
+		public final OsAccountInstance.OsAccountInstanceType osAccountInstanceType;
+
+		public NewDataArtifactRequest(BlackboardArtifact.Type artifactType, long sourceObjId, Long dataSourceObjId, Collection<BlackboardAttribute> attributes, Long osAccountObjId, OsAccountInstance.OsAccountInstanceType osAccountInstanceType) {
+			if (artifactType == null) {
+				throw new IllegalArgumentException("artifactType is required");
+			}
+			this.artifactType = artifactType;
+			this.sourceObjId = sourceObjId;
+			this.dataSourceObjId = dataSourceObjId;
+			this.attributes = attributes;
+			this.osAccountObjId = osAccountObjId;
+			this.osAccountInstanceType = osAccountInstanceType;
+		}
+	}
+
+	/**
+	 * Internal carrier for an attribute pending a batched INSERT. Bundles
+	 * the artifact_id and artifact_type_id alongside the attribute so the
+	 * attribute-batch helper can stage rows without re-deriving them per
+	 * attribute.
+	 */
+	private static final class PendingAttr {
+
+		final long artifactId;
+		final int artifactTypeId;
+		final BlackboardAttribute attr;
+
+		PendingAttr(long artifactId, int artifactTypeId, BlackboardAttribute attr) {
+			this.artifactId = artifactId;
+			this.artifactTypeId = artifactTypeId;
+			this.attr = attr;
 		}
 	}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
@@ -39,10 +39,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.sleuthkit.datamodel.BlackboardAttribute.TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE;
 import org.sleuthkit.datamodel.SleuthkitCase.CaseDbConnection;
 import org.sleuthkit.datamodel.SleuthkitCase.CaseDbTransaction;
@@ -94,6 +96,13 @@ public final class Blackboard {
 	 * 35,000 parameters, well under the 65,535 ceiling.
 	 */
 	static final int PG_ATTR_CHUNK_SIZE = 5000;
+
+	/**
+	 * Maximum number of artifact_obj_ids per PostgreSQL DELETE batch in
+	 * {@link #deleteAnalysisResults}. The single bigint[] array parameter has
+	 * plenty of headroom; sized to match {@link #PG_CHUNK_SIZE}.
+	 */
+	static final int PG_DELETE_CHUNK_SIZE = 9000;
 
 	private final SleuthkitCase caseDb;
 
@@ -2759,18 +2768,18 @@ public final class Blackboard {
 	 * @param requests   Original chunk of requests (carries the attribute lists).
 	 * @param connection Case DB connection bound to the caller's transaction.
 	 */
-	private void addAttributesBatched(List<DataArtifact> artifacts, List<NewDataArtifactRequest> requests, CaseDbConnection connection) throws TskCoreException {
+	private void addAttributesBatched(List<? extends BlackboardArtifact> artifacts, List<? extends HasArtifactRequestAttributes> requests, CaseDbConnection connection) throws TskCoreException {
 
 		// Lazy allocation: skip all heap work when no request has attributes.
 		EnumMap<TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE, List<PendingAttr>> grouped = null;
 
 		for (int i = 0; i < requests.size(); i++) {
-			Collection<BlackboardAttribute> attrs = requests.get(i).attributes;
+			Collection<BlackboardAttribute> attrs = requests.get(i).getAttributes();
 			if (attrs == null || attrs.isEmpty()) {
 				continue;
 			}
 			long artifactId = artifacts.get(i).getArtifactID();
-			int artifactTypeId = requests.get(i).artifactType.getTypeID();
+			int artifactTypeId = requests.get(i).getArtifactType().getTypeID();
 			if (grouped == null) {
 				grouped = new EnumMap<>(TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.class);
 			}
@@ -2840,7 +2849,7 @@ public final class Blackboard {
 
 		// Cache update mirrors BlackboardArtifact.addAttributes line 520.
 		for (int i = 0; i < requests.size(); i++) {
-			Collection<BlackboardAttribute> attrs = requests.get(i).attributes;
+			Collection<BlackboardAttribute> attrs = requests.get(i).getAttributes();
 			if (attrs != null && !attrs.isEmpty()) {
 				artifacts.get(i).markAttributesAdded(attrs);
 			}
@@ -2855,7 +2864,7 @@ public final class Blackboard {
 	 * Collection, Long, OsAccountInstance.OsAccountInstanceType,
 	 * CaseDbTransaction)}.
 	 */
-	public static final class NewDataArtifactRequest {
+	public static final class NewDataArtifactRequest implements HasArtifactRequestAttributes {
 
 		public final BlackboardArtifact.Type artifactType;
 		public final long sourceObjId;
@@ -2874,6 +2883,492 @@ public final class Blackboard {
 			this.attributes = attributes;
 			this.osAccountObjId = osAccountObjId;
 			this.osAccountInstanceType = osAccountInstanceType;
+		}
+
+		@Override
+		public BlackboardArtifact.Type getArtifactType() {
+			return artifactType;
+		}
+
+		@Override
+		public Collection<BlackboardAttribute> getAttributes() {
+			return attributes;
+		}
+	}
+
+	/**
+	 * Adapter contract used by {@link #addAttributesBatched} to read the
+	 * attribute payload and artifact type from request DTOs without coupling the
+	 * helper to a specific request class. Package-private: it is an internal
+	 * adapter, not a public extension point. Implementations live in this file
+	 * ({@link NewDataArtifactRequest} and {@link NewAnalysisResultRequest}).
+	 */
+	interface HasArtifactRequestAttributes {
+
+		BlackboardArtifact.Type getArtifactType();
+
+		Collection<BlackboardAttribute> getAttributes();
+	}
+
+	/**
+	 * Per-AR request data for {@link Blackboard#newAnalysisResults}.
+	 *
+	 * <p>Field semantics match the parameters of the 9-arg single-row
+	 * {@link Blackboard#newAnalysisResult(BlackboardArtifact.Type, long, Long, Score,
+	 * String, String, String, Collection, CaseDbTransaction)}.</p>
+	 *
+	 * <p><strong>Multiple requests for the same parent objId are allowed.</strong>
+	 * The batched path collapses them: one aggregate-score recompute per parent
+	 * (using the max of all scores for that parent), one ScoreChange event per
+	 * upgraded parent. If two requests for the same parent specify different
+	 * {@code dataSourceObjId} values, the first-seen value wins for the
+	 * aggregate-score row's {@code data_source_obj_id} column - in practice
+	 * children share their parent's data source so this is rarely exercised.</p>
+	 */
+	public static final class NewAnalysisResultRequest implements HasArtifactRequestAttributes {
+
+		public final BlackboardArtifact.Type artifactType;
+		public final long objId;
+		public final Long dataSourceObjId;
+		public final Score score;
+		public final String conclusion;
+		public final String configuration;
+		public final String justification;
+		public final Collection<BlackboardAttribute> attributes;
+
+		public NewAnalysisResultRequest(BlackboardArtifact.Type artifactType, long objId, Long dataSourceObjId, Score score,
+				String conclusion, String configuration, String justification, Collection<BlackboardAttribute> attributes) {
+			if (artifactType == null) {
+				throw new IllegalArgumentException("artifactType is required");
+			}
+			if (score == null) {
+				throw new IllegalArgumentException("score is required");
+			}
+			if (artifactType.getCategory() != BlackboardArtifact.Category.ANALYSIS_RESULT) {
+				throw new IllegalArgumentException(String.format("Artifact type (name = %s) is not of Analysis Result category. ", artifactType.getTypeName()));
+			}
+			this.artifactType = artifactType;
+			this.objId = objId;
+			this.dataSourceObjId = dataSourceObjId;
+			this.score = score;
+			this.conclusion = conclusion;
+			this.configuration = configuration;
+			this.justification = justification;
+			this.attributes = attributes;
+		}
+
+		@Override
+		public BlackboardArtifact.Type getArtifactType() {
+			return artifactType;
+		}
+
+		@Override
+		public Collection<BlackboardAttribute> getAttributes() {
+			return attributes;
+		}
+	}
+
+	/**
+	 * Bulk variant of {@link #newAnalysisResult}: creates many AnalysisResults
+	 * under one caller-managed transaction.
+	 *
+	 * <p><strong>PostgreSQL behavior:</strong> partitions the input at
+	 * {@value #PG_CHUNK_SIZE} and uses sequence pre-allocation plus batched
+	 * INSERTs to amortize round trips (reserve ids, tsk_objects,
+	 * blackboard_artifacts, tsk_analysis_results (conditional subset), batched
+	 * attribute INSERTs grouped by value type, and a collapsed per-parent
+	 * aggregate-score recompute).</p>
+	 *
+	 * <p><strong>SQLite behavior:</strong> delegates to the single-row
+	 * {@link #newAnalysisResult} per request.</p>
+	 *
+	 * <p><strong>Return order</strong> matches input order.</p>
+	 *
+	 * <p><strong>Aggregate-score semantics:</strong> if N requests target the
+	 * same parent objId, the aggregate score is recomputed once for that parent
+	 * (max of the N scores, gated by the comparator against the current value).
+	 * All N AnalysisResultAdded entries for that parent report the same
+	 * aggregate. One ScoreChange is registered per upgraded parent with the
+	 * (currentBeforeBatch, finalAfterBatch) pair, which differs from the
+	 * sequential path's "last upward transition" semantics.</p>
+	 *
+	 * @param requests    Per-AR request data; must not be null. May be empty.
+	 * @param transaction Caller-managed transaction; must not be null.
+	 *
+	 * @return AnalysisResultAdded entries in input order; same size as requests.
+	 *
+	 * @throws BlackboardException On non-ANALYSIS_RESULT category or SQL failure.
+	 */
+	public List<AnalysisResultAdded> newAnalysisResults(List<NewAnalysisResultRequest> requests, final CaseDbTransaction transaction) throws BlackboardException {
+
+		if (requests == null) {
+			throw new BlackboardException("requests list is required");
+		}
+		if (transaction == null) {
+			throw new BlackboardException("transaction is required");
+		}
+		if (requests.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		for (NewAnalysisResultRequest r : requests) {
+			if (r.artifactType.getCategory() != BlackboardArtifact.Category.ANALYSIS_RESULT) {
+				throw new BlackboardException(String.format("Artifact type (name = %s) is not of Analysis Result category. ", r.artifactType.getTypeName()));
+			}
+		}
+
+		try {
+			if (caseDb.getDatabaseType() == DbType.POSTGRESQL) {
+				List<AnalysisResultAdded> out = new ArrayList<>(requests.size());
+				for (List<NewAnalysisResultRequest> chunk : Lists.partition(requests, PG_CHUNK_SIZE)) {
+					out.addAll(newAnalysisResultsBatchedPostgres(chunk, transaction));
+				}
+				return out;
+			}
+
+			// SQLite: per-row delegation against the same caller-owned transaction.
+			List<AnalysisResultAdded> out = new ArrayList<>(requests.size());
+			for (NewAnalysisResultRequest r : requests) {
+				out.add(newAnalysisResult(r.artifactType, r.objId, r.dataSourceObjId, r.score,
+						r.conclusion, r.configuration, r.justification, r.attributes, transaction));
+			}
+			return out;
+		} catch (TskCoreException ex) {
+			throw new BlackboardException("Failed to add analysis results in batch.", ex);
+		}
+	}
+
+	/**
+	 * PostgreSQL-only batched implementation of {@link #newAnalysisResults}.
+	 *
+	 * <p>Does NOT acquire {@code acquireSingleUserCaseWriteLock} - same rationale
+	 * as {@link #newDataArtifactsBatchedPostgres}.</p>
+	 *
+	 * @param requests    Pre-chunked to size &le; {@link #PG_CHUNK_SIZE}.
+	 * @param transaction Caller-managed transaction.
+	 */
+	private List<AnalysisResultAdded> newAnalysisResultsBatchedPostgres(List<NewAnalysisResultRequest> requests, CaseDbTransaction transaction) throws TskCoreException {
+
+		int n = requests.size();
+		CaseDbConnection connection = transaction.getConnection();
+		long[] objIds = new long[n];
+		long[] artifactIds = new long[n];
+
+		try {
+			// Step 1: reserve N obj_ids + N artifact_ids in one round trip.
+			PreparedStatement reserveStmt = caseDb.getReserveArtifactIdsStatement(connection);
+			reserveStmt.clearParameters();
+			reserveStmt.setInt(1, n);
+			try (ResultSet rs = reserveStmt.executeQuery()) {
+				int i = 0;
+				while (rs.next()) {
+					if (i >= n) {
+						throw new TskCoreException("Reserve query returned more than " + n + " rows");
+					}
+					objIds[i] = rs.getLong("obj_id");
+					artifactIds[i] = rs.getLong("artifact_id");
+					i++;
+				}
+				if (i != n) {
+					throw new TskCoreException("Reserve query returned " + i + " rows, expected " + n);
+				}
+			}
+
+			// Step 2: batch INSERT into tsk_objects with explicit obj_ids.
+			PreparedStatement objStmt = caseDb.getInsertObjectWithIdStatement(connection);
+			objStmt.clearBatch();
+			for (int i = 0; i < n; i++) {
+				NewAnalysisResultRequest r = requests.get(i);
+				objStmt.clearParameters();
+				objStmt.setLong(1, objIds[i]);
+				if (r.objId != 0) {
+					objStmt.setLong(2, r.objId);
+				} else {
+					objStmt.setNull(2, Types.BIGINT);
+				}
+				objStmt.setInt(3, ObjectType.ARTIFACT.getObjectType());
+				objStmt.addBatch();
+			}
+			try {
+				objStmt.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("Batched newAnalysisResults: tsk_objects INSERT failed (chunk size " + n + ")", ex);
+			}
+
+			// Step 3: batch INSERT into blackboard_artifacts with explicit artifact_ids.
+			PreparedStatement artStmt = caseDb.getInsertArtifactStatement(connection);
+			artStmt.clearBatch();
+			for (int i = 0; i < n; i++) {
+				NewAnalysisResultRequest r = requests.get(i);
+				artStmt.clearParameters();
+				artStmt.setLong(1, artifactIds[i]);
+				artStmt.setLong(2, r.objId);
+				artStmt.setLong(3, objIds[i]);
+				if (r.dataSourceObjId != null) {
+					artStmt.setLong(4, r.dataSourceObjId);
+				} else {
+					artStmt.setNull(4, Types.BIGINT);
+				}
+				artStmt.setInt(5, r.artifactType.getTypeID());
+				artStmt.addBatch();
+			}
+			try {
+				artStmt.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("Batched newAnalysisResults: blackboard_artifacts INSERT failed (chunk size " + n + ")", ex);
+			}
+
+			// Step 4: batch INSERT into tsk_analysis_results (conditional subset).
+			// Only requests whose score/conclusion/configuration/justification is
+			// non-default get a row (mirrors the single-row leaf at
+			// SleuthkitCase.newAnalysisResult).
+			PreparedStatement arStmt = null;
+			int arCount = 0;
+			for (int i = 0; i < n; i++) {
+				NewAnalysisResultRequest r = requests.get(i);
+				boolean needsRow = r.score.getSignificance() != Score.Significance.UNKNOWN
+						|| !StringUtils.isBlank(r.conclusion)
+						|| !StringUtils.isBlank(r.configuration)
+						|| !StringUtils.isBlank(r.justification);
+				if (!needsRow) {
+					continue;
+				}
+				if (arStmt == null) {
+					arStmt = caseDb.getInsertAnalysisResultStatement(connection);
+					arStmt.clearBatch();
+				}
+				arStmt.clearParameters();
+				arStmt.setLong(1, objIds[i]);
+				arStmt.setString(2, (r.conclusion != null) ? r.conclusion : "");
+				arStmt.setInt(3, r.score.getSignificance().getId());
+				arStmt.setInt(4, r.score.getPriority().getId());
+				arStmt.setString(5, (r.configuration != null) ? r.configuration : "");
+				arStmt.setString(6, (r.justification != null) ? r.justification : "");
+				arStmt.addBatch();
+				arCount++;
+			}
+			if (arStmt != null) {
+				try {
+					arStmt.executeBatch();
+				} catch (SQLException ex) {
+					throw new TskCoreException("Batched newAnalysisResults: tsk_analysis_results INSERT failed (rows: " + arCount + ")", ex);
+				}
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("Batched newAnalysisResults: SQL error during chunk of size " + n, ex);
+		}
+
+		// Step 5: update the parent-has-children bitset for unique parents.
+		// In-memory only; not rollback-safe (same as newDataArtifactsBatchedPostgres).
+		Set<Long> uniqueParents = new HashSet<>();
+		for (NewAnalysisResultRequest r : requests) {
+			uniqueParents.add(r.objId);
+		}
+		caseDb.markParentsHaveChildren(uniqueParents);
+
+		// Step 6: construct AnalysisResult result list. isNew=true sets
+		// loadedCacheFromDb=true so the attribute cache is authoritative.
+		List<AnalysisResult> analysisResults = new ArrayList<>(n);
+		for (int i = 0; i < n; i++) {
+			NewAnalysisResultRequest r = requests.get(i);
+			analysisResults.add(new AnalysisResult(caseDb, artifactIds[i], r.objId, objIds[i], r.dataSourceObjId,
+					r.artifactType.getTypeID(), r.artifactType.getTypeName(), r.artifactType.getDisplayName(),
+					BlackboardArtifact.ReviewStatus.UNDECIDED, true,
+					r.score, (r.conclusion != null) ? r.conclusion : "",
+					(r.configuration != null) ? r.configuration : "", (r.justification != null) ? r.justification : ""));
+		}
+
+		// Step 7: batched attribute INSERTs + cache update (reuses generalized helper).
+		addAttributesBatched(analysisResults, requests, connection);
+
+		// Step 8: batched aggregate-score collapse + ScoreChange registration.
+		Map<Long, Score> finalScorePerParent = caseDb.getScoringManager().updateAggregateScoresAfterAdditions(requests, transaction);
+
+		// Step 9: build AnalysisResultAdded list using each parent's final aggregate.
+		List<AnalysisResultAdded> out = new ArrayList<>(n);
+		for (int i = 0; i < n; i++) {
+			out.add(new AnalysisResultAdded(analysisResults.get(i), finalScorePerParent.get(requests.get(i).objId)));
+		}
+		return out;
+	}
+
+	/**
+	 * Bulk variant of {@link #deleteAnalysisResult(long, CaseDbTransaction)}:
+	 * deletes many analysis results and recomputes the aggregate score once per
+	 * unique parent objId.
+	 *
+	 * <p><strong>PostgreSQL behavior:</strong> partitions input at
+	 * {@value #PG_DELETE_CHUNK_SIZE}; each chunk runs a bulk SELECT to resolve
+	 * parent objIds, one batched DELETE (FK CASCADE handles dependent tables),
+	 * then one aggregate-score recompute per unique parent.</p>
+	 *
+	 * <p><strong>SQLite behavior:</strong> delegates to single-row
+	 * {@link #deleteAnalysisResult(long, CaseDbTransaction)} per id.</p>
+	 *
+	 * <p><strong>Tolerance:</strong> artifact_obj_ids that do not exist in
+	 * blackboard_artifacts are silently skipped (logged at FINE). The result map
+	 * omits parents that had no rows to delete.</p>
+	 *
+	 * <p><strong>Aggregate-score semantics:</strong> per unique parent objId the
+	 * single-row {@link ScoringManager#updateAggregateScoreAfterDeletion} is
+	 * invoked once (parents sorted ascending by objId for deadlock avoidance).</p>
+	 *
+	 * @param artifactObjIds artifact_obj_ids to delete; must not be null. May be empty.
+	 * @param transaction    Caller-managed transaction; must not be null.
+	 *
+	 * @return Map of unique parent objId to new aggregate Score (one entry per
+	 *         parent that had at least one AR successfully deleted).
+	 *
+	 * @throws BlackboardException On SQL failure.
+	 */
+	public Map<Long, Score> deleteAnalysisResults(List<Long> artifactObjIds, CaseDbTransaction transaction) throws BlackboardException {
+
+		if (artifactObjIds == null) {
+			throw new BlackboardException("artifactObjIds list is required");
+		}
+		if (transaction == null) {
+			throw new BlackboardException("transaction is required");
+		}
+		if (artifactObjIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		try {
+			if (caseDb.getDatabaseType() == DbType.POSTGRESQL) {
+				Map<Long, Score> out = new HashMap<>();
+				for (List<Long> chunk : Lists.partition(artifactObjIds, PG_DELETE_CHUNK_SIZE)) {
+					out.putAll(deleteAnalysisResultsBatchedPostgres(chunk, transaction));
+				}
+				return out;
+			}
+
+			// SQLite: per-row delegation. Look up the parent BEFORE deleting (the
+			// row is gone afterward), then delegate to the single-row delete. If
+			// two ids share a parent the last recompute's value wins, which
+			// matches sequential semantics (each delete re-reads and recomputes).
+			Map<Long, Score> out = new HashMap<>();
+			for (Long artifactObjId : artifactObjIds) {
+				Long parentObjId = lookupParentObjIdForArtifact(artifactObjId, transaction);
+				if (parentObjId == null) {
+					LOGGER.log(Level.FINE, "deleteAnalysisResults: skipping missing artifact_obj_id {0}", artifactObjId);
+					continue;
+				}
+				Score newScore = deleteAnalysisResult(artifactObjId, transaction);
+				out.put(parentObjId, newScore);
+			}
+			return out;
+		} catch (TskCoreException ex) {
+			throw new BlackboardException("Failed to delete analysis results in batch.", ex);
+		}
+	}
+
+	/**
+	 * PostgreSQL-only batched implementation of {@link #deleteAnalysisResults}.
+	 *
+	 * @param artifactObjIds Pre-chunked to size &le; {@link #PG_DELETE_CHUNK_SIZE}.
+	 *                       Must be non-empty.
+	 * @param transaction    Caller-managed transaction.
+	 */
+	private Map<Long, Score> deleteAnalysisResultsBatchedPostgres(List<Long> artifactObjIds, CaseDbTransaction transaction) throws TskCoreException {
+
+		CaseDbConnection connection = transaction.getConnection();
+
+		// Step 1: bulk-resolve each artifact_obj_id to (parent objId, dataSourceObjId).
+		// Ids that don't exist are simply absent from the result (silent tolerance).
+		Map<Long, ParentLookup> parentByArtifactObjId = new HashMap<>();
+		try {
+			PreparedStatement ps = connection.getPreparedStatement(
+					"SELECT artifact_obj_id, obj_id, data_source_obj_id FROM blackboard_artifacts WHERE artifact_obj_id = ANY(?::bigint[])",
+					Statement.NO_GENERATED_KEYS);
+			ps.clearParameters();
+			Long[] ids = artifactObjIds.toArray(new Long[0]);
+			ps.setArray(1, connection.getConnection().createArrayOf("bigint", ids));
+			try (ResultSet rs = ps.executeQuery()) {
+				while (rs.next()) {
+					long aoid = rs.getLong("artifact_obj_id");
+					long parent = rs.getLong("obj_id");
+					long dsObjIdRaw = rs.getLong("data_source_obj_id");
+					Long dsObjId = rs.wasNull() ? null : dsObjIdRaw;
+					parentByArtifactObjId.put(aoid, new ParentLookup(parent, dsObjId));
+				}
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("Batched deleteAnalysisResults: parent-lookup SELECT failed (chunk size " + artifactObjIds.size() + ")", ex);
+		}
+
+		if (parentByArtifactObjId.isEmpty()) {
+			// All ids were missing.
+			return Collections.emptyMap();
+		}
+
+		// Step 2: batched DELETE on blackboard_artifacts. FK CASCADE handles
+		// tsk_analysis_results, blackboard_attributes, and tsk_data_artifacts.
+		try {
+			PreparedStatement ps = caseDb.getDeleteBbArtifactsByIdsStatement(connection);
+			ps.clearParameters();
+			Long[] foundIds = parentByArtifactObjId.keySet().toArray(new Long[0]);
+			ps.setArray(1, connection.getConnection().createArrayOf("bigint", foundIds));
+			ps.executeUpdate();
+		} catch (SQLException ex) {
+			throw new TskCoreException("Batched deleteAnalysisResults: DELETE failed (rows: " + parentByArtifactObjId.size() + ")", ex);
+		}
+
+		// Step 3: register one deleted-AR event per actually-deleted row. The
+		// single-row deleteAnalysisResult registers analysisResult.getObjectID()
+		// (the parent content obj_id, not the AR's own obj_id); match that so the
+		// resulting AnalysisResultsDeletedTskEvent carries the same ids.
+		for (ParentLookup p : parentByArtifactObjId.values()) {
+			transaction.registerDeletedAnalysisResult(p.parentObjId);
+		}
+
+		// Step 4: per-unique-parent aggregate-score recompute. Parents collected
+		// into a TreeSet (ascending objId order) so concurrent batches acquire
+		// FOR UPDATE locks in a consistent order and cannot deadlock.
+		Set<Long> uniqueParents = new TreeSet<>();
+		Map<Long, Long> dsObjIdByParent = new HashMap<>();
+		for (ParentLookup p : parentByArtifactObjId.values()) {
+			uniqueParents.add(p.parentObjId);
+			dsObjIdByParent.putIfAbsent(p.parentObjId, p.dataSourceObjId);
+		}
+		Map<Long, Score> out = new HashMap<>();
+		for (Long parentObjId : uniqueParents) {
+			Score newScore = caseDb.getScoringManager().updateAggregateScoreAfterDeletion(parentObjId, dsObjIdByParent.get(parentObjId), transaction);
+			out.put(parentObjId, newScore);
+		}
+		return out;
+	}
+
+	/**
+	 * Single-row helper used by the SQLite delete path to recover the parent
+	 * objId for an artifact_obj_id. The PG path resolves parents in bulk.
+	 *
+	 * @return The parent obj_id, or null if the artifact is not in
+	 *         blackboard_artifacts.
+	 */
+	private Long lookupParentObjIdForArtifact(long artifactObjId, CaseDbTransaction transaction) throws TskCoreException {
+		CaseDbConnection connection = transaction.getConnection();
+		String queryString = "SELECT obj_id FROM blackboard_artifacts WHERE artifact_obj_id = " + artifactObjId;
+		try (Statement s = connection.createStatement(); ResultSet rs = connection.executeQuery(s, queryString)) {
+			if (rs.next()) {
+				return rs.getLong("obj_id");
+			}
+			return null;
+		} catch (SQLException ex) {
+			throw new TskCoreException("deleteAnalysisResults: parent-lookup failed for artifact_obj_id " + artifactObjId, ex);
+		}
+	}
+
+	/**
+	 * Internal carrier: parent objId + dataSourceObjId for one AR being deleted.
+	 */
+	private static final class ParentLookup {
+
+		final long parentObjId;
+		final Long dataSourceObjId;
+
+		ParentLookup(long parentObjId, Long dataSourceObjId) {
+			this.parentObjId = parentObjId;
+			this.dataSourceObjId = dataSourceObjId;
 		}
 	}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/Blackboard.java
@@ -2557,7 +2557,9 @@ public final class Blackboard {
 	 * @return DataArtifacts in input order; same size as {@code requests}.
 	 *
 	 * @throws TskCoreException If any request has a non-DATA_ARTIFACT
-	 *                          category, or on any underlying SQL failure.
+	 *                          category, if any request has a null
+	 *                          {@code dataSourceObjId}, or on any underlying SQL
+	 *                          failure.
 	 */
 	@Beta
 	public List<DataArtifact> newDataArtifacts(List<NewDataArtifactRequest> requests, final CaseDbTransaction transaction) throws TskCoreException {
@@ -2573,8 +2575,14 @@ public final class Blackboard {
 		}
 
 		for (NewDataArtifactRequest r : requests) {
+			if (r == null) {
+				throw new TskCoreException("requests list contains a null NewDataArtifactRequest element");
+			}
 			if (r.artifactType.getCategory() != BlackboardArtifact.Category.DATA_ARTIFACT) {
 				throw new TskCoreException(String.format("Artifact type (name = %s) is not of Data Artifact category. ", r.artifactType.getTypeName()));
+			}
+			if (r.dataSourceObjId == null) {
+				throw new TskCoreException("dataSourceObjId cannot be null for batched data artifact creation");
 			}
 		}
 
@@ -2668,11 +2676,8 @@ public final class Blackboard {
 				artStmt.setLong(1, artifactIds[i]);
 				artStmt.setLong(2, r.sourceObjId);
 				artStmt.setLong(3, objIds[i]);
-				if (r.dataSourceObjId != null) {
-					artStmt.setLong(4, r.dataSourceObjId);
-				} else {
-					artStmt.setNull(4, Types.BIGINT);
-				}
+				// dataSourceObjId is guaranteed non-null by the validation in newDataArtifacts.
+				artStmt.setLong(4, r.dataSourceObjId);
 				artStmt.setInt(5, r.artifactType.getTypeID());
 				artStmt.addBatch();
 			}
@@ -2997,7 +3002,8 @@ public final class Blackboard {
 	 *
 	 * @return AnalysisResultAdded entries in input order; same size as requests.
 	 *
-	 * @throws BlackboardException On non-ANALYSIS_RESULT category or SQL failure.
+	 * @throws BlackboardException On non-ANALYSIS_RESULT category, on a null
+	 *                             {@code dataSourceObjId}, or on SQL failure.
 	 */
 	public List<AnalysisResultAdded> newAnalysisResults(List<NewAnalysisResultRequest> requests, final CaseDbTransaction transaction) throws BlackboardException {
 
@@ -3014,6 +3020,9 @@ public final class Blackboard {
 		for (NewAnalysisResultRequest r : requests) {
 			if (r.artifactType.getCategory() != BlackboardArtifact.Category.ANALYSIS_RESULT) {
 				throw new BlackboardException(String.format("Artifact type (name = %s) is not of Analysis Result category. ", r.artifactType.getTypeName()));
+			}
+			if (r.dataSourceObjId == null) {
+				throw new BlackboardException("dataSourceObjId cannot be null for batched analysis result creation");
 			}
 		}
 
@@ -3104,11 +3113,8 @@ public final class Blackboard {
 				artStmt.setLong(1, artifactIds[i]);
 				artStmt.setLong(2, r.objId);
 				artStmt.setLong(3, objIds[i]);
-				if (r.dataSourceObjId != null) {
-					artStmt.setLong(4, r.dataSourceObjId);
-				} else {
-					artStmt.setNull(4, Types.BIGINT);
-				}
+				// dataSourceObjId is guaranteed non-null by the validation in newAnalysisResults.
+				artStmt.setLong(4, r.dataSourceObjId);
 				artStmt.setInt(5, r.artifactType.getTypeID());
 				artStmt.addBatch();
 			}
@@ -3231,6 +3237,11 @@ public final class Blackboard {
 		}
 		if (artifactObjIds.isEmpty()) {
 			return Collections.emptyMap();
+		}
+		for (int i = 0; i < artifactObjIds.size(); i++) {
+			if (artifactObjIds.get(i) == null) {
+				throw new BlackboardException("artifactObjIds contains null element at index " + i);
+			}
 		}
 
 		try {

--- a/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/BlackboardArtifact.java
@@ -524,6 +524,21 @@ public abstract class BlackboardArtifact implements Content {
 	}
 
 	/**
+	 * Adds attributes to this artifact's in-memory cache without performing
+	 * any DB write. Internal use only — the caller is responsible for having
+	 * already written the corresponding rows to {@code blackboard_attributes}.
+	 *
+	 * Mirrors the cache mutation done by {@link #addAttributes} (line 520).
+	 * Invoked by {@link Blackboard#newDataArtifacts} after batched
+	 * attribute INSERTs have been persisted.
+	 *
+	 * @param attributes attributes already written to the DB.
+	 */
+	void markAttributesAdded(Collection<BlackboardAttribute> attributes) {
+		attrsCache.addAll(attributes);
+	}
+
+	/**
 	 * This overiding implementation returns the unique path of the parent. It
 	 * does not include the Artifact name in the unique path.
 	 *

--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDbAccessManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDbAccessManager.java
@@ -837,15 +837,129 @@ public final class CaseDbAccessManager {
 	 */
 	@Beta
 	public void insert(CaseDbPreparedStatement preparedStatement) throws TskCoreException {
-		
+
 		if (!preparedStatement.getType().equals(StatementType.INSERT)) {
 			throw new TskCoreException("CaseDbPreparedStatement has incorrect type for insert operation");
 		}
-		
+
 		try {
 			preparedStatement.getStatement().executeUpdate();
 		} catch (SQLException ex) {
 			throw new TskCoreException("Error inserting row in table " + "" + " with sql = "+ "", ex);
+		}
+	}
+
+	/**
+	 * Adds the current parameter state of the prepared statement to its
+	 * driver-side batch. Does not execute. The caller is expected to call
+	 * {@link #insertBatch} once a batch's worth of rows has been added.
+	 *
+	 * <p>Mirrors {@link #insert(CaseDbPreparedStatement)} — the statement
+	 * must be of INSERT type. Use the usual {@code setLong}/{@code setString}/...
+	 * methods on the {@code CaseDbPreparedStatement} between {@code addToBatch}
+	 * calls to bind each row. Every column should be rebound for every row.</p>
+	 *
+	 * @param preparedStatement INSERT-type case prepared statement.
+	 *
+	 * @throws TskCoreException if the statement is not of INSERT type, or
+	 *                          if the underlying {@code addBatch} call fails.
+	 */
+	@Beta
+	public void addToBatch(CaseDbPreparedStatement preparedStatement) throws TskCoreException {
+
+		if (!preparedStatement.getType().equals(StatementType.INSERT)) {
+			throw new TskCoreException("CaseDbPreparedStatement has incorrect type for batch insert operation");
+		}
+
+		try {
+			preparedStatement.getStatement().addBatch();
+		} catch (SQLException ex) {
+			throw new TskCoreException("Error adding row to batch", ex);
+		}
+	}
+
+	/**
+	 * Executes the accumulated batch on the prepared statement and returns
+	 * the per-row update counts.
+	 *
+	 * <p>On PostgreSQL with the JDBC URL parameter
+	 * {@code reWriteBatchedInserts=true} set on the case-DB connection pool,
+	 * the driver fuses the batched rows into a single multi-VALUES INSERT at
+	 * the wire level. Without that flag, {@code executeBatch} still sends one
+	 * INSERT statement per row; the round-trip cost is unchanged.</p>
+	 *
+	 * <p>This method does NOT return generated keys. Callers using batch
+	 * insert must supply their own row identifiers.</p>
+	 *
+	 * <p>Failure semantics: if the underlying {@code executeBatch} throws,
+	 * this method wraps the exception in a {@link TskCoreException}. The
+	 * transaction is left as the caller configured it; the caller is
+	 * responsible for rolling back on failure (same contract as
+	 * {@link #insert(CaseDbPreparedStatement)}).</p>
+	 *
+	 * @param preparedStatement INSERT-type case prepared statement.
+	 *
+	 * @return Per-row update counts as returned by
+	 *         {@link PreparedStatement#executeBatch}.
+	 *
+	 * @throws TskCoreException if the statement is not of INSERT type, or
+	 *                          if the underlying {@code executeBatch} fails.
+	 */
+	@Beta
+	public int[] insertBatch(CaseDbPreparedStatement preparedStatement) throws TskCoreException {
+
+		if (!preparedStatement.getType().equals(StatementType.INSERT)) {
+			throw new TskCoreException("CaseDbPreparedStatement has incorrect type for batch insert operation");
+		}
+
+		try {
+			return preparedStatement.getStatement().executeBatch();
+		} catch (SQLException ex) {
+			throw new TskCoreException("Error executing batch insert", ex);
+		}
+	}
+
+	/**
+	 * Returns a conservative upper bound on the number of rows that can be
+	 * accumulated via {@link #addToBatch} before {@link #insertBatch} must be
+	 * called.
+	 *
+	 * <p>The bound is derived from the prepared statement's parameter count
+	 * and the PostgreSQL wire-protocol ceiling of 65,535 bind parameters per
+	 * statement. With {@code reWriteBatchedInserts=true} the driver fuses
+	 * batched rows into a single multi-VALUES INSERT, and each batched row
+	 * contributes its columns as bind parameters, so the row ceiling is
+	 * approximately {@code 65,535 / columns}. A small margin is left below
+	 * the wire-level ceiling for safety.</p>
+	 *
+	 * <p>This bound does NOT account for driver-side memory pressure from
+	 * large string or blob columns. Callers writing wide rows with large
+	 * payloads (e.g. JSON, long text) should cap further at their own
+	 * discretion.</p>
+	 *
+	 * <p>SQLite has different parameter ceilings, but its JDBC driver
+	 * executes batches as a loop of single-row updates, so this bound is
+	 * not strictly necessary there; the value returned is still safe to
+	 * use.</p>
+	 *
+	 * @param preparedStatement Any case prepared statement.
+	 *
+	 * @return Maximum rows per batch driven by the PostgreSQL bind-parameter
+	 *         ceiling. Returns {@link Integer#MAX_VALUE} if the statement has
+	 *         no bind parameters.
+	 *
+	 * @throws TskCoreException if parameter metadata cannot be retrieved.
+	 */
+	@Beta
+	public int getMaxBatchSize(CaseDbPreparedStatement preparedStatement) throws TskCoreException {
+		try {
+			int paramsPerRow = preparedStatement.getStatement().getParameterMetaData().getParameterCount();
+			if (paramsPerRow <= 0) {
+				return Integer.MAX_VALUE;
+			}
+			return 65000 / paramsPerRow;
+		} catch (SQLException ex) {
+			throw new TskCoreException("Error determining max batch size for prepared statement", ex);
 		}
 	}
 

--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDbAccessManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDbAccessManager.java
@@ -957,7 +957,7 @@ public final class CaseDbAccessManager {
 			if (paramsPerRow <= 0) {
 				return Integer.MAX_VALUE;
 			}
-			return 65000 / paramsPerRow;
+			return Math.max(1, 65000 / paramsPerRow);
 		} catch (SQLException ex) {
 			throw new TskCoreException("Error determining max batch size for prepared statement", ex);
 		}

--- a/bindings/java/src/org/sleuthkit/datamodel/ScoringManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/ScoringManager.java
@@ -22,8 +22,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -113,6 +116,62 @@ public class ScoringManager {
 			}
 		} finally {
 			db.releaseSingleUserCaseReadLock();
+		}
+		return results;
+	}
+
+	/**
+	 * Bulk-reads aggregate scores for the supplied object ids in one SQL
+	 * statement, optionally with FOR UPDATE on PostgreSQL. Uses the connection
+	 * from the supplied transaction (does NOT acquire a case read lock - it is
+	 * an internal helper for the batched analysis-result paths, which run under
+	 * a caller-managed transaction).
+	 *
+	 * <p>Uses a bigint[] array parameter rather than an inline IN list so the PG
+	 * planner gets a stable plan regardless of input size. PostgreSQL only - the
+	 * SQLite batched paths delegate to the single-row methods and never call
+	 * this.</p>
+	 *
+	 * @param objIds      Object ids to read; must not be null. Empty returns an
+	 *                    empty map without issuing SQL.
+	 * @param forUpdate   If true and the DB is PostgreSQL, the SELECT is
+	 *                    decorated with FOR UPDATE for row-level locking.
+	 * @param transaction Caller-managed transaction; must not be null.
+	 *
+	 * @return Map of objId to Score for every supplied id that has a row in
+	 *         tsk_aggregate_score. Missing rows are absent from the map (callers
+	 *         treat them as SCORE_UNKNOWN).
+	 *
+	 * @throws TskCoreException
+	 */
+	Map<Long, Score> getAggregateScores(Collection<Long> objIds, boolean forUpdate, CaseDbTransaction transaction) throws TskCoreException {
+
+		if (objIds == null) {
+			throw new TskCoreException("objIds is required");
+		}
+		if (objIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		boolean isPostgres = db.getDatabaseType().equals(DbType.POSTGRESQL);
+		String queryString = "SELECT obj_id, significance, priority FROM tsk_aggregate_score WHERE obj_id = ANY(?::bigint[])"
+				+ (isPostgres && forUpdate ? " FOR UPDATE" : "");
+
+		Map<Long, Score> results = new HashMap<>();
+		CaseDbConnection connection = transaction.getConnection();
+		try {
+			PreparedStatement preparedStatement = connection.getPreparedStatement(queryString, Statement.NO_GENERATED_KEYS);
+			preparedStatement.clearParameters();
+			Long[] ids = objIds.toArray(new Long[0]);
+			preparedStatement.setArray(1, connection.getConnection().createArrayOf("bigint", ids));
+			try (ResultSet rs = preparedStatement.executeQuery()) {
+				while (rs.next()) {
+					results.put(rs.getLong("obj_id"),
+							new Score(Significance.fromID(rs.getInt("significance")), Priority.fromID(rs.getInt("priority"))));
+				}
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("Error bulk-reading aggregate scores", ex);
 		}
 		return results;
 	}
@@ -267,7 +326,136 @@ public class ScoringManager {
 			return currentAggregateScore;
 		}
 	}
-	
+
+	/**
+	 * Bulk counterpart to {@link #updateAggregateScoreAfterAddition}. Updates the
+	 * aggregate score for every parent objId touched by a batch of newly-added
+	 * analysis results, registering one ScoreChange per upgraded parent.
+	 *
+	 * <p><strong>PostgreSQL only.</strong> Collapses the per-parent recompute:
+	 * one bulk SELECT (FOR UPDATE) of the current scores, then one batched
+	 * race-safe UPSERT for the parents whose score is upgraded. The UPSERT WHERE
+	 * guard ({@code UPSERT_AGGREGATE_SCORE_IF_HIGHER}) prevents a concurrent
+	 * batch's higher score from being overwritten by our lower one.</p>
+	 *
+	 * <p><strong>ScoreChange semantics differ from the sequential path.</strong>
+	 * The sequential path emits one ScoreChange per upward step, but the
+	 * transaction's score-change map is keyed by objId so only the last step
+	 * survives commit. This batched API emits one ScoreChange per upgraded parent
+	 * with the (currentBeforeBatch, finalAfterBatch) pair. Different, equally
+	 * valid; documented for reviewer awareness.</p>
+	 *
+	 * <p>If two requests for the same parent specify different dataSourceObjId
+	 * values, the first-seen value is used for the aggregate-score row.</p>
+	 *
+	 * @param requests    The batch of analysis-result requests. Empty is a no-op
+	 *                    returning an empty map.
+	 * @param transaction Caller-managed transaction.
+	 *
+	 * @return Map of every parent objId in the input to its final aggregate score
+	 *         (upgraded or unchanged). Callers use this to populate the per-AR
+	 *         AnalysisResultAdded aggregate score.
+	 *
+	 * @throws TskCoreException
+	 */
+	Map<Long, Score> updateAggregateScoresAfterAdditions(List<Blackboard.NewAnalysisResultRequest> requests, CaseDbTransaction transaction) throws TskCoreException {
+
+		if (requests == null) {
+			throw new TskCoreException("requests is required");
+		}
+		if (requests.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		// Step A: group by parent objId; max-merge scores; first-seen dataSourceObjId.
+		Map<Long, Score> maxNewScorePerParent = new HashMap<>();
+		Map<Long, Long> dataSourceObjIdPerParent = new HashMap<>();
+		for (Blackboard.NewAnalysisResultRequest r : requests) {
+			maxNewScorePerParent.merge(r.objId, r.score,
+					(a, b) -> Score.getScoreComparator().compare(a, b) > 0 ? a : b);
+			dataSourceObjIdPerParent.putIfAbsent(r.objId, r.dataSourceObjId);
+		}
+
+		boolean isPostgres = db.getDatabaseType().equals(DbType.POSTGRESQL);
+
+		// Step B: bulk-read current scores with FOR UPDATE on PG.
+		Map<Long, Score> currentScorePerParent = getAggregateScores(maxNewScorePerParent.keySet(), isPostgres, transaction);
+
+		// Step C: classify upgraded vs unchanged. Mirrors the single-row decision
+		// in updateAggregateScoreAfterAddition: a previously-Unknown parent is
+		// upgraded by any non-Unknown score; otherwise the comparator decides.
+		// NOTE: Score has no equals() override, so the Unknown test uses compareTo.
+		List<Long> upgradedParents = new ArrayList<>();
+		Map<Long, Score> finalScorePerParent = new HashMap<>();
+		for (Map.Entry<Long, Score> e : maxNewScorePerParent.entrySet()) {
+			Long objId = e.getKey();
+			Score maxNew = e.getValue();
+			Score current = currentScorePerParent.getOrDefault(objId, Score.SCORE_UNKNOWN);
+			boolean upgrade = (current.compareTo(Score.SCORE_UNKNOWN) == 0 && maxNew.compareTo(Score.SCORE_UNKNOWN) != 0)
+					|| Score.getScoreComparator().compare(maxNew, current) > 0;
+			if (upgrade) {
+				upgradedParents.add(objId);
+				finalScorePerParent.put(objId, maxNew);
+			} else {
+				finalScorePerParent.put(objId, current);
+			}
+		}
+
+		// Step D: batched race-safe UPSERT for upgraded parents only.
+		if (!upgradedParents.isEmpty()) {
+			try {
+				PreparedStatement preparedStatement = db.getUpsertAggregateScoreIfHigherStatement(transaction.getConnection());
+				preparedStatement.clearBatch();
+				for (Long objId : upgradedParents) {
+					Score finalScore = finalScorePerParent.get(objId);
+					Long dsObjId = dataSourceObjIdPerParent.get(objId);
+					preparedStatement.clearParameters();
+					preparedStatement.setLong(1, objId);
+					if (dsObjId != null) {
+						preparedStatement.setLong(2, dsObjId);
+					} else {
+						preparedStatement.setNull(2, Types.BIGINT);
+					}
+					preparedStatement.setInt(3, finalScore.getSignificance().getId());
+					preparedStatement.setInt(4, finalScore.getPriority().getId());
+					preparedStatement.setInt(5, finalScore.getSignificance().getId());
+					preparedStatement.setInt(6, finalScore.getPriority().getId());
+					preparedStatement.addBatch();
+				}
+				preparedStatement.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("Batched updateAggregateScoresAfterAdditions: UPSERT failed (rows: "
+						+ upgradedParents.size() + ")", ex);
+			}
+		}
+
+		// Step E: register one ScoreChange per upgraded parent. The WHERE guard in
+		// step D may have suppressed an upgrade if a concurrent batch wrote a
+		// higher score between our SELECT and our UPSERT. Re-read the upgraded
+		// parents to discover the actual final score for the return value, and
+		// only register a ScoreChange when our write actually took effect.
+		if (!upgradedParents.isEmpty()) {
+			Map<Long, Score> recheck = getAggregateScores(upgradedParents, false, transaction);
+			for (Long objId : upgradedParents) {
+				Score actual = recheck.getOrDefault(objId, Score.SCORE_UNKNOWN);
+				Score expected = finalScorePerParent.get(objId);
+				if (actual.compareTo(expected) != 0) {
+					// Concurrent transaction wrote a higher score; honor it in the
+					// return value but do NOT register a ScoreChange (the other
+					// transaction owns that event).
+					finalScorePerParent.put(objId, actual);
+				} else {
+					transaction.registerScoreChange(new ScoreChange(objId,
+							dataSourceObjIdPerParent.get(objId),
+							currentScorePerParent.getOrDefault(objId, Score.SCORE_UNKNOWN),
+							actual));
+				}
+			}
+		}
+
+		return finalScorePerParent;
+	}
+
 	/**
 	 * Recalculate the aggregate score after an analysis result was 
 	 * deleted.

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -5621,6 +5621,31 @@ public class SleuthkitCase {
 	}
 
 	/**
+	 * Returns the cached prepared statement that inserts a row into
+	 * tsk_analysis_results. Shared between the single-row {@code newAnalysisResult}
+	 * leaf and the batched {@link Blackboard#newAnalysisResults} path.
+	 */
+	PreparedStatement getInsertAnalysisResultStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.INSERT_ANALYSIS_RESULT, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
+	 * Returns the cached race-safe aggregate-score UPSERT prepared statement used
+	 * by the batched analysis-result insert path. PostgreSQL only.
+	 */
+	PreparedStatement getUpsertAggregateScoreIfHigherStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.UPSERT_AGGREGATE_SCORE_IF_HIGHER, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
+	 * Returns the cached batched-DELETE prepared statement for analysis-result
+	 * artifacts (deletes by a bigint[] of artifact_obj_ids). PostgreSQL only.
+	 */
+	PreparedStatement getDeleteBbArtifactsByIdsStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.DELETE_BB_ARTIFACTS_BY_IDS, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
 	 * Returns the cached attribute-INSERT prepared statement matching the
 	 * given attribute value type. Mirrors the switch in
 	 * {@link #addBlackBoardAttribute}.
@@ -14378,6 +14403,26 @@ public class SleuthkitCase {
 				+ "FROM   generate_series(1, ?) AS ord " //NON-NLS
 				+ "ORDER BY ord"), //NON-NLS
 		POSTGRESQL_INSERT_OBJECT_WITH_ID("INSERT INTO tsk_objects (obj_id, par_obj_id, type) VALUES (?, ?, ?)"), //NON-NLS
+		// Race-safe UPSERT for tsk_aggregate_score, used by the batched analysis-result insert path.
+		// The WHERE guard ensures a concurrent transaction's higher score is never overwritten by our
+		// lower one. NOTE: Score.compareTo orders by PRIORITY first, then significance (Score.java:233),
+		// so the ROW comparison must lead with priority. The stored id columns are monotonic with the
+		// enum ordinals within each enum, so comparing the id columns matches the Java comparator.
+		// PostgreSQL only (SQLite path delegates to the single-row method). See design doc 5.1/10.1.
+		// Bind columns: 1=obj_id, 2=data_source_obj_id (or NULL), 3=significance, 4=priority,
+		//               5=significance (ON CONFLICT branch), 6=priority (ON CONFLICT branch).
+		UPSERT_AGGREGATE_SCORE_IF_HIGHER(
+				"INSERT INTO tsk_aggregate_score (obj_id, data_source_obj_id, significance, priority) " //NON-NLS
+				+ "VALUES (?, ?, ?, ?) " //NON-NLS
+				+ "ON CONFLICT (obj_id) DO UPDATE SET significance = ?, priority = ? " //NON-NLS
+				+ "WHERE (EXCLUDED.priority, EXCLUDED.significance) " //NON-NLS
+				+ "    > (tsk_aggregate_score.priority, tsk_aggregate_score.significance)"), //NON-NLS
+		// Batched DELETE for analysis-result artifacts. The single bind is a bigint[] of artifact_obj_ids.
+		// FK CASCADE on tsk_analysis_results, blackboard_attributes, and tsk_data_artifacts handles the
+		// dependent rows; tsk_objects rows are left orphaned (matches single-row deleteAnalysisResult).
+		// PostgreSQL only. See design doc 5.1/7.8.
+		DELETE_BB_ARTIFACTS_BY_IDS(
+				"DELETE FROM blackboard_artifacts WHERE artifact_obj_id = ANY(?::bigint[])"), //NON-NLS
 		POSTGRESQL_RESERVE_FILE_IDS(
 				"SELECT nextval(pg_get_serial_sequence('tsk_objects', 'obj_id')) AS obj_id " //NON-NLS
 				+ "FROM   generate_series(1, ?) AS ord " //NON-NLS
@@ -15307,7 +15352,18 @@ public class SleuthkitCase {
 		void registerScoreChange(ScoreChange scoreChange) {
 			scoreChangeMap.put(scoreChange.getObjectId(), scoreChange);
 		}
-		
+
+		/**
+		 * For test use only. Returns an unmodifiable view of the ScoreChange
+		 * entries registered in this transaction (keyed internally by obj_id, so
+		 * at most one entry per object). Production code must not call this.
+		 *
+		 * @return Unmodifiable collection of registered score changes.
+		 */
+		Collection<ScoreChange> getRegisteredScoreChanges() {
+			return Collections.unmodifiableCollection(scoreChangeMap.values());
+		}
+
 		/**
 		 * Register timeline event to be fired when transaction finishes.
 		 * @param timelineEvent The timeline event.

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 import com.google.gson.Gson;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
@@ -195,6 +196,26 @@ public class SleuthkitCase {
 	
 	// key in acquisition tool settings; the password for decrypting an image
 	static final String IMAGE_PASSWORD_KEY = "imagePassword";
+
+	/**
+	 * Maximum number of files per PostgreSQL batch chunk inside
+	 * {@link #addFileSystemFiles}. Internal chunking unit; callers may pass any
+	 * size and the method partitions internally.
+	 *
+	 * Sized to keep tsk_files INSERTs (28 columns per row) under PostgreSQL's
+	 * 65,535 bind-parameter ceiling: 2000 rows = 56,000 params.
+	 */
+	static final int PG_FILES_CHUNK_SIZE = 2000;
+
+	/**
+	 * Maximum number of attributes per PostgreSQL batch chunk inside the
+	 * tsk_file_attributes INSERT loop. Independent of
+	 * {@link #PG_FILES_CHUNK_SIZE}.
+	 *
+	 * Sized for tsk_file_attributes INSERTs (9 columns per row): 5000 rows =
+	 * 45,000 parameters.
+	 */
+	static final int PG_FILE_ATTR_CHUNK_SIZE = 5000;
 
 	private final ConnectionPool connections;
 	private final Object carvedFileDirsLock = new Object();
@@ -7915,6 +7936,576 @@ public class SleuthkitCase {
 	}
 
 	/**
+	 * Bulk variant of {@link #addFileSystemFile}: creates many file/directory
+	 * rows under one caller-managed transaction.
+	 *
+	 * <p><strong>PostgreSQL behavior:</strong> internally partitions the input
+	 * at {@value #PG_FILES_CHUNK_SIZE} and uses sequence pre-allocation plus
+	 * batched INSERTs into tsk_objects, tsk_files and tsk_file_attributes. Each
+	 * chunk runs a fixed number of round trips regardless of chunk size.</p>
+	 *
+	 * <p><strong>SQLite behavior:</strong> delegates to the single-row
+	 * {@link #addFileSystemFile} in a loop.</p>
+	 *
+	 * <p><strong>Parent ordering:</strong> each request's parent is referenced
+	 * via exactly one of {@link NewFileSystemFileRequest#parent} (a
+	 * {@link Content} the caller already holds — typically from a committed
+	 * prior batch) or {@link NewFileSystemFileRequest#inBatchParentPath} (parent
+	 * is created earlier in the same {@code requests} list). The caller MUST
+	 * place parents before their children in input order. An in-batch parent
+	 * reference that cannot be resolved is a {@link TskCoreException}.
+	 * Parent references work across the entire {@code requests} list regardless
+	 * of how the implementation internally chunks the input — internal chunking
+	 * at {@value #PG_FILES_CHUNK_SIZE} is an implementation detail and callers
+	 * may pass any number of requests in one call.</p>
+	 *
+	 * <p><strong>Return order:</strong> the returned list matches input order
+	 * element-for-element.</p>
+	 *
+	 * <p><strong>Timeline events:</strong> when
+	 * {@code timelineEventsDisabled.get() == false}, this method invokes
+	 * {@code timelineManager.addEventsForNewFile} once per row in a final loop
+	 * — identical conditional as single-row {@link #addFileSystemFile}.
+	 * Per-row timeline event creation is NOT batched by this method.</p>
+	 *
+	 * <p><strong>OS account instance handling:</strong> for each request where
+	 * {@code osAccount != null}, a {@code newOsAccountInstance} upsert with
+	 * type {@code ACCESSED} is issued in a final per-row loop after the main
+	 * batched INSERTs.</p>
+	 *
+	 * <p><strong>Lock behavior:</strong> does NOT acquire
+	 * {@code acquireSingleUserCaseWriteLock}; the caller-owned transaction
+	 * serializes writes on its connection and PostgreSQL sequence atomicity
+	 * handles cross-connection concurrency.</p>
+	 *
+	 * @param requests    Per-row request data; must not be null. May be empty
+	 *                    (returns empty list immediately).
+	 * @param transaction Caller-managed transaction; must not be null.
+	 *
+	 * @return FsContents (all {@code org.sleuthkit.datamodel.File}) in input
+	 *         order; same size as {@code requests}.
+	 *
+	 * @throws TskCoreException If input validation fails, if an
+	 *                          {@code inBatchParentPath} cannot be resolved,
+	 *                          or on any underlying SQL failure.
+	 */
+	@Beta
+	public List<FsContent> addFileSystemFiles(List<NewFileSystemFileRequest> requests, final CaseDbTransaction transaction) throws TskCoreException {
+
+		if (requests == null) {
+			throw new TskCoreException("requests list is required");
+		}
+		if (transaction == null) {
+			throw new TskCoreException("transaction is required");
+		}
+		if (requests.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		if (getDatabaseType() == DbType.POSTGRESQL) {
+			List<FsContent> out = new ArrayList<>(requests.size());
+			// Shared across chunks so a child request in chunk N+1 can resolve
+			// its inBatchParentPath against a directory row defined in chunk N.
+			// Without this, the internal chunking would surface as an
+			// "inBatchParentPath ... did not resolve" error at the first row of
+			// the first chunk that references a prior chunk's directory.
+			Map<String, Long> sharedInBatchMap = new HashMap<>(requests.size() * 2);
+			for (List<NewFileSystemFileRequest> chunk : Lists.partition(requests, PG_FILES_CHUNK_SIZE)) {
+				out.addAll(addFileSystemFilesBatchedPostgres(chunk, sharedInBatchMap, transaction));
+			}
+			return out;
+		}
+
+		// SQLite: per-row delegation against the caller-owned transaction. Pass
+		// the Content references directly — re-fetching via getContentById would
+		// open a separate pooled connection that cannot see rows still in the
+		// caller's uncommitted transaction.
+		List<FsContent> out = new ArrayList<>(requests.size());
+		Map<String, FsContent> inBatchCreated = new HashMap<>();
+		for (NewFileSystemFileRequest r : requests) {
+			Content parent;
+			if (r.parent != null) {
+				parent = r.parent;
+			} else {
+				parent = inBatchCreated.get(r.inBatchParentPath);
+				if (parent == null) {
+					throw new TskCoreException("addFileSystemFiles: inBatchParentPath '" + r.inBatchParentPath
+							+ "' not resolved (parent must appear earlier in the requests list with a matching normalizedFullPath)");
+				}
+			}
+			FsContent created = addFileSystemFile(
+					r.dataSourceObjId, r.fsObjId, r.name, r.metaAddr, r.metaSeq,
+					r.attrType, r.attrId, r.dirFlag, r.metaFlags, r.size,
+					r.ctime, r.crtime, r.atime, r.mtime,
+					r.md5Hash, r.sha256Hash, r.sha1Hash, r.mimeType, r.isFile,
+					parent, r.ownerUid, r.osAccount, r.collected,
+					r.fileAttributes, transaction);
+			out.add(created);
+			if (!r.isFile && r.normalizedFullPath != null) {
+				inBatchCreated.put(r.normalizedFullPath, created);
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * PostgreSQL-only batched implementation of {@link #addFileSystemFiles}.
+	 *
+	 * <p>Does NOT acquire {@code acquireSingleUserCaseWriteLock}. The single-row
+	 * {@link #addFileSystemFile} acquires it indirectly through
+	 * {@link #addObject}; here we omit it for the same reason as the batched
+	 * artifact path. The caller-owned {@link CaseDbTransaction} serializes
+	 * writes on its connection and PostgreSQL sequence atomicity handles
+	 * cross-connection concurrency.</p>
+	 *
+	 * @param requests         Pre-chunked to size &le; {@link #PG_FILES_CHUNK_SIZE};
+	 *                         non-empty.
+	 * @param inBatchMap       Shared {@code normalizedFullPath -> objId} map
+	 *                         accumulated across chunks of one
+	 *                         {@link #addFileSystemFiles} call. This chunk's
+	 *                         directory rows are added to it; this chunk's
+	 *                         {@code inBatchParentPath} resolutions consult it,
+	 *                         so a child request can reference a directory
+	 *                         created in any prior chunk of the same call.
+	 * @param transaction      Caller-managed transaction.
+	 */
+	private List<FsContent> addFileSystemFilesBatchedPostgres(List<NewFileSystemFileRequest> requests, Map<String, Long> inBatchMap, CaseDbTransaction transaction) throws TskCoreException {
+
+		int n = requests.size();
+		CaseDbConnection connection = transaction.getConnection();
+		long[] objIds = new long[n];
+		long[] parObjIds = new long[n];
+
+		try {
+			// Step 1: reserve N obj_ids in one round trip.
+			PreparedStatement reserveStmt = connection.getPreparedStatement(PREPARED_STATEMENT.POSTGRESQL_RESERVE_FILE_IDS, Statement.NO_GENERATED_KEYS);
+			reserveStmt.clearParameters();
+			reserveStmt.setInt(1, n);
+			try (ResultSet rs = reserveStmt.executeQuery()) {
+				int i = 0;
+				while (rs.next()) {
+					if (i >= n) {
+						throw new TskCoreException("addFileSystemFiles: reserve query returned more than " + n + " rows");
+					}
+					objIds[i++] = rs.getLong("obj_id");
+				}
+				if (i != n) {
+					throw new TskCoreException("addFileSystemFiles: reserve query returned " + i + " rows, expected " + n);
+				}
+			}
+
+			// Step 2: extend the caller-owned in-batch map with this chunk's
+			// directory rows, then resolve par_obj_id for each row. The map
+			// spans all chunks of the enclosing addFileSystemFiles call.
+			for (int i = 0; i < n; i++) {
+				NewFileSystemFileRequest r = requests.get(i);
+				if (!r.isFile && r.normalizedFullPath != null) {
+					Long prev = inBatchMap.put(r.normalizedFullPath, objIds[i]);
+					if (prev != null) {
+						throw new TskCoreException("addFileSystemFiles: duplicate normalizedFullPath in batch: '"
+								+ r.normalizedFullPath + "' at index " + i);
+					}
+				}
+				if (r.parent != null) {
+					parObjIds[i] = r.parent.getId();
+				} else {
+					Long resolved = inBatchMap.get(r.inBatchParentPath);
+					if (resolved == null) {
+						throw new TskCoreException("addFileSystemFiles: inBatchParentPath '" + r.inBatchParentPath
+								+ "' at index " + i + " did not resolve. Parents must appear earlier in the input list with matching normalizedFullPath.");
+					}
+					parObjIds[i] = resolved;
+				}
+			}
+
+			// Step 3: batch INSERT into tsk_objects with explicit obj_ids.
+			// Null-on-zero par_obj_id mirrors addObject:6840-6844.
+			PreparedStatement objStmt = connection.getPreparedStatement(PREPARED_STATEMENT.POSTGRESQL_INSERT_OBJECT_WITH_ID, Statement.NO_GENERATED_KEYS);
+			objStmt.clearBatch();
+			for (int i = 0; i < n; i++) {
+				objStmt.clearParameters();
+				objStmt.setLong(1, objIds[i]);
+				if (parObjIds[i] != 0L) {
+					objStmt.setLong(2, parObjIds[i]);
+				} else {
+					objStmt.setNull(2, java.sql.Types.BIGINT);
+				}
+				objStmt.setInt(3, TskData.ObjectType.ABSTRACTFILE.getObjectType());
+				objStmt.addBatch();
+			}
+			try {
+				objStmt.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("addFileSystemFiles: tsk_objects INSERT failed (chunk size " + n + ")", ex);
+			}
+
+			// Step 4: batch INSERT into tsk_files with explicit obj_ids.
+			// Reuses INSERT_FILE_SYSTEM_FILE; first bind parameter is obj_id.
+			PreparedStatement fileStmt = connection.getPreparedStatement(PREPARED_STATEMENT.INSERT_FILE_SYSTEM_FILE, Statement.NO_GENERATED_KEYS);
+			fileStmt.clearBatch();
+			for (int i = 0; i < n; i++) {
+				NewFileSystemFileRequest r = requests.get(i);
+				fileStmt.clearParameters();
+				fileStmt.setLong(1, objIds[i]);
+				fileStmt.setLong(2, r.fsObjId);
+				fileStmt.setLong(3, r.dataSourceObjId);
+				fileStmt.setShort(4, (short) r.attrType.getValue());
+				fileStmt.setInt(5, r.attrId);
+				fileStmt.setString(6, r.name);
+				fileStmt.setLong(7, r.metaAddr);
+				fileStmt.setInt(8, r.metaSeq);
+				fileStmt.setShort(9, TskData.TSK_DB_FILES_TYPE_ENUM.FS.getFileType());
+				fileStmt.setShort(10, (short) 1);
+				TSK_FS_NAME_TYPE_ENUM dirType = r.isFile ? TSK_FS_NAME_TYPE_ENUM.REG : TSK_FS_NAME_TYPE_ENUM.DIR;
+				fileStmt.setShort(11, dirType.getValue());
+				TSK_FS_META_TYPE_ENUM metaType = r.isFile ? TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_REG : TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_DIR;
+				fileStmt.setShort(12, metaType.getValue());
+				fileStmt.setShort(13, r.dirFlag.getValue());
+				fileStmt.setShort(14, r.metaFlags);
+				fileStmt.setLong(15, r.size < 0 ? 0 : r.size);
+				fileStmt.setLong(16, r.ctime);
+				fileStmt.setLong(17, r.crtime);
+				fileStmt.setLong(18, r.atime);
+				fileStmt.setLong(19, r.mtime);
+				fileStmt.setString(20, r.md5Hash);
+				fileStmt.setString(21, r.sha256Hash);
+				fileStmt.setString(22, r.sha1Hash);
+				fileStmt.setString(23, r.mimeType);
+				fileStmt.setString(24, r.parentPath);
+				fileStmt.setString(25, extractExtension(r.name));
+				fileStmt.setString(26, r.ownerUid);
+				if (r.osAccount != null) {
+					fileStmt.setLong(27, r.osAccount.getId());
+				} else {
+					fileStmt.setNull(27, java.sql.Types.BIGINT);
+				}
+				fileStmt.setLong(28, r.collected.getType());
+				fileStmt.addBatch();
+			}
+			try {
+				fileStmt.executeBatch();
+			} catch (SQLException ex) {
+				throw new TskCoreException("addFileSystemFiles: tsk_files INSERT failed (chunk size " + n + ")", ex);
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("addFileSystemFiles: SQL error during chunk of size " + n, ex);
+		}
+
+		// Step 5: batched tsk_file_attributes INSERTs.
+		addFileAttributesBatched(requests, objIds, connection);
+
+		// Step 6: parent-has-children bookkeeping for unique parents.
+		Set<Long> uniqueParents = new HashSet<>();
+		for (int i = 0; i < n; i++) {
+			uniqueParents.add(parObjIds[i]);
+		}
+		markParentsHaveChildren(uniqueParents);
+
+		// Step 7: construct File result list (same shape as single-row path).
+		// Must happen before Steps 8/9 because they pass File instances to the
+		// side-effect APIs.
+		List<FsContent> out = new ArrayList<>(n);
+		for (int i = 0; i < n; i++) {
+			NewFileSystemFileRequest r = requests.get(i);
+			TSK_FS_NAME_TYPE_ENUM dirType = r.isFile ? TSK_FS_NAME_TYPE_ENUM.REG : TSK_FS_NAME_TYPE_ENUM.DIR;
+			TSK_FS_META_TYPE_ENUM metaType = r.isFile ? TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_REG : TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_DIR;
+			Long osAccountId = (r.osAccount != null) ? r.osAccount.getId() : null;
+			out.add(new org.sleuthkit.datamodel.File(
+					this, objIds[i], r.dataSourceObjId, r.fsObjId,
+					r.attrType, r.attrId, r.name, r.metaAddr, r.metaSeq,
+					dirType, metaType, r.dirFlag, r.metaFlags,
+					r.size, r.ctime, r.crtime, r.atime, r.mtime,
+					(short) 0, 0, 0, r.md5Hash, r.sha256Hash, r.sha1Hash,
+					null, r.parentPath, r.mimeType, extractExtension(r.name), r.ownerUid,
+					osAccountId, r.collected, r.fileAttributes));
+		}
+
+		// Step 8: per-row timeline event creation when timeline events are NOT
+		// globally disabled. Mirrors single-row conditional at line 7889. The
+		// returned File (rather than the transient DerivedFile single-row code
+		// builds) is passed in; both extend AbstractFile and both expose the
+		// timestamps/parent_path/data_source_obj_id getters used by
+		// addEventsForNewFileQuiet, so the call is observationally equivalent.
+		if (!timelineEventsDisabled.get()) {
+			TimelineManager timelineManager = getTimelineManager();
+			for (int i = 0; i < n; i++) {
+				timelineManager.addEventsForNewFile((AbstractFile) out.get(i), connection);
+			}
+		}
+
+		// Step 9: OS account instance upsert per row. Per-row to match
+		// single-row contract; batching newOsAccountInstance is a follow-up PR.
+		for (int i = 0; i < n; i++) {
+			NewFileSystemFileRequest r = requests.get(i);
+			if (r.osAccount != null) {
+				osAccountManager.newOsAccountInstance(r.osAccount.getId(), r.dataSourceObjId, OsAccountInstance.OsAccountInstanceType.ACCESSED, connection);
+			}
+		}
+
+		return out;
+	}
+
+	/**
+	 * Batched persistence of {@link Attribute} rows owned by files just created
+	 * by {@link #addFileSystemFilesBatchedPostgres}.
+	 *
+	 * <p>Pre-allocates {@code tsk_file_attributes.id} via a sequence reserve,
+	 * then issues a chunked batched INSERT against
+	 * {@code POSTGRESQL_INSERT_FILE_ATTRIBUTE_WITH_ID}. Inner chunk size is
+	 * {@link #PG_FILE_ATTR_CHUNK_SIZE}.</p>
+	 *
+	 * <p>After persistence, each {@link Attribute} has its {@code id} set via
+	 * package-private {@link Attribute#setId} and its
+	 * {@code attributeParentId} set via {@link Attribute#setAttributeParentId}
+	 * — mirroring the single-row {@code addFileAttribute} contract.</p>
+	 *
+	 * <p>If no request has any attributes, this method allocates nothing and
+	 * returns immediately (no sequence reserve, no SQL).</p>
+	 *
+	 * @param requests   Original chunk of requests (carries attribute lists).
+	 * @param objIds     The obj_ids assigned to each request (parallel array).
+	 * @param connection Case DB connection bound to the caller's transaction.
+	 */
+	private void addFileAttributesBatched(List<NewFileSystemFileRequest> requests, long[] objIds, CaseDbConnection connection) throws TskCoreException {
+
+		int totalAttrs = 0;
+		for (NewFileSystemFileRequest r : requests) {
+			totalAttrs += r.fileAttributes.size();
+		}
+		if (totalAttrs == 0) {
+			return;
+		}
+
+		try {
+			long[] attrIds = new long[totalAttrs];
+			PreparedStatement reserveStmt = connection.getPreparedStatement(PREPARED_STATEMENT.POSTGRESQL_RESERVE_FILE_ATTRIBUTE_IDS, Statement.NO_GENERATED_KEYS);
+			reserveStmt.clearParameters();
+			reserveStmt.setInt(1, totalAttrs);
+			try (ResultSet rs = reserveStmt.executeQuery()) {
+				int i = 0;
+				while (rs.next()) {
+					if (i >= totalAttrs) {
+						throw new TskCoreException("addFileSystemFiles: file_attr reserve query returned more than " + totalAttrs + " rows");
+					}
+					attrIds[i++] = rs.getLong("attr_id");
+				}
+				if (i != totalAttrs) {
+					throw new TskCoreException("addFileSystemFiles: file_attr reserve query returned " + i + " rows, expected " + totalAttrs);
+				}
+			}
+
+			PreparedStatement attrStmt = connection.getPreparedStatement(PREPARED_STATEMENT.POSTGRESQL_INSERT_FILE_ATTRIBUTE_WITH_ID, Statement.NO_GENERATED_KEYS);
+			attrStmt.clearBatch();
+
+			int attrCursor = 0;
+			int batchedInChunk = 0;
+			for (int reqIdx = 0; reqIdx < requests.size(); reqIdx++) {
+				NewFileSystemFileRequest r = requests.get(reqIdx);
+				long parentObjId = objIds[reqIdx];
+				for (Attribute a : r.fileAttributes) {
+					long assignedId = attrIds[attrCursor++];
+					a.setId(assignedId);
+					a.setAttributeParentId(parentObjId);
+					a.setCaseDatabase(this);
+
+					attrStmt.clearParameters();
+					attrStmt.setLong(1, assignedId);
+					attrStmt.setLong(2, parentObjId);
+					attrStmt.setInt(3, a.getAttributeType().getTypeID());
+					attrStmt.setLong(4, a.getAttributeType().getValueType().getType());
+					TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE vt = a.getAttributeType().getValueType();
+					if (vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.BYTE) {
+						attrStmt.setBytes(5, a.getValueBytes());
+					} else {
+						attrStmt.setBytes(5, null);
+					}
+					if (vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.STRING
+							|| vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.JSON) {
+						attrStmt.setString(6, a.getValueString());
+					} else {
+						attrStmt.setString(6, null);
+					}
+					if (vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.INTEGER) {
+						attrStmt.setInt(7, a.getValueInt());
+					} else {
+						attrStmt.setNull(7, java.sql.Types.INTEGER);
+					}
+					if (vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.DATETIME
+							|| vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.LONG) {
+						attrStmt.setLong(8, a.getValueLong());
+					} else {
+						attrStmt.setNull(8, java.sql.Types.BIGINT);
+					}
+					if (vt == TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE.DOUBLE) {
+						attrStmt.setDouble(9, a.getValueDouble());
+					} else {
+						attrStmt.setNull(9, java.sql.Types.DOUBLE);
+					}
+					attrStmt.addBatch();
+					batchedInChunk++;
+
+					if (batchedInChunk >= PG_FILE_ATTR_CHUNK_SIZE) {
+						try {
+							attrStmt.executeBatch();
+						} catch (SQLException ex) {
+							throw new TskCoreException("addFileSystemFiles: tsk_file_attributes INSERT failed (chunk size " + batchedInChunk + ")", ex);
+						}
+						attrStmt.clearBatch();
+						batchedInChunk = 0;
+					}
+				}
+			}
+			if (batchedInChunk > 0) {
+				try {
+					attrStmt.executeBatch();
+				} catch (SQLException ex) {
+					throw new TskCoreException("addFileSystemFiles: tsk_file_attributes INSERT failed (tail chunk size " + batchedInChunk + ")", ex);
+				}
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException("addFileSystemFiles: SQL error during file_attribute INSERTs", ex);
+		}
+	}
+
+	/**
+	 * Per-row request data for {@link SleuthkitCase#addFileSystemFiles}.
+	 *
+	 * <p>Field semantics match the parameters of the 25-arg single-row
+	 * {@link SleuthkitCase#addFileSystemFile(long, long, String, long, int,
+	 * TSK_FS_ATTR_TYPE_ENUM, int, TSK_FS_NAME_FLAG_ENUM, short, long, long,
+	 * long, long, long, String, String, String, String, boolean, Content,
+	 * String, OsAccount, TskData.CollectedStatus, List, CaseDbTransaction)}
+	 * with two differences:</p>
+	 *
+	 * <ul>
+	 *   <li>The parent is supplied via exactly one of {@link #parent} (an
+	 *       in-memory {@link Content} the caller already holds, typically from
+	 *       a committed prior batch) or {@link #inBatchParentPath} (parent is
+	 *       added earlier in the same batch and does not yet exist as a
+	 *       {@link Content}). Exactly one of these MUST be non-null; the
+	 *       constructor enforces this.</li>
+	 *   <li>The {@code parent_path} column value is supplied directly via
+	 *       {@link #parentPath} (caller-computed).</li>
+	 * </ul>
+	 *
+	 * <p>The {@link #normalizedFullPath} field is the caller's chosen unique
+	 * key for this row when referenced by other rows in the same batch via
+	 * {@code inBatchParentPath}. Used ONLY for in-batch parent resolution;
+	 * not stored in the database. For file rows it may be {@code null}; for
+	 * directory rows it MUST be unique within a single batch.</p>
+	 */
+	public static final class NewFileSystemFileRequest {
+
+		public final long dataSourceObjId;
+		public final long fsObjId;
+		public final String name;
+		public final long metaAddr;
+		public final int metaSeq;
+		public final TSK_FS_ATTR_TYPE_ENUM attrType;
+		public final int attrId;
+		public final TSK_FS_NAME_FLAG_ENUM dirFlag;
+		public final short metaFlags;
+		public final long size;
+		public final long ctime;
+		public final long crtime;
+		public final long atime;
+		public final long mtime;
+		public final String md5Hash;
+		public final String sha256Hash;
+		public final String sha1Hash;
+		public final String mimeType;
+		public final boolean isFile;
+		public final Content parent;
+		public final String inBatchParentPath;
+		public final String parentPath;
+		public final String normalizedFullPath;
+		public final String ownerUid;
+		public final OsAccount osAccount;
+		public final TskData.CollectedStatus collected;
+		public final List<Attribute> fileAttributes;
+
+		public NewFileSystemFileRequest(
+				long dataSourceObjId,
+				long fsObjId,
+				String name,
+				long metaAddr,
+				int metaSeq,
+				TSK_FS_ATTR_TYPE_ENUM attrType,
+				int attrId,
+				TSK_FS_NAME_FLAG_ENUM dirFlag,
+				short metaFlags,
+				long size,
+				long ctime,
+				long crtime,
+				long atime,
+				long mtime,
+				String md5Hash,
+				String sha256Hash,
+				String sha1Hash,
+				String mimeType,
+				boolean isFile,
+				Content parent,
+				String inBatchParentPath,
+				String parentPath,
+				String normalizedFullPath,
+				String ownerUid,
+				OsAccount osAccount,
+				TskData.CollectedStatus collected,
+				List<Attribute> fileAttributes) {
+			if ((parent == null) == (inBatchParentPath == null)) {
+				throw new IllegalArgumentException("Exactly one of parent or inBatchParentPath must be non-null (got parent="
+						+ (parent == null ? "null" : "id=" + parent.getId())
+						+ ", inBatchParentPath=" + inBatchParentPath + ")");
+			}
+			if (parentPath == null) {
+				throw new IllegalArgumentException("parentPath is required");
+			}
+			if (attrType == null) {
+				throw new IllegalArgumentException("attrType is required");
+			}
+			if (dirFlag == null) {
+				throw new IllegalArgumentException("dirFlag is required");
+			}
+			if (collected == null) {
+				throw new IllegalArgumentException("collected is required");
+			}
+			if (fileAttributes == null) {
+				throw new IllegalArgumentException("fileAttributes must not be null; use Collections.emptyList()");
+			}
+			if (!isFile && normalizedFullPath == null) {
+				throw new IllegalArgumentException("normalizedFullPath is required for directory rows (isFile=false)");
+			}
+			this.dataSourceObjId = dataSourceObjId;
+			this.fsObjId = fsObjId;
+			this.name = name;
+			this.metaAddr = metaAddr;
+			this.metaSeq = metaSeq;
+			this.attrType = attrType;
+			this.attrId = attrId;
+			this.dirFlag = dirFlag;
+			this.metaFlags = metaFlags;
+			this.size = size;
+			this.ctime = ctime;
+			this.crtime = crtime;
+			this.atime = atime;
+			this.mtime = mtime;
+			this.md5Hash = md5Hash;
+			this.sha256Hash = sha256Hash;
+			this.sha1Hash = sha1Hash;
+			this.mimeType = mimeType;
+			this.isFile = isFile;
+			this.parent = parent;
+			this.inBatchParentPath = inBatchParentPath;
+			this.parentPath = parentPath;
+			this.normalizedFullPath = normalizedFullPath;
+			this.ownerUid = ownerUid;
+			this.osAccount = osAccount;
+			this.collected = collected;
+			this.fileAttributes = fileAttributes;
+		}
+	}
+
+	/**
 	 * Get IDs of the virtual folder roots (at the same level as image), used
 	 * for containers such as for local files.
 	 *
@@ -13787,6 +14378,18 @@ public class SleuthkitCase {
 				+ "FROM   generate_series(1, ?) AS ord " //NON-NLS
 				+ "ORDER BY ord"), //NON-NLS
 		POSTGRESQL_INSERT_OBJECT_WITH_ID("INSERT INTO tsk_objects (obj_id, par_obj_id, type) VALUES (?, ?, ?)"), //NON-NLS
+		POSTGRESQL_RESERVE_FILE_IDS(
+				"SELECT nextval(pg_get_serial_sequence('tsk_objects', 'obj_id')) AS obj_id " //NON-NLS
+				+ "FROM   generate_series(1, ?) AS ord " //NON-NLS
+				+ "ORDER BY ord"), //NON-NLS
+		POSTGRESQL_RESERVE_FILE_ATTRIBUTE_IDS(
+				"SELECT nextval(pg_get_serial_sequence('tsk_file_attributes', 'id')) AS attr_id " //NON-NLS
+				+ "FROM   generate_series(1, ?) AS ord " //NON-NLS
+				+ "ORDER BY ord"), //NON-NLS
+		POSTGRESQL_INSERT_FILE_ATTRIBUTE_WITH_ID(
+				"INSERT INTO tsk_file_attributes (id, obj_id, attribute_type_id, value_type, " //NON-NLS
+				+ "value_byte, value_text, value_int32, value_int64, value_double) " //NON-NLS
+				+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"), //NON-NLS
 		INSERT_DATA_ARTIFACT("INSERT INTO tsk_data_artifacts (artifact_obj_id, os_account_obj_id) VALUES (?, ?)"), //NON-NLS
 		INSERT_FILE("INSERT INTO tsk_files (obj_id, fs_obj_id, name, type, has_path, dir_type, meta_type, dir_flags, meta_flags, size, ctime, crtime, atime, mtime, md5, sha256, sha1, known, mime_type, parent_path, data_source_obj_id, extension, owner_uid, os_account_obj_id, collected) " //NON-NLS
 				+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"), //NON-NLS

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -589,6 +589,27 @@ public class SleuthkitCase {
 	}
 
 	/**
+	 * Marks each non-zero parent id in the collection as having children.
+	 * Memory-only update; safe to call from any thread.
+	 *
+	 * Used by the batched artifact-creation path to amortize the parent
+	 * has-children bookkeeping across a chunk of newly-created artifacts.
+	 *
+	 * @param parentIds Parent obj_ids; nulls and zeros are ignored to mirror
+	 *                  the single-row {@code addObject} semantics.
+	 */
+	void markParentsHaveChildren(Collection<Long> parentIds) {
+		if (parentIds == null || parentIds.isEmpty()) {
+			return;
+		}
+		for (Long parentId : parentIds) {
+			if (parentId != null && parentId != 0L) {
+				setHasChildren(parentId);
+			}
+		}
+	}
+
+	/**
 	 * Gets the communications manager for this case.
 	 *
 	 * @return The per case CommunicationsManager object.
@@ -5535,6 +5556,78 @@ public class SleuthkitCase {
 		}
 
 		return statement;
+	}
+
+	/**
+	 * Returns the cached prepared statement that reserves N obj_ids and N
+	 * artifact_ids in a single PostgreSQL round trip. PostgreSQL only.
+	 *
+	 * Used by {@link Blackboard#newDataArtifacts} to pre-allocate IDs before
+	 * the batched INSERTs. Keeping this accessor avoids widening the
+	 * {@link PREPARED_STATEMENT} enum visibility.
+	 */
+	PreparedStatement getReserveArtifactIdsStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.POSTGRESQL_RESERVE_ARTIFACT_IDS, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
+	 * Returns the cached prepared statement that inserts into tsk_objects with
+	 * an explicit obj_id. PostgreSQL only — used by the batched artifact
+	 * creation path which pre-allocates obj_ids via
+	 * {@link #getReserveArtifactIdsStatement}.
+	 */
+	PreparedStatement getInsertObjectWithIdStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.POSTGRESQL_INSERT_OBJECT_WITH_ID, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
+	 * Returns the cached prepared statement that inserts into
+	 * blackboard_artifacts with an explicit artifact_id. Reuses the same SQL
+	 * shape SQLite uses for the single-row path; explicit values are accepted
+	 * on PostgreSQL BIGSERIAL columns when the IDs are pre-allocated.
+	 */
+	PreparedStatement getInsertArtifactStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.INSERT_ARTIFACT, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
+	 * Returns the cached prepared statement that inserts a row into
+	 * tsk_data_artifacts. Shared between the single-row {@code newDataArtifact}
+	 * path and the batched {@link Blackboard#newDataArtifacts} path.
+	 */
+	PreparedStatement getInsertDataArtifactStatement(CaseDbConnection connection) throws SQLException {
+		return connection.getPreparedStatement(PREPARED_STATEMENT.INSERT_DATA_ARTIFACT, Statement.NO_GENERATED_KEYS);
+	}
+
+	/**
+	 * Returns the cached attribute-INSERT prepared statement matching the
+	 * given attribute value type. Mirrors the switch in
+	 * {@link #addBlackBoardAttribute}.
+	 */
+	PreparedStatement getInsertAttributeStatement(CaseDbConnection connection, BlackboardAttribute.TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE valueType) throws SQLException, TskCoreException {
+		PREPARED_STATEMENT key;
+		switch (valueType) {
+			case STRING:
+			case JSON:
+				key = PREPARED_STATEMENT.INSERT_STRING_ATTRIBUTE;
+				break;
+			case BYTE:
+				key = PREPARED_STATEMENT.INSERT_BYTE_ATTRIBUTE;
+				break;
+			case INTEGER:
+				key = PREPARED_STATEMENT.INSERT_INT_ATTRIBUTE;
+				break;
+			case LONG:
+			case DATETIME:
+				key = PREPARED_STATEMENT.INSERT_LONG_ATTRIBUTE;
+				break;
+			case DOUBLE:
+				key = PREPARED_STATEMENT.INSERT_DOUBLE_ATTRIBUTE;
+				break;
+			default:
+				throw new TskCoreException("Unrecognized attribute value type: " + valueType);
+		}
+		return connection.getPreparedStatement(key, Statement.NO_GENERATED_KEYS);
 	}
 
 	/**
@@ -13688,6 +13781,13 @@ public class SleuthkitCase {
 		SELECT_FILE_DERIVATION_METHOD("SELECT tool_name, tool_version, other FROM tsk_files_derived_method WHERE derived_id = ?"), //NON-NLS
 		SELECT_MAX_OBJECT_ID("SELECT MAX(obj_id) AS max_obj_id FROM tsk_objects"), //NON-NLS
 		INSERT_OBJECT("INSERT INTO tsk_objects (par_obj_id, type) VALUES (?, ?)"), //NON-NLS
+		POSTGRESQL_RESERVE_ARTIFACT_IDS(
+				"SELECT nextval(pg_get_serial_sequence('tsk_objects', 'obj_id'))               AS obj_id, " //NON-NLS
+				+ "       nextval(pg_get_serial_sequence('blackboard_artifacts', 'artifact_id')) AS artifact_id " //NON-NLS
+				+ "FROM   generate_series(1, ?) AS ord " //NON-NLS
+				+ "ORDER BY ord"), //NON-NLS
+		POSTGRESQL_INSERT_OBJECT_WITH_ID("INSERT INTO tsk_objects (obj_id, par_obj_id, type) VALUES (?, ?, ?)"), //NON-NLS
+		INSERT_DATA_ARTIFACT("INSERT INTO tsk_data_artifacts (artifact_obj_id, os_account_obj_id) VALUES (?, ?)"), //NON-NLS
 		INSERT_FILE("INSERT INTO tsk_files (obj_id, fs_obj_id, name, type, has_path, dir_type, meta_type, dir_flags, meta_flags, size, ctime, crtime, atime, mtime, md5, sha256, sha1, known, mime_type, parent_path, data_source_obj_id, extension, owner_uid, os_account_obj_id, collected) " //NON-NLS
 				+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"), //NON-NLS
 		INSERT_FILE_SYSTEM_FILE("INSERT INTO tsk_files(obj_id, fs_obj_id, data_source_obj_id, attr_type, attr_id, name, meta_addr, meta_seq, type, has_path, dir_type, meta_type, dir_flags, meta_flags, size, ctime, crtime, atime, mtime, md5, sha256, sha1, mime_type, parent_path, extension, owner_uid, os_account_obj_id, collected)"

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -13953,6 +13953,10 @@ public class SleuthkitCase {
 				} else {
 					connectionURL += CaseDatabaseFactory.SSL_NONVERIFY_URL;
 				}
+				// SSL constants already lead with "?ssl=true&..." — append with &.
+				connectionURL += "&reWriteBatchedInserts=true";
+			} else {
+				connectionURL += "?reWriteBatchedInserts=true";
 			}
 			comboPooledDataSource.setJdbcUrl(connectionURL);
 			comboPooledDataSource.setUser(info.getUserName());

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -8026,6 +8026,11 @@ public class SleuthkitCase {
 		if (requests.isEmpty()) {
 			return Collections.emptyList();
 		}
+		for (int i = 0; i < requests.size(); i++) {
+			if (requests.get(i) == null) {
+				throw new TskCoreException("requests contains null element at index " + i);
+			}
+		}
 
 		if (getDatabaseType() == DbType.POSTGRESQL) {
 			List<FsContent> out = new ArrayList<>(requests.size());
@@ -8035,8 +8040,14 @@ public class SleuthkitCase {
 			// "inBatchParentPath ... did not resolve" error at the first row of
 			// the first chunk that references a prior chunk's directory.
 			Map<String, Long> sharedInBatchMap = new HashMap<>(requests.size() * 2);
+			// Parallel to sharedInBatchMap: normalizedFullPath -> the parent_path
+			// string that this directory's children must receive. Lets the derived
+			// parent_path of an in-batch child reference a directory created in any
+			// prior chunk, mirroring the topology-based derivation of the single-row
+			// path on both backends.
+			Map<String, String> sharedInBatchChildPaths = new HashMap<>(requests.size() * 2);
 			for (List<NewFileSystemFileRequest> chunk : Lists.partition(requests, PG_FILES_CHUNK_SIZE)) {
-				out.addAll(addFileSystemFilesBatchedPostgres(chunk, sharedInBatchMap, transaction));
+				out.addAll(addFileSystemFilesBatchedPostgres(chunk, sharedInBatchMap, sharedInBatchChildPaths, transaction));
 			}
 			return out;
 		}
@@ -8067,6 +8078,10 @@ public class SleuthkitCase {
 					r.fileAttributes, transaction);
 			out.add(created);
 			if (!r.isFile && r.normalizedFullPath != null) {
+				if (inBatchCreated.containsKey(r.normalizedFullPath)) {
+					throw new TskCoreException("addFileSystemFiles: duplicate normalizedFullPath in batch: '"
+							+ r.normalizedFullPath + "'");
+				}
 				inBatchCreated.put(r.normalizedFullPath, created);
 			}
 		}
@@ -8092,14 +8107,21 @@ public class SleuthkitCase {
 	 *                         {@code inBatchParentPath} resolutions consult it,
 	 *                         so a child request can reference a directory
 	 *                         created in any prior chunk of the same call.
+	 * @param inBatchChildPaths Shared {@code normalizedFullPath -> child
+	 *                         parent_path} map accumulated across chunks. For each
+	 *                         directory row this chunk records the parent_path its
+	 *                         children should receive; in-batch children consult it
+	 *                         to derive their own parent_path, spanning chunks like
+	 *                         {@code inBatchMap}.
 	 * @param transaction      Caller-managed transaction.
 	 */
-	private List<FsContent> addFileSystemFilesBatchedPostgres(List<NewFileSystemFileRequest> requests, Map<String, Long> inBatchMap, CaseDbTransaction transaction) throws TskCoreException {
+	private List<FsContent> addFileSystemFilesBatchedPostgres(List<NewFileSystemFileRequest> requests, Map<String, Long> inBatchMap, Map<String, String> inBatchChildPaths, CaseDbTransaction transaction) throws TskCoreException {
 
 		int n = requests.size();
 		CaseDbConnection connection = transaction.getConnection();
 		long[] objIds = new long[n];
 		long[] parObjIds = new long[n];
+		String[] parentPaths = new String[n];
 
 		try {
 			// Step 1: reserve N obj_ids in one round trip.
@@ -8119,20 +8141,31 @@ public class SleuthkitCase {
 				}
 			}
 
-			// Step 2: extend the caller-owned in-batch map with this chunk's
-			// directory rows, then resolve par_obj_id for each row. The map
-			// spans all chunks of the enclosing addFileSystemFiles call.
+			// Step 2: resolve par_obj_id and derive parent_path for each row first,
+			// then extend the caller-owned in-batch maps with this chunk's
+			// directory rows. The maps span all chunks of the enclosing
+			// addFileSystemFiles call. Resolving before publishing prevents a
+			// directory from resolving its inBatchParentPath against its own
+			// normalizedFullPath; legitimate parents always appear earlier in the
+			// input list.
+			//
+			// parent_path is derived from topology to match the single-row path
+			// (and the SQLite batched path, which delegates to it): a child of the
+			// file system root directory gets "/", otherwise
+			// parentDerivedPath + parentName + "/".
 			for (int i = 0; i < n; i++) {
 				NewFileSystemFileRequest r = requests.get(i);
-				if (!r.isFile && r.normalizedFullPath != null) {
-					Long prev = inBatchMap.put(r.normalizedFullPath, objIds[i]);
-					if (prev != null) {
-						throw new TskCoreException("addFileSystemFiles: duplicate normalizedFullPath in batch: '"
-								+ r.normalizedFullPath + "' at index " + i);
-					}
-				}
+				String parentPath;
 				if (r.parent != null) {
 					parObjIds[i] = r.parent.getId();
+					if (r.parent instanceof AbstractFile) {
+						AbstractFile parentFile = (AbstractFile) r.parent;
+						parentPath = isRootDirectory(parentFile, transaction)
+								? "/"
+								: parentFile.getParentPath() + parentFile.getName() + "/";
+					} else {
+						parentPath = "/";
+					}
 				} else {
 					Long resolved = inBatchMap.get(r.inBatchParentPath);
 					if (resolved == null) {
@@ -8140,6 +8173,24 @@ public class SleuthkitCase {
 								+ "' at index " + i + " did not resolve. Parents must appear earlier in the input list with matching normalizedFullPath.");
 					}
 					parObjIds[i] = resolved;
+					parentPath = inBatchChildPaths.get(r.inBatchParentPath);
+				}
+				parentPaths[i] = parentPath;
+
+				if (!r.isFile && r.normalizedFullPath != null) {
+					Long prev = inBatchMap.put(r.normalizedFullPath, objIds[i]);
+					if (prev != null) {
+						throw new TskCoreException("addFileSystemFiles: duplicate normalizedFullPath in batch: '"
+								+ r.normalizedFullPath + "' at index " + i);
+					}
+					// The parent_path this directory's children should receive. A
+					// directory whose parent is a non-AbstractFile container
+					// (FS/IMG/VS/VOL) is the file system root, so its children get
+					// "/" — mirroring isRootDirectory in the single-row path.
+					String childPath = (r.parent != null && !(r.parent instanceof AbstractFile))
+							? "/"
+							: parentPath + r.name + "/";
+					inBatchChildPaths.put(r.normalizedFullPath, childPath);
 				}
 			}
 
@@ -8196,7 +8247,7 @@ public class SleuthkitCase {
 				fileStmt.setString(21, r.sha256Hash);
 				fileStmt.setString(22, r.sha1Hash);
 				fileStmt.setString(23, r.mimeType);
-				fileStmt.setString(24, r.parentPath);
+				fileStmt.setString(24, parentPaths[i]);
 				fileStmt.setString(25, extractExtension(r.name));
 				fileStmt.setString(26, r.ownerUid);
 				if (r.osAccount != null) {
@@ -8241,7 +8292,7 @@ public class SleuthkitCase {
 					dirType, metaType, r.dirFlag, r.metaFlags,
 					r.size, r.ctime, r.crtime, r.atime, r.mtime,
 					(short) 0, 0, 0, r.md5Hash, r.sha256Hash, r.sha1Hash,
-					null, r.parentPath, r.mimeType, extractExtension(r.name), r.ownerUid,
+					null, parentPaths[i], r.mimeType, extractExtension(r.name), r.ownerUid,
 					osAccountId, r.collected, r.fileAttributes));
 		}
 
@@ -8409,8 +8460,9 @@ public class SleuthkitCase {
 	 *       added earlier in the same batch and does not yet exist as a
 	 *       {@link Content}). Exactly one of these MUST be non-null; the
 	 *       constructor enforces this.</li>
-	 *   <li>The {@code parent_path} column value is supplied directly via
-	 *       {@link #parentPath} (caller-computed).</li>
+	 *   <li>The {@code parent_path} column value is derived from the parent's
+	 *       topology (identical to the single-row path), not supplied by the
+	 *       caller.</li>
 	 * </ul>
 	 *
 	 * <p>The {@link #normalizedFullPath} field is the caller's chosen unique
@@ -8442,7 +8494,6 @@ public class SleuthkitCase {
 		public final boolean isFile;
 		public final Content parent;
 		public final String inBatchParentPath;
-		public final String parentPath;
 		public final String normalizedFullPath;
 		public final String ownerUid;
 		public final OsAccount osAccount;
@@ -8471,7 +8522,6 @@ public class SleuthkitCase {
 				boolean isFile,
 				Content parent,
 				String inBatchParentPath,
-				String parentPath,
 				String normalizedFullPath,
 				String ownerUid,
 				OsAccount osAccount,
@@ -8481,9 +8531,6 @@ public class SleuthkitCase {
 				throw new IllegalArgumentException("Exactly one of parent or inBatchParentPath must be non-null (got parent="
 						+ (parent == null ? "null" : "id=" + parent.getId())
 						+ ", inBatchParentPath=" + inBatchParentPath + ")");
-			}
-			if (parentPath == null) {
-				throw new IllegalArgumentException("parentPath is required");
 			}
 			if (attrType == null) {
 				throw new IllegalArgumentException("attrType is required");
@@ -8521,7 +8568,6 @@ public class SleuthkitCase {
 			this.isFile = isFile;
 			this.parent = parent;
 			this.inBatchParentPath = inBatchParentPath;
-			this.parentPath = parentPath;
 			this.normalizedFullPath = normalizedFullPath;
 			this.ownerUid = ownerUid;
 			this.osAccount = osAccount;

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedAnalysisResultTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedAnalysisResultTest.java
@@ -83,8 +83,8 @@ public class BatchedAnalysisResultTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			 caseDB = SleuthkitCase.newCase("TskBatchedAnalysisResultTest", connectionInfo, tempDirPath);
+			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			// caseDB = SleuthkitCase.newCase("TskBatchedAnalysisResultTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 			image = caseDB.addImage(TskData.TSK_IMG_TYPE_ENUM.TSK_IMG_TYPE_DETECT, 512, 1024, "", Collections.emptyList(), "America/NewYork", null, null, null, "BatchedAnalysisResultTestImage", trans);

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedAnalysisResultTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedAnalysisResultTest.java
@@ -1,0 +1,456 @@
+/*
+ * Sleuth Kit Data Model
+ *
+ * Copyright 2026 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.datamodel;
+
+import java.nio.file.Paths;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.sleuthkit.datamodel.Score.Significance;
+
+/**
+ * Functional tests for the batched analysis-result APIs:
+ * {@link Blackboard#newAnalysisResults} and
+ * {@link Blackboard#deleteAnalysisResults}.
+ *
+ * <p>Runs against SQLite (suite convention). The SQLite path delegates to the
+ * single-row methods, so these tests verify behavioral parity (result shape,
+ * aggregate-score math, FK-cascade deletes, ScoreChange events, rollback). To
+ * exercise the batched PostgreSQL code path, uncomment the connection block in
+ * {@link #setUpClass} and point it at a test PostgreSQL instance.</p>
+ */
+public class BatchedAnalysisResultTest {
+
+	private static final Logger LOGGER = Logger.getLogger(BatchedAnalysisResultTest.class.getName());
+
+	private static final String TEST_DB = "BatchedAnalysisResultTest.db";
+	private static final String MODULE = "BatchedAnalysisResultTest";
+
+	private static SleuthkitCase caseDB;
+	private static String dbPath = null;
+	private static Image image = null;
+	private static FileSystem fs = null;
+	private static long dataSourceId = 0;
+
+	private static final BlackboardArtifact.Type AR_TYPE =
+			new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_KEYWORD_HIT);
+	private static final BlackboardArtifact.Type DATA_ARTIFACT_TYPE =
+			new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+
+	public BatchedAnalysisResultTest() {
+	}
+
+	@BeforeClass
+	public static void setUpClass() {
+		String tempDirPath = System.getProperty("java.io.tmpdir");
+		try {
+			dbPath = Paths.get(tempDirPath, TEST_DB).toString();
+			java.io.File dbFile = new java.io.File(dbPath);
+			dbFile.delete();
+			if (dbFile.getParentFile() != null) {
+				dbFile.getParentFile().mkdirs();
+			}
+
+			caseDB = SleuthkitCase.newCase(dbPath);
+
+			// Uncomment to manually exercise the batched PostgreSQL path.
+			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			 caseDB = SleuthkitCase.newCase("TskBatchedAnalysisResultTest", connectionInfo, tempDirPath);
+
+			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+			image = caseDB.addImage(TskData.TSK_IMG_TYPE_ENUM.TSK_IMG_TYPE_DETECT, 512, 1024, "", Collections.emptyList(), "America/NewYork", null, null, null, "BatchedAnalysisResultTestImage", trans);
+			fs = caseDB.addFileSystem(image.getId(), 0, TskData.TSK_FS_TYPE_ENUM.TSK_FS_TYPE_RAW, 0, 0, 0, 0, 0, "", trans);
+			trans.commit();
+
+			dataSourceId = image.getId();
+
+			System.out.println("BatchedAnalysisResultTest DB created at: " + dbPath);
+		} catch (TskCoreException ex) {
+			LOGGER.log(Level.SEVERE, "Failed to set up BatchedAnalysisResultTest", ex);
+			fail("Set-up failed: " + ex.getMessage());
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+	}
+
+	// ---------- helpers ----------
+
+	/** Create a fresh file to use as an isolated AR parent (own committed tx). */
+	private static AbstractFile createParentFile(String name) throws TskCoreException {
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			AbstractFile f = caseDB.addFileSystemFile(dataSourceId, fs.getId(), name, 0, 0,
+					TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0, TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC,
+					(short) 0, 200, 0, 0, 0, 0, null, null, null, false, fs, null, null, Collections.emptyList(), trans);
+			trans.commit();
+			return f;
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+	}
+
+	private static Blackboard.NewAnalysisResultRequest req(long parentId, Score score) {
+		return new Blackboard.NewAnalysisResultRequest(AR_TYPE, parentId, dataSourceId, score, null, null, null, Collections.emptyList());
+	}
+
+	private static Significance aggregateSignificance(long objId) throws TskCoreException {
+		return caseDB.getScoringManager().getAggregateScore(objId).getSignificance();
+	}
+
+	private static List<AnalysisResultAdded> insertCommitted(List<Blackboard.NewAnalysisResultRequest> reqs) throws Exception {
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			List<AnalysisResultAdded> out = caseDB.getBlackboard().newAnalysisResults(reqs, trans);
+			trans.commit();
+			return out;
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+	}
+
+	private static int countRows(String table, String whereClause) throws TskCoreException {
+		final int[] count = new int[1];
+		caseDB.getCaseDbAccessManager().select(
+				"COUNT(*) AS c FROM " + table + " WHERE " + whereClause,
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							if (rs.next()) {
+								count[0] = rs.getInt("c");
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		return count[0];
+	}
+
+	// ---------- insert ----------
+
+	/** Input-contract guards for both APIs: null throws, empty is a no-op. */
+	@Test
+	public void nullAndEmptyInputs() throws Exception {
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			try {
+				caseDB.getBlackboard().newAnalysisResults(null, trans);
+				fail("Expected BlackboardException for null requests");
+			} catch (Blackboard.BlackboardException expected) {
+			}
+			try {
+				caseDB.getBlackboard().newAnalysisResults(Collections.emptyList(), null);
+				fail("Expected BlackboardException for null transaction");
+			} catch (Blackboard.BlackboardException expected) {
+			}
+			try {
+				caseDB.getBlackboard().deleteAnalysisResults(null, trans);
+				fail("Expected BlackboardException for null ids");
+			} catch (Blackboard.BlackboardException expected) {
+			}
+
+			assertTrue(caseDB.getBlackboard().newAnalysisResults(Collections.emptyList(), trans).isEmpty());
+			assertTrue(caseDB.getBlackboard().deleteAnalysisResults(Collections.emptyList(), trans).isEmpty());
+		} finally {
+			trans.commit();
+		}
+	}
+
+	/** Single AR with a real score: returned shape, persisted rows, aggregate. */
+	@Test
+	public void singleInsert() throws Exception {
+		AbstractFile parent = createParentFile("single.bin");
+
+		List<AnalysisResultAdded> result = insertCommitted(
+				Collections.singletonList(req(parent.getId(), Score.SCORE_NOTABLE)));
+
+		assertEquals(1, result.size());
+		AnalysisResultAdded added = result.get(0);
+		AnalysisResult ar = added.getAnalysisResult();
+		assertEquals(parent.getId(), ar.getObjectID());
+		assertEquals(AR_TYPE.getTypeID(), ar.getArtifactTypeID());
+		assertEquals(Significance.NOTABLE, ar.getScore().getSignificance());
+		assertEquals("returned aggregate should reflect the new AR", Significance.NOTABLE, added.getAggregateScore().getSignificance());
+
+		assertEquals("blackboard_artifacts row missing", 1, countRows("blackboard_artifacts", "artifact_obj_id = " + ar.getId()));
+		assertEquals("tsk_analysis_results row missing", 1, countRows("tsk_analysis_results", "artifact_obj_id = " + ar.getId()));
+		assertEquals("aggregate score not persisted", Significance.NOTABLE, aggregateSignificance(parent.getId()));
+	}
+
+	/**
+	 * tsk_analysis_results is conditional: an AR with UNKNOWN significance and
+	 * blank conclusion/configuration/justification gets no child row, while one
+	 * with a real score does.
+	 */
+	@Test
+	public void conditionalAnalysisResultsRow() throws Exception {
+		AbstractFile parent = createParentFile("conditional.bin");
+
+		List<AnalysisResultAdded> result = insertCommitted(Arrays.asList(
+				req(parent.getId(), Score.SCORE_UNKNOWN),   // no child row expected
+				req(parent.getId(), Score.SCORE_NOTABLE)));  // child row expected
+
+		long unknownArObjId = result.get(0).getAnalysisResult().getId();
+		long notableArObjId = result.get(1).getAnalysisResult().getId();
+
+		assertEquals("both artifacts should exist", 2,
+				countRows("blackboard_artifacts", "artifact_obj_id IN (" + unknownArObjId + "," + notableArObjId + ")"));
+		assertEquals("UNKNOWN+blank AR must not get a tsk_analysis_results row", 0,
+				countRows("tsk_analysis_results", "artifact_obj_id = " + unknownArObjId));
+		assertEquals("real-scored AR must get a tsk_analysis_results row", 1,
+				countRows("tsk_analysis_results", "artifact_obj_id = " + notableArObjId));
+	}
+
+	/** Attributes are persisted and visible on the returned (cache-authoritative) AR. */
+	@Test
+	public void attributesPersisted() throws Exception {
+		AbstractFile parent = createParentFile("attrs.bin");
+		List<BlackboardAttribute> attrs = Arrays.asList(
+				new BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD, MODULE, "needle"),
+				new BlackboardAttribute(BlackboardAttribute.Type.TSK_PATH_ID, MODULE, 4242L));
+
+		Blackboard.NewAnalysisResultRequest r = new Blackboard.NewAnalysisResultRequest(
+				AR_TYPE, parent.getId(), dataSourceId, Score.SCORE_LIKELY_NOTABLE, null, null, null, attrs);
+
+		List<AnalysisResultAdded> result = insertCommitted(Collections.singletonList(r));
+		AnalysisResult ar = result.get(0).getAnalysisResult();
+
+		assertEquals("cache should return the supplied attributes", 2, ar.getAttributes().size());
+		assertEquals("attribute rows not persisted", 2, countRows("blackboard_attributes", "artifact_id = " + ar.getArtifactID()));
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + ar.getArtifactID() + " AND value_text = 'needle'"));
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + ar.getArtifactID() + " AND value_int64 = 4242"));
+	}
+
+	/**
+	 * Several ARs on one parent resolve to the max score with a single
+	 * aggregate-score row.
+	 *
+	 * <p>The cross-path invariants (final aggregate = max, exactly one aggregate
+	 * row) are asserted always. The batched-collapse specifics (every returned
+	 * entry reports the max; one collapsed UNKNOWN-&gt;NOTABLE ScoreChange) only
+	 * hold on the PostgreSQL path - the SQLite path delegates to the single-row
+	 * method, which reports incremental aggregates and a last-step ScoreChange.</p>
+	 */
+	@Test
+	public void multipleSameParentCollapses() throws Exception {
+		AbstractFile parent = createParentFile("collapse.bin");
+		boolean isPg = caseDB.getDatabaseType() == TskData.DbType.POSTGRESQL;
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			List<AnalysisResultAdded> result = caseDB.getBlackboard().newAnalysisResults(Arrays.asList(
+					req(parent.getId(), Score.SCORE_LIKELY_NOTABLE),
+					req(parent.getId(), Score.SCORE_NOTABLE),
+					req(parent.getId(), Score.SCORE_NONE)), trans);
+
+			if (isPg) {
+				// Batched collapse: every entry reports the same (max) aggregate.
+				for (AnalysisResultAdded a : result) {
+					assertEquals(Significance.NOTABLE, a.getAggregateScore().getSignificance());
+				}
+				// Exactly one collapsed ScoreChange for this parent: UNKNOWN -> NOTABLE.
+				List<ScoreChange> changes = new ArrayList<>();
+				for (ScoreChange sc : trans.getRegisteredScoreChanges()) {
+					if (sc.getObjectId() == parent.getId()) {
+						changes.add(sc);
+					}
+				}
+				assertEquals("one collapsed ScoreChange expected", 1, changes.size());
+				assertEquals(Significance.UNKNOWN, changes.get(0).getOldScore().getSignificance());
+				assertEquals(Significance.NOTABLE, changes.get(0).getNewScore().getSignificance());
+			}
+
+			trans.commit();
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals("exactly one aggregate row for the parent", 1, countRows("tsk_aggregate_score", "obj_id = " + parent.getId()));
+		assertEquals("final aggregate must be the max of the batch", Significance.NOTABLE, aggregateSignificance(parent.getId()));
+	}
+
+	/** A DATA_ARTIFACT type must be rejected. */
+	@Test
+	public void wrongCategoryRejected() throws Exception {
+		AbstractFile parent = createParentFile("wrongcat.bin");
+		// Build the request directly (the DTO constructor also guards category,
+		// but we want to confirm the API rejects it too).
+		try {
+			new Blackboard.NewAnalysisResultRequest(DATA_ARTIFACT_TYPE, parent.getId(), dataSourceId, Score.SCORE_NOTABLE, null, null, null, Collections.emptyList());
+			fail("Expected IllegalArgumentException from the DTO for a DATA_ARTIFACT type");
+		} catch (IllegalArgumentException expected) {
+			assertTrue(expected.getMessage().toLowerCase().contains("analysis result"));
+		}
+	}
+
+	// ---------- delete ----------
+
+	/** Deleting an AR cascades to its child rows and drops the aggregate to UNKNOWN. */
+	@Test
+	public void deleteSingleCascades() throws Exception {
+		AbstractFile parent = createParentFile("del-single.bin");
+		AnalysisResult ar = insertCommitted(Collections.singletonList(req(parent.getId(), Score.SCORE_NOTABLE)))
+				.get(0).getAnalysisResult();
+		assertEquals(Significance.NOTABLE, aggregateSignificance(parent.getId()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		Map<Long, Score> result;
+		try {
+			result = caseDB.getBlackboard().deleteAnalysisResults(Collections.singletonList(ar.getId()), trans);
+			trans.commit();
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		assertEquals(Significance.UNKNOWN, result.get(parent.getId()).getSignificance());
+		assertEquals("blackboard_artifacts row should be gone", 0, countRows("blackboard_artifacts", "artifact_obj_id = " + ar.getId()));
+		assertEquals("tsk_analysis_results child row should be cascade-deleted", 0, countRows("tsk_analysis_results", "artifact_obj_id = " + ar.getId()));
+		assertEquals(Significance.UNKNOWN, aggregateSignificance(parent.getId()));
+	}
+
+	/** Deleting the highest-scoring AR downgrades the aggregate to the next-highest remaining. */
+	@Test
+	public void deleteHighestDowngrades() throws Exception {
+		AbstractFile parent = createParentFile("del-downgrade.bin");
+		List<AnalysisResultAdded> added = insertCommitted(Arrays.asList(
+				req(parent.getId(), Score.SCORE_NOTABLE),
+				req(parent.getId(), Score.SCORE_LIKELY_NOTABLE)));
+		long notableArObjId = added.get(0).getAnalysisResult().getId();
+		assertEquals(Significance.NOTABLE, aggregateSignificance(parent.getId()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		Map<Long, Score> result;
+		try {
+			result = caseDB.getBlackboard().deleteAnalysisResults(Collections.singletonList(notableArObjId), trans);
+			trans.commit();
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(Significance.LIKELY_NOTABLE, result.get(parent.getId()).getSignificance());
+		assertEquals(Significance.LIKELY_NOTABLE, aggregateSignificance(parent.getId()));
+	}
+
+	/** A batched delete spanning multiple parents recomputes each one independently. */
+	@Test
+	public void deleteAcrossParents() throws Exception {
+		AbstractFile p1 = createParentFile("del-p1.bin");
+		AbstractFile p2 = createParentFile("del-p2.bin");
+		AnalysisResult ar1 = insertCommitted(Collections.singletonList(req(p1.getId(), Score.SCORE_NOTABLE))).get(0).getAnalysisResult();
+		AnalysisResult ar2 = insertCommitted(Collections.singletonList(req(p2.getId(), Score.SCORE_LIKELY_NOTABLE))).get(0).getAnalysisResult();
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		Map<Long, Score> result;
+		try {
+			result = caseDB.getBlackboard().deleteAnalysisResults(Arrays.asList(ar1.getId(), ar2.getId()), trans);
+			trans.commit();
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals("one entry per parent", 2, result.size());
+		assertEquals(Significance.UNKNOWN, result.get(p1.getId()).getSignificance());
+		assertEquals(Significance.UNKNOWN, result.get(p2.getId()).getSignificance());
+	}
+
+	/** Non-existent artifact_obj_ids are silently skipped; real ones still delete. */
+	@Test
+	public void deleteMissingIdTolerated() throws Exception {
+		AbstractFile parent = createParentFile("del-missing.bin");
+		AnalysisResult ar = insertCommitted(Collections.singletonList(req(parent.getId(), Score.SCORE_NOTABLE))).get(0).getAnalysisResult();
+		long missingId = 99_999_999L;
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		Map<Long, Score> result;
+		try {
+			result = caseDB.getBlackboard().deleteAnalysisResults(Arrays.asList(missingId, ar.getId()), trans);
+			trans.commit();
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals("only the real parent should be in the map", 1, result.size());
+		assertNotNull(result.get(parent.getId()));
+		assertEquals(0, countRows("blackboard_artifacts", "artifact_obj_id = " + ar.getId()));
+	}
+
+	// ---------- combined / transaction ----------
+
+	/** Delete-then-insert on the same parent in one tx ends at the new AR's score. */
+	@Test
+	public void deleteThenInsertSameParent() throws Exception {
+		AbstractFile parent = createParentFile("del-then-ins.bin");
+		AnalysisResult existing = insertCommitted(Collections.singletonList(req(parent.getId(), Score.SCORE_NOTABLE))).get(0).getAnalysisResult();
+		assertEquals(Significance.NOTABLE, aggregateSignificance(parent.getId()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			caseDB.getBlackboard().deleteAnalysisResults(Collections.singletonList(existing.getId()), trans);
+			caseDB.getBlackboard().newAnalysisResults(Collections.singletonList(req(parent.getId(), Score.SCORE_NONE)), trans);
+			trans.commit();
+		} catch (Exception ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(Significance.NONE, aggregateSignificance(parent.getId()));
+		assertEquals("only the new AR should remain", 1, countRows("blackboard_artifacts", "obj_id = " + parent.getId()));
+	}
+
+	/** A rolled-back batched insert persists nothing. */
+	@Test
+	public void insertRollback() throws Exception {
+		AbstractFile parent = createParentFile("rollback.bin");
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<AnalysisResultAdded> result = caseDB.getBlackboard().newAnalysisResults(Arrays.asList(
+				req(parent.getId(), Score.SCORE_NOTABLE),
+				req(parent.getId(), Score.SCORE_LIKELY_NOTABLE)), trans);
+		long arObjId = result.get(0).getAnalysisResult().getId();
+		trans.rollback();
+
+		assertEquals("rolled-back artifact must not persist", 0, countRows("blackboard_artifacts", "artifact_obj_id = " + arObjId));
+		assertEquals("no AR rows for the parent after rollback", 0, countRows("blackboard_artifacts", "obj_id = " + parent.getId()));
+		assertEquals(Significance.UNKNOWN, aggregateSignificance(parent.getId()));
+	}
+}

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
@@ -77,8 +77,8 @@ public class BatchedArtifactTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			 CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			  caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
+			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			// caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 
@@ -105,6 +105,7 @@ public class BatchedArtifactTest {
 			System.out.println("BatchedArtifactTest DB created at: " + dbPath);
 		} catch (TskCoreException | OsAccountManager.NotUserSIDException ex) {
 			LOGGER.log(Level.SEVERE, "Failed to set up BatchedArtifactTest", ex);
+			fail("Failed to set up BatchedArtifactTest: " + ex.getMessage());
 		}
 	}
 
@@ -423,10 +424,9 @@ public class BatchedArtifactTest {
 	}
 
 	/**
-	 * A null {@code dataSourceObjId} must persist as NULL in
-	 * {@code blackboard_artifacts.data_source_obj_id}, exercising the
-	 * {@code setNull(4, Types.BIGINT)} branch in the batched
-	 * blackboard_artifacts INSERT.
+	 * A null {@code dataSourceObjId} is invalid input for batched data artifact
+	 * creation and must be rejected up front with a {@link TskCoreException}
+	 * (rather than persisted or surfaced as a NullPointerException).
 	 *
 	 * (Note: {@code sourceObjId == 0} is not a supported case for data
 	 * artifacts — {@code blackboard_artifacts.obj_id} is a FK to
@@ -434,27 +434,22 @@ public class BatchedArtifactTest {
 	 * batched paths fail the same way; not tested here.)
 	 */
 	@Test
-	public void nullDataSourceObjIdPersistsAsNull() throws TskCoreException {
+	public void nullDataSourceObjIdRejected() throws TskCoreException {
 		BlackboardArtifact.Type type = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
 
 		Blackboard.NewDataArtifactRequest req = new Blackboard.NewDataArtifactRequest(
 				type, rootFile.getId(), null, Collections.emptyList(), null, null);
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
-		List<DataArtifact> result;
 		try {
-			result = caseDB.getBlackboard().newDataArtifacts(Collections.singletonList(req), trans);
+			caseDB.getBlackboard().newDataArtifacts(Collections.singletonList(req), trans);
 			trans.commit();
+			fail("Expected TskCoreException for null dataSourceObjId");
 		} catch (TskCoreException ex) {
 			trans.rollback();
-			throw ex;
+			assertTrue("Exception should explain the null dataSourceObjId: " + ex.getMessage(),
+					ex.getMessage().toLowerCase().contains("datasourceobjid"));
 		}
-
-		assertEquals(1, result.size());
-		DataArtifact a = result.get(0);
-
-		assertEquals("data_source_obj_id should be NULL when dataSourceObjId==null",
-				1, countRows("blackboard_artifacts", "artifact_id = " + a.getArtifactID() + " AND data_source_obj_id IS NULL"));
 	}
 
 	/**

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
@@ -77,8 +77,8 @@ public class BatchedArtifactTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			//  caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
+			 CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			  caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
@@ -1,0 +1,542 @@
+/*
+ * Sleuth Kit Data Model
+ *
+ * Copyright 2026 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.datamodel;
+
+import java.nio.file.Paths;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for Blackboard#newDataArtifacts, the bulk variant of
+ * Blackboard#newDataArtifact.
+ *
+ * <p>Default execution runs against SQLite (per the suite convention). To
+ * exercise the batched PostgreSQL code path, uncomment the connection block
+ * in {@link #setUpClass} and point it at a test PostgreSQL instance.</p>
+ */
+public class BatchedArtifactTest {
+
+	private static final Logger LOGGER = Logger.getLogger(BatchedArtifactTest.class.getName());
+
+	private static final String TEST_DB = "BatchedArtifactTest.db";
+
+	private static SleuthkitCase caseDB;
+	private static String dbPath = null;
+	private static Image image = null;
+	private static FileSystem fs = null;
+	private static FsContent rootFile = null;
+	private static OsAccount osAccount1 = null;
+	private static OsAccount osAccount2 = null;
+
+	public BatchedArtifactTest() {
+	}
+
+	@BeforeClass
+	public static void setUpClass() {
+		String tempDirPath = System.getProperty("java.io.tmpdir");
+		try {
+			dbPath = Paths.get(tempDirPath, TEST_DB).toString();
+
+			java.io.File dbFile = new java.io.File(dbPath);
+			dbFile.delete();
+			if (dbFile.getParentFile() != null) {
+				dbFile.getParentFile().mkdirs();
+			}
+
+			caseDB = SleuthkitCase.newCase(dbPath);
+
+			// Uncomment to manually exercise the batched PostgreSQL path.
+			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
+
+			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+
+			image = caseDB.addImage(TskData.TSK_IMG_TYPE_ENUM.TSK_IMG_TYPE_DETECT, 512, 1024, "", Collections.emptyList(), "America/NewYork", null, null, null, "BatchedArtifactTestImage", trans);
+			fs = caseDB.addFileSystem(image.getId(), 0, TskData.TSK_FS_TYPE_ENUM.TSK_FS_TYPE_RAW, 0, 0, 0, 0, 0, "", trans);
+
+			// fs.getDataSource() isn't populated until after commit; use image.getId() directly.
+			long dataSourceObjectId = image.getId();
+			rootFile = caseDB.addFileSystemFile(dataSourceObjectId, fs.getId(), "root.bin", 0, 0,
+					TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0, TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC,
+					(short) 0, 200, 0, 0, 0, 0, null, null, null, false, fs, null, null, Collections.emptyList(), trans);
+
+			trans.commit();
+
+			// Create OS accounts for tests that exercise the tsk_data_artifacts side-effect.
+			Host host = caseDB.getHostManager().newHost("batched-test-host");
+			String realmName = "batched-test-realm";
+			String acct1Sid = "S-1-5-21-111111111-222222222-3333333333-1001";
+			String acct2Sid = "S-1-5-21-111111111-222222222-3333333333-1002";
+			caseDB.getOsAccountRealmManager().newWindowsRealm(acct1Sid, realmName, host, OsAccountRealm.RealmScope.LOCAL);
+			osAccount1 = caseDB.getOsAccountManager().newWindowsOsAccount(acct1Sid, null, realmName, host, OsAccountRealm.RealmScope.LOCAL);
+			osAccount2 = caseDB.getOsAccountManager().newWindowsOsAccount(acct2Sid, null, realmName, host, OsAccountRealm.RealmScope.LOCAL);
+
+			System.out.println("BatchedArtifactTest DB created at: " + dbPath);
+		} catch (TskCoreException | OsAccountManager.NotUserSIDException ex) {
+			LOGGER.log(Level.SEVERE, "Failed to set up BatchedArtifactTest", ex);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+	}
+
+	// ---------- DB verification helpers ----------
+
+	/** Count rows matching {@code whereClause} (no leading WHERE) on the given table. */
+	private static int countRows(String table, String whereClause) throws TskCoreException {
+		final int[] count = new int[1];
+		caseDB.getCaseDbAccessManager().select(
+				"COUNT(*) AS c FROM " + table + " WHERE " + whereClause,
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							if (rs.next()) {
+								count[0] = rs.getInt("c");
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		return count[0];
+	}
+
+	/** Read a single long column from a row identified by the given WHERE clause. */
+	private static long selectLong(String column, String table, String whereClause) throws TskCoreException {
+		final long[] value = new long[]{Long.MIN_VALUE};
+		caseDB.getCaseDbAccessManager().select(
+				column + " FROM " + table + " WHERE " + whereClause,
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							if (rs.next()) {
+								value[0] = rs.getLong(column);
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		return value[0];
+	}
+
+	/** Join a list of longs as a comma-separated SQL IN-clause body. */
+	private static String inList(List<Long> ids) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < ids.size(); i++) {
+			if (i > 0) sb.append(',');
+			sb.append(ids.get(i));
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Null and empty input guards.
+	 */
+	@Test
+	public void nullAndEmptyInputs() throws TskCoreException {
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			try {
+				caseDB.getBlackboard().newDataArtifacts(null, trans);
+				fail("Expected TskCoreException for null requests");
+			} catch (TskCoreException expected) {
+			}
+
+			try {
+				caseDB.getBlackboard().newDataArtifacts(Collections.emptyList(), null);
+				fail("Expected TskCoreException for null transaction");
+			} catch (TskCoreException expected) {
+			}
+
+			List<DataArtifact> empty = caseDB.getBlackboard().newDataArtifacts(Collections.emptyList(), trans);
+			assertNotNull(empty);
+			assertEquals(0, empty.size());
+		} finally {
+			trans.commit();
+		}
+	}
+
+	/**
+	 * Single-request happy path; verify the returned DataArtifact has the
+	 * fields the caller supplied.
+	 */
+	@Test
+	public void singleRequest() throws TskCoreException {
+		BlackboardArtifact.Type type = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+		Long dataSourceId = fs.getDataSource().getId();
+
+		Blackboard.NewDataArtifactRequest req = new Blackboard.NewDataArtifactRequest(
+				type, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null);
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<DataArtifact> result;
+		try {
+			result = caseDB.getBlackboard().newDataArtifacts(Collections.singletonList(req), trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		DataArtifact a = result.get(0);
+		assertEquals(rootFile.getId(), a.getObjectID());
+		assertEquals(dataSourceId, a.getDataSourceObjectID());
+		assertEquals(type.getTypeID(), a.getArtifactTypeID());
+
+		// DB-level: confirm the rows are actually persisted.
+		assertEquals("tsk_objects row missing", 1, countRows("tsk_objects", "obj_id = " + a.getId()));
+		assertEquals("tsk_objects par_obj_id mismatch", rootFile.getId(), selectLong("par_obj_id", "tsk_objects", "obj_id = " + a.getId()));
+
+		assertEquals("blackboard_artifacts row missing", 1, countRows("blackboard_artifacts", "artifact_id = " + a.getArtifactID()));
+		assertEquals("blackboard_artifacts.obj_id mismatch", rootFile.getId(), selectLong("obj_id", "blackboard_artifacts", "artifact_id = " + a.getArtifactID()));
+		assertEquals("blackboard_artifacts.artifact_obj_id mismatch", a.getId(), selectLong("artifact_obj_id", "blackboard_artifacts", "artifact_id = " + a.getArtifactID()));
+		assertEquals("blackboard_artifacts.data_source_obj_id mismatch", (long) dataSourceId, selectLong("data_source_obj_id", "blackboard_artifacts", "artifact_id = " + a.getArtifactID()));
+		assertEquals("blackboard_artifacts.artifact_type_id mismatch", type.getTypeID(), selectLong("artifact_type_id", "blackboard_artifacts", "artifact_id = " + a.getArtifactID()));
+
+		// No osAccount in this request, so no tsk_data_artifacts row.
+		assertEquals("unexpected tsk_data_artifacts row", 0, countRows("tsk_data_artifacts", "artifact_obj_id = " + a.getId()));
+
+		// Parent bitset must be updated for the source (the rootFile that
+		// became a parent when this artifact was attached to it).
+		assertTrue("parent has-children bit not set", caseDB.getHasChildren(rootFile));
+	}
+
+	/**
+	 * Mixed artifact types: each returned artifact must carry its request's type.
+	 */
+	@Test
+	public void mixedArtifactTypes() throws TskCoreException {
+		BlackboardArtifact.Type gps = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+		BlackboardArtifact.Type clip = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_CLIPBOARD_CONTENT);
+		BlackboardArtifact.Type area = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_AREA);
+		Long dataSourceId = fs.getDataSource().getId();
+
+		List<Blackboard.NewDataArtifactRequest> reqs = Arrays.asList(
+				new Blackboard.NewDataArtifactRequest(gps, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null),
+				new Blackboard.NewDataArtifactRequest(clip, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null),
+				new Blackboard.NewDataArtifactRequest(area, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null),
+				new Blackboard.NewDataArtifactRequest(gps, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<DataArtifact> result;
+		try {
+			result = caseDB.getBlackboard().newDataArtifacts(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(4, result.size());
+		assertEquals(gps.getTypeID(), result.get(0).getArtifactTypeID());
+		assertEquals(clip.getTypeID(), result.get(1).getArtifactTypeID());
+		assertEquals(area.getTypeID(), result.get(2).getArtifactTypeID());
+		assertEquals(gps.getTypeID(), result.get(3).getArtifactTypeID());
+
+		// DB-level: each returned artifact must be present in blackboard_artifacts
+		// with the type-id we asked for, and each must have a tsk_objects row.
+		List<Long> artifactIds = new ArrayList<>();
+		List<Long> objIds = new ArrayList<>();
+		for (DataArtifact a : result) {
+			artifactIds.add(a.getArtifactID());
+			objIds.add(a.getId());
+		}
+		assertEquals(4, countRows("blackboard_artifacts", "artifact_id IN (" + inList(artifactIds) + ")"));
+		assertEquals(4, countRows("tsk_objects", "obj_id IN (" + inList(objIds) + ")"));
+
+		// Per-row type check.
+		for (int i = 0; i < result.size(); i++) {
+			long readType = selectLong("artifact_type_id", "blackboard_artifacts", "artifact_id = " + result.get(i).getArtifactID());
+			assertEquals("type mismatch for row " + i, result.get(i).getArtifactTypeID(), readType);
+		}
+
+		// No osAccounts → no tsk_data_artifacts rows.
+		assertEquals(0, countRows("tsk_data_artifacts", "artifact_obj_id IN (" + inList(objIds) + ")"));
+	}
+
+	/**
+	 * Mixed osAccountObjId: requests with non-null osAccount should produce
+	 * tsk_data_artifacts rows; requests without should not.
+	 */
+	@Test
+	public void mixedOsAccount() throws TskCoreException {
+		BlackboardArtifact.Type type = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+		Long dataSourceId = fs.getDataSource().getId();
+
+		List<Blackboard.NewDataArtifactRequest> reqs = Arrays.asList(
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, Collections.emptyList(), osAccount1.getId(), null),
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null),
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, Collections.emptyList(), osAccount2.getId(), null),
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<DataArtifact> result;
+		try {
+			result = caseDB.getBlackboard().newDataArtifacts(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(4, result.size());
+
+		// The returned artifacts carry the osAccountObjId from the request via the
+		// DataArtifact constructor's last-but-one parameter. Verify via the
+		// optional accessor.
+		assertTrue(result.get(0).getOsAccountObjectId().isPresent());
+		assertTrue(result.get(1).getOsAccountObjectId().isEmpty());
+		assertTrue(result.get(2).getOsAccountObjectId().isPresent());
+		assertTrue(result.get(3).getOsAccountObjectId().isEmpty());
+
+		// DB-level: 4 rows in blackboard_artifacts; exactly 2 in tsk_data_artifacts.
+		List<Long> artifactIds = new ArrayList<>();
+		List<Long> objIds = new ArrayList<>();
+		for (DataArtifact a : result) {
+			artifactIds.add(a.getArtifactID());
+			objIds.add(a.getId());
+		}
+		assertEquals(4, countRows("blackboard_artifacts", "artifact_id IN (" + inList(artifactIds) + ")"));
+		assertEquals("tsk_data_artifacts should have rows only for the 2 osAccount requests",
+				2, countRows("tsk_data_artifacts", "artifact_obj_id IN (" + inList(objIds) + ")"));
+
+		// The two persisted os_account_obj_id values must be exactly {osAccount1, osAccount2}.
+		final Set<Long> persistedOsAccts = new HashSet<>();
+		caseDB.getCaseDbAccessManager().select(
+				"os_account_obj_id FROM tsk_data_artifacts WHERE artifact_obj_id IN (" + inList(objIds) + ")",
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							while (rs.next()) {
+								persistedOsAccts.add(rs.getLong("os_account_obj_id"));
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		Set<Long> expectedOsAccts = new HashSet<>();
+		expectedOsAccts.add(osAccount1.getId());
+		expectedOsAccts.add(osAccount2.getId());
+		assertEquals(expectedOsAccts, persistedOsAccts);
+	}
+
+	/**
+	 * Attributes covering multiple value types are persisted and visible via
+	 * the artifact's in-memory cache.
+	 */
+	@Test
+	public void withAttributesAcrossValueTypes() throws TskCoreException {
+		BlackboardArtifact.Type type = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+		Long dataSourceId = fs.getDataSource().getId();
+		final String moduleName = "BatchedArtifactTest";
+
+		List<BlackboardAttribute> attrs = new ArrayList<>();
+		// STRING
+		attrs.add(new BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD, moduleName, "needle"));
+		// INTEGER
+		attrs.add(new BlackboardAttribute(BlackboardAttribute.Type.TSK_MALWARE_DETECTED, moduleName, 1));
+		// LONG
+		attrs.add(new BlackboardAttribute(BlackboardAttribute.Type.TSK_PATH_ID, moduleName, 9999L));
+		// DOUBLE
+		attrs.add(new BlackboardAttribute(BlackboardAttribute.Type.TSK_ENTROPY, moduleName, 3.14));
+		// DATETIME (uses LONG storage)
+		attrs.add(new BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_DATETIME, moduleName, 1700000000L));
+
+		Blackboard.NewDataArtifactRequest req = new Blackboard.NewDataArtifactRequest(
+				type, rootFile.getId(), dataSourceId, attrs, null, null);
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<DataArtifact> result;
+		try {
+			result = caseDB.getBlackboard().newDataArtifacts(Collections.singletonList(req), trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		// isNew=true means the cache is authoritative; getAttributes() returns
+		// what we just added without hitting the DB.
+		List<BlackboardAttribute> fetched = result.get(0).getAttributes();
+		assertEquals(attrs.size(), fetched.size());
+
+		// DB-level: 5 rows in blackboard_attributes, distributed across the
+		// value-type columns we wrote. The driver writes each row into the
+		// per-type column (value_text for STRING, value_int32 for INTEGER, etc).
+		long artifactId = result.get(0).getArtifactID();
+		String whereArtifact = "artifact_id = " + artifactId;
+		assertEquals("expected 5 attribute rows", 5, countRows("blackboard_attributes", whereArtifact));
+
+		// Spot-check one row per value type by querying for the expected
+		// non-null column.
+		assertEquals("STRING attr row not found",
+				1, countRows("blackboard_attributes", whereArtifact + " AND value_text = 'needle'"));
+		assertEquals("INTEGER attr row not found",
+				1, countRows("blackboard_attributes", whereArtifact + " AND value_int32 = 1"));
+		// PATH_ID (LONG) and DATETIME (LONG storage) both land in value_int64; their values are distinct.
+		assertEquals("LONG attr row (9999) not found",
+				1, countRows("blackboard_attributes", whereArtifact + " AND value_int64 = 9999"));
+		assertEquals("DATETIME attr row (1700000000) not found",
+				1, countRows("blackboard_attributes", whereArtifact + " AND value_int64 = 1700000000"));
+		// DOUBLE comparison uses a small range to avoid float-equality flakiness.
+		assertEquals("DOUBLE attr row not found",
+				1, countRows("blackboard_attributes", whereArtifact + " AND value_double > 3.13 AND value_double < 3.15"));
+	}
+
+	/**
+	 * A null {@code dataSourceObjId} must persist as NULL in
+	 * {@code blackboard_artifacts.data_source_obj_id}, exercising the
+	 * {@code setNull(4, Types.BIGINT)} branch in the batched
+	 * blackboard_artifacts INSERT.
+	 *
+	 * (Note: {@code sourceObjId == 0} is not a supported case for data
+	 * artifacts — {@code blackboard_artifacts.obj_id} is a FK to
+	 * {@code tsk_objects.obj_id} and 0 will not match. Both single-row and
+	 * batched paths fail the same way; not tested here.)
+	 */
+	@Test
+	public void nullDataSourceObjIdPersistsAsNull() throws TskCoreException {
+		BlackboardArtifact.Type type = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+
+		Blackboard.NewDataArtifactRequest req = new Blackboard.NewDataArtifactRequest(
+				type, rootFile.getId(), null, Collections.emptyList(), null, null);
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<DataArtifact> result;
+		try {
+			result = caseDB.getBlackboard().newDataArtifacts(Collections.singletonList(req), trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		DataArtifact a = result.get(0);
+
+		assertEquals("data_source_obj_id should be NULL when dataSourceObjId==null",
+				1, countRows("blackboard_artifacts", "artifact_id = " + a.getArtifactID() + " AND data_source_obj_id IS NULL"));
+	}
+
+	/**
+	 * Cross-artifact attribute bucketing: each artifact's attributes must
+	 * land against the correct artifact_id even though the helper groups
+	 * attributes by value type across the whole chunk.
+	 */
+	@Test
+	public void attributesAcrossMultipleArtifacts() throws TskCoreException {
+		BlackboardArtifact.Type type = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_GPS_SEARCH);
+		Long dataSourceId = fs.getDataSource().getId();
+		final String moduleName = "BatchedArtifactTest";
+
+		// Three artifacts each with two attrs spanning two value-type buckets
+		// (STRING + LONG). The batched helper groups by value type across all
+		// artifacts; this test catches a bug like "I joined all attrs under
+		// the first artifact's id".
+		List<BlackboardAttribute> attrsA = Arrays.asList(
+				new BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD, moduleName, "artA"),
+				new BlackboardAttribute(BlackboardAttribute.Type.TSK_PATH_ID, moduleName, 1001L));
+		List<BlackboardAttribute> attrsB = Arrays.asList(
+				new BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD, moduleName, "artB"),
+				new BlackboardAttribute(BlackboardAttribute.Type.TSK_PATH_ID, moduleName, 1002L));
+		List<BlackboardAttribute> attrsC = Arrays.asList(
+				new BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD, moduleName, "artC"),
+				new BlackboardAttribute(BlackboardAttribute.Type.TSK_PATH_ID, moduleName, 1003L));
+
+		List<Blackboard.NewDataArtifactRequest> reqs = Arrays.asList(
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, attrsA, null, null),
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, attrsB, null, null),
+				new Blackboard.NewDataArtifactRequest(type, rootFile.getId(), dataSourceId, attrsC, null, null));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<DataArtifact> result;
+		try {
+			result = caseDB.getBlackboard().newDataArtifacts(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(3, result.size());
+		long idA = result.get(0).getArtifactID();
+		long idB = result.get(1).getArtifactID();
+		long idC = result.get(2).getArtifactID();
+
+		// Each artifact must have exactly 2 attribute rows.
+		assertEquals("artA attr count", 2, countRows("blackboard_attributes", "artifact_id = " + idA));
+		assertEquals("artB attr count", 2, countRows("blackboard_attributes", "artifact_id = " + idB));
+		assertEquals("artC attr count", 2, countRows("blackboard_attributes", "artifact_id = " + idC));
+
+		// Each artifact's STRING attribute carries the artifact-specific marker.
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + idA + " AND value_text = 'artA'"));
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + idB + " AND value_text = 'artB'"));
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + idC + " AND value_text = 'artC'"));
+
+		// Each artifact's LONG attribute carries the artifact-specific marker.
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + idA + " AND value_int64 = 1001"));
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + idB + " AND value_int64 = 1002"));
+		assertEquals(1, countRows("blackboard_attributes", "artifact_id = " + idC + " AND value_int64 = 1003"));
+	}
+
+	/**
+	 * ANALYSIS_RESULT-category types must be rejected.
+	 */
+	@Test
+	public void wrongCategoryRejected() throws TskCoreException {
+		BlackboardArtifact.Type analysisType = new BlackboardArtifact.Type(BlackboardArtifact.ARTIFACT_TYPE.TSK_KEYWORD_HIT);
+		Long dataSourceId = fs.getDataSource().getId();
+
+		Blackboard.NewDataArtifactRequest req = new Blackboard.NewDataArtifactRequest(
+				analysisType, rootFile.getId(), dataSourceId, Collections.emptyList(), null, null);
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			caseDB.getBlackboard().newDataArtifacts(Collections.singletonList(req), trans);
+			fail("Expected TskCoreException for non-DATA_ARTIFACT category");
+		} catch (TskCoreException expected) {
+			assertTrue(expected.getMessage().toLowerCase().contains("data artifact"));
+		} finally {
+			trans.rollback();
+		}
+	}
+}

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedArtifactTest.java
@@ -77,8 +77,8 @@ public class BatchedArtifactTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
+			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			//  caseDB = SleuthkitCase.newCase("TskBatchedArtifactTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
@@ -1,0 +1,623 @@
+/*
+ * Sleuth Kit Data Model
+ *
+ * Copyright 2026 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.datamodel;
+
+import java.nio.file.Paths;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for SleuthkitCase#addFileSystemFiles, the bulk variant of
+ * SleuthkitCase#addFileSystemFile.
+ *
+ * <p>Default execution runs against SQLite. To exercise the batched
+ * PostgreSQL code path, uncomment the connection block in {@link #setUpClass}
+ * and point it at a test PostgreSQL instance.</p>
+ */
+public class BatchedFileSystemFileTest {
+
+	private static final Logger LOGGER = Logger.getLogger(BatchedFileSystemFileTest.class.getName());
+
+	private static final String TEST_DB = "BatchedFileSystemFileTest.db";
+
+	private static SleuthkitCase caseDB;
+	private static String dbPath = null;
+	private static Image image = null;
+	private static FileSystem fs = null;
+	private static FsContent rootFile = null;
+	private static OsAccount osAccount = null;
+
+	public BatchedFileSystemFileTest() {
+	}
+
+	@BeforeClass
+	public static void setUpClass() {
+		String tempDirPath = System.getProperty("java.io.tmpdir");
+		try {
+			dbPath = Paths.get(tempDirPath, TEST_DB).toString();
+
+			java.io.File dbFile = new java.io.File(dbPath);
+			dbFile.delete();
+			if (dbFile.getParentFile() != null) {
+				dbFile.getParentFile().mkdirs();
+			}
+
+			caseDB = SleuthkitCase.newCase(dbPath);
+
+			// Uncomment to manually exercise the batched PostgreSQL path.
+			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
+
+			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+
+			image = caseDB.addImage(TskData.TSK_IMG_TYPE_ENUM.TSK_IMG_TYPE_DETECT, 512, 1024, "", Collections.emptyList(), "America/NewYork", null, null, null, "BatchedFileSystemFileTestImage", trans);
+			fs = caseDB.addFileSystem(image.getId(), 0, TskData.TSK_FS_TYPE_ENUM.TSK_FS_TYPE_RAW, 0, 0, 0, 0, 0, "", trans);
+
+			// fs.getDataSource() isn't populated until after commit; use image.getId() directly.
+			long dataSourceObjectId = image.getId();
+			rootFile = caseDB.addFileSystemFile(dataSourceObjectId, fs.getId(), "root.dir", 0, 0,
+					TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0, TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC,
+					(short) 0, 200, 0, 0, 0, 0, null, null, null, false, fs, null, null, Collections.emptyList(), trans);
+
+			trans.commit();
+
+			// One OS account for the withOsAccount test.
+			Host host = caseDB.getHostManager().newHost("batched-fs-host");
+			String realmName = "batched-fs-realm";
+			String acctSid = "S-1-5-21-111111111-222222222-3333333333-2001";
+			caseDB.getOsAccountRealmManager().newWindowsRealm(acctSid, realmName, host, OsAccountRealm.RealmScope.LOCAL);
+			osAccount = caseDB.getOsAccountManager().newWindowsOsAccount(acctSid, null, realmName, host, OsAccountRealm.RealmScope.LOCAL);
+
+			System.out.println("BatchedFileSystemFileTest DB created at: " + dbPath);
+		} catch (TskCoreException | OsAccountManager.NotUserSIDException ex) {
+			LOGGER.log(Level.SEVERE, "Failed to set up BatchedFileSystemFileTest", ex);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+	}
+
+	// ---------- DB verification helpers ----------
+
+	/** Count rows matching {@code whereClause} (no leading WHERE) on the given table. */
+	private static int countRows(String table, String whereClause) throws TskCoreException {
+		final int[] count = new int[1];
+		caseDB.getCaseDbAccessManager().select(
+				"COUNT(*) AS c FROM " + table + " WHERE " + whereClause,
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							if (rs.next()) {
+								count[0] = rs.getInt("c");
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		return count[0];
+	}
+
+	/** Read a single long column from a row identified by the given WHERE clause. */
+	private static long selectLong(String column, String table, String whereClause) throws TskCoreException {
+		final long[] value = new long[]{Long.MIN_VALUE};
+		caseDB.getCaseDbAccessManager().select(
+				column + " FROM " + table + " WHERE " + whereClause,
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							if (rs.next()) {
+								value[0] = rs.getLong(column);
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		return value[0];
+	}
+
+	/** Read a single string column from a row identified by the given WHERE clause. */
+	private static String selectString(String column, String table, String whereClause) throws TskCoreException {
+		final String[] value = new String[]{null};
+		caseDB.getCaseDbAccessManager().select(
+				column + " FROM " + table + " WHERE " + whereClause,
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet rs) {
+						try {
+							if (rs.next()) {
+								value[0] = rs.getString(column);
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		return value[0];
+	}
+
+	/** Join a list of longs as a comma-separated SQL IN-clause body. */
+	private static String inList(List<Long> ids) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < ids.size(); i++) {
+			if (i > 0) sb.append(',');
+			sb.append(ids.get(i));
+		}
+		return sb.toString();
+	}
+
+	// ---------- DTO request builder (defaults for terseness) ----------
+
+	private static SleuthkitCase.NewFileSystemFileRequest dirRequest(String name, String normalizedFullPath, Content parent, String inBatchParentPath, String parentPath) {
+		return new SleuthkitCase.NewFileSystemFileRequest(
+				image.getId(), fs.getId(), name, 0, 0,
+				TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0,
+				TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 0,
+				0, 0, 0, 0,
+				null, null, null, null, false,
+				parent, inBatchParentPath, parentPath, normalizedFullPath,
+				null, null, TskData.CollectedStatus.UNKNOWN, Collections.emptyList());
+	}
+
+	private static SleuthkitCase.NewFileSystemFileRequest fileRequest(String name, Content parent, String inBatchParentPath, String parentPath, List<Attribute> attrs) {
+		return new SleuthkitCase.NewFileSystemFileRequest(
+				image.getId(), fs.getId(), name, 0, 0,
+				TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0,
+				TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 100,
+				0, 0, 0, 0,
+				null, null, null, null, true,
+				parent, inBatchParentPath, parentPath, null,
+				null, null, TskData.CollectedStatus.UNKNOWN, attrs);
+	}
+
+	// ---------- Tests ----------
+
+	/**
+	 * Null inputs, empty input, and DTO constructor validation in one place.
+	 */
+	@Test
+	public void nullAndInvalidInputs() throws TskCoreException {
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			// Null / empty inputs on the public method.
+			try {
+				caseDB.addFileSystemFiles(null, trans);
+				fail("Expected TskCoreException for null requests");
+			} catch (TskCoreException expected) {
+			}
+
+			try {
+				caseDB.addFileSystemFiles(Collections.<SleuthkitCase.NewFileSystemFileRequest>emptyList(), null);
+				fail("Expected TskCoreException for null transaction");
+			} catch (TskCoreException expected) {
+			}
+
+			List<FsContent> empty = caseDB.addFileSystemFiles(Collections.<SleuthkitCase.NewFileSystemFileRequest>emptyList(), trans);
+			assertNotNull(empty);
+			assertEquals(0, empty.size());
+
+			// DTO constructor: both parent refs set → IAE.
+			try {
+				dirRequest("d", "/d/", rootFile, "/something/", "/");
+				fail("Expected IAE for both parent refs non-null");
+			} catch (IllegalArgumentException expected) {
+			}
+
+			// DTO constructor: neither parent ref set → IAE.
+			try {
+				dirRequest("d", "/d/", null, null, "/");
+				fail("Expected IAE for both parent refs null");
+			} catch (IllegalArgumentException expected) {
+			}
+
+			// DTO constructor: directory row without normalizedFullPath → IAE.
+			try {
+				dirRequest("d", null, rootFile, null, "/");
+				fail("Expected IAE for directory without normalizedFullPath");
+			} catch (IllegalArgumentException expected) {
+			}
+
+			// DTO constructor: null fileAttributes → IAE.
+			try {
+				new SleuthkitCase.NewFileSystemFileRequest(
+						image.getId(), fs.getId(), "x", 0, 0,
+						TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0,
+						TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 100,
+						0, 0, 0, 0,
+						null, null, null, null, true,
+						rootFile, null, "/", null,
+						null, null, TskData.CollectedStatus.UNKNOWN, null);
+				fail("Expected IAE for null fileAttributes");
+			} catch (IllegalArgumentException expected) {
+			}
+		} finally {
+			trans.rollback();
+		}
+	}
+
+	/**
+	 * Single-file happy path: tsk_objects, tsk_files, parent_path, and
+	 * parent has-children bit all populated correctly.
+	 */
+	@Test
+	public void singleFile() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Collections.singletonList(
+				fileRequest("solo.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		FsContent file = result.get(0);
+
+		// tsk_objects row exists and points at rootFile as parent.
+		assertEquals(1, countRows("tsk_objects", "obj_id = " + file.getId()));
+		assertEquals(rootFile.getId(), selectLong("par_obj_id", "tsk_objects", "obj_id = " + file.getId()));
+
+		// tsk_files row with the right fields.
+		assertEquals(1, countRows("tsk_files", "obj_id = " + file.getId()));
+		assertEquals("solo.txt", selectString("name", "tsk_files", "obj_id = " + file.getId()));
+		assertEquals("/root.dir/", selectString("parent_path", "tsk_files", "obj_id = " + file.getId()));
+		assertEquals(image.getId(), selectLong("data_source_obj_id", "tsk_files", "obj_id = " + file.getId()));
+		assertEquals(fs.getId(), selectLong("fs_obj_id", "tsk_files", "obj_id = " + file.getId()));
+		// meta_type = REG for files.
+		assertEquals(TskData.TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_REG.getValue(),
+				selectLong("meta_type", "tsk_files", "obj_id = " + file.getId()));
+
+		// Parent has-children bit set.
+		assertTrue("parent has-children bit not set", caseDB.getHasChildren(rootFile));
+	}
+
+	/**
+	 * A batch of mixed dirs + files (both directly under {@code rootFile}).
+	 * Verifies row counts and that dir_type/meta_type are set correctly per row.
+	 */
+	@Test
+	public void mixedFilesAndDirs() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
+				dirRequest("etc", "/root.dir/etc/", rootFile, null, "/root.dir/"),
+				fileRequest("hosts", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()),
+				dirRequest("var", "/root.dir/var/", rootFile, null, "/root.dir/"),
+				fileRequest("README", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(4, result.size());
+
+		List<Long> objIds = new ArrayList<>();
+		for (FsContent f : result) {
+			objIds.add(f.getId());
+		}
+		assertEquals(4, countRows("tsk_objects", "obj_id IN (" + inList(objIds) + ")"));
+		assertEquals(4, countRows("tsk_files", "obj_id IN (" + inList(objIds) + ")"));
+
+		// Two dirs.
+		assertEquals(2, countRows("tsk_files",
+				"obj_id IN (" + inList(objIds) + ") AND meta_type = " + TskData.TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_DIR.getValue()));
+		// Two files.
+		assertEquals(2, countRows("tsk_files",
+				"obj_id IN (" + inList(objIds) + ") AND meta_type = " + TskData.TSK_FS_META_TYPE_ENUM.TSK_FS_META_TYPE_REG.getValue()));
+
+		// All four point at rootFile as parent.
+		assertEquals(4, countRows("tsk_objects",
+				"obj_id IN (" + inList(objIds) + ") AND par_obj_id = " + rootFile.getId()));
+	}
+
+	/**
+	 * In-batch parent reference: a directory at index 0 is referenced by a
+	 * file at index 1 via {@code inBatchParentPath}. Verify the file's
+	 * par_obj_id chains to the directory's obj_id.
+	 */
+	@Test
+	public void inBatchParentResolves() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
+				dirRequest("subdir", "/root.dir/subdir/", rootFile, null, "/root.dir/"),
+				fileRequest("inside.txt", null, "/root.dir/subdir/", "/root.dir/subdir/", Collections.<Attribute>emptyList()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(2, result.size());
+		long dirId = result.get(0).getId();
+		long fileId = result.get(1).getId();
+
+		// File's par_obj_id is the dir's obj_id.
+		assertEquals(dirId, selectLong("par_obj_id", "tsk_objects", "obj_id = " + fileId));
+		// Dir's par_obj_id is rootFile.
+		assertEquals(rootFile.getId(), selectLong("par_obj_id", "tsk_objects", "obj_id = " + dirId));
+	}
+
+	/**
+	 * Unresolvable {@code inBatchParentPath} → {@link TskCoreException}.
+	 */
+	@Test
+	public void inBatchParentMissingThrows() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Collections.singletonList(
+				fileRequest("orphan.txt", null, "/never/declared/", "/never/declared/", Collections.<Attribute>emptyList()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			caseDB.addFileSystemFiles(reqs, trans);
+			fail("Expected TskCoreException for unresolvable inBatchParentPath");
+		} catch (TskCoreException expected) {
+			assertTrue(expected.getMessage().contains("/never/declared/"));
+		} finally {
+			trans.rollback();
+		}
+	}
+
+	/**
+	 * Deep chain: /a → /a/b → /a/b/c → /a/b/c/d.exe, each row's parent the
+	 * previous row via {@code inBatchParentPath}. All four rows committed and
+	 * par_obj_id chain checks out.
+	 */
+	@Test
+	public void deepChain() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
+				dirRequest("a", "/a/", rootFile, null, "/root.dir/"),
+				dirRequest("b", "/a/b/", null, "/a/", "/a/"),
+				dirRequest("c", "/a/b/c/", null, "/a/b/", "/a/b/"),
+				fileRequest("d.exe", null, "/a/b/c/", "/a/b/c/", Collections.<Attribute>emptyList()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(4, result.size());
+		long aId = result.get(0).getId();
+		long bId = result.get(1).getId();
+		long cId = result.get(2).getId();
+		long dId = result.get(3).getId();
+
+		assertEquals(rootFile.getId(), selectLong("par_obj_id", "tsk_objects", "obj_id = " + aId));
+		assertEquals(aId, selectLong("par_obj_id", "tsk_objects", "obj_id = " + bId));
+		assertEquals(bId, selectLong("par_obj_id", "tsk_objects", "obj_id = " + cId));
+		assertEquals(cId, selectLong("par_obj_id", "tsk_objects", "obj_id = " + dId));
+	}
+
+	/**
+	 * Two directory rows sharing the same {@code normalizedFullPath} within
+	 * a single batch must be rejected.
+	 */
+	@Test
+	public void duplicateInBatchPathThrows() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
+				dirRequest("etc", "/root.dir/etc/", rootFile, null, "/root.dir/"),
+				dirRequest("etc-copy", "/root.dir/etc/", rootFile, null, "/root.dir/"));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			caseDB.addFileSystemFiles(reqs, trans);
+			fail("Expected TskCoreException for duplicate normalizedFullPath");
+		} catch (TskCoreException expected) {
+			assertTrue(expected.getMessage().toLowerCase().contains("duplicate"));
+		} finally {
+			trans.rollback();
+		}
+	}
+
+	/**
+	 * One file with attributes covering all value-type columns. Verify rows
+	 * persist in tsk_file_attributes and each Attribute's id and
+	 * attributeParentId are set after the call.
+	 */
+	@Test
+	public void withAttributesAcrossValueTypes() throws TskCoreException {
+		// STRING, INTEGER, LONG, DOUBLE, DATETIME (LONG-storage)
+		List<Attribute> attrs = new ArrayList<>();
+		attrs.add(new Attribute(new BlackboardAttribute.Type(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD), "needle"));
+		attrs.add(new Attribute(BlackboardAttribute.Type.TSK_MALWARE_DETECTED, 1));
+		attrs.add(new Attribute(BlackboardAttribute.Type.TSK_PATH_ID, 9999L));
+		attrs.add(new Attribute(BlackboardAttribute.Type.TSK_ENTROPY, 3.14));
+		attrs.add(new Attribute(new BlackboardAttribute.Type(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_DATETIME), 1700000000L));
+
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Collections.singletonList(
+				fileRequest("attrs.txt", rootFile, null, "/root.dir/", attrs));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		long fileId = result.get(0).getId();
+
+		// 5 rows total in tsk_file_attributes.
+		assertEquals(5, countRows("tsk_file_attributes", "obj_id = " + fileId));
+
+		// Spot-check one row per value type.
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + fileId + " AND value_text = 'needle'"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + fileId + " AND value_int32 = 1"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + fileId + " AND value_int64 = 9999"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + fileId + " AND value_int64 = 1700000000"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + fileId + " AND value_double > 3.13 AND value_double < 3.15"));
+
+		// Each Attribute object got id and parentObjId set (mirrors single-row contract).
+		for (Attribute a : attrs) {
+			assertTrue("attribute id was not assigned", a.getId() > 0);
+			assertEquals("attributeParentId mismatch", fileId, a.getAttributeParentId());
+		}
+	}
+
+	/**
+	 * Three files each with two attributes — verify each attribute is
+	 * persisted against the correct {@code obj_id} (catches a bug like
+	 * "all attrs end up on the first file's id").
+	 */
+	@Test
+	public void attributesAcrossMultipleFiles() throws TskCoreException {
+		List<Attribute> attrsA = Arrays.asList(
+				new Attribute(new BlackboardAttribute.Type(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD), "fileA"),
+				new Attribute(BlackboardAttribute.Type.TSK_PATH_ID, 1001L));
+		List<Attribute> attrsB = Arrays.asList(
+				new Attribute(new BlackboardAttribute.Type(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD), "fileB"),
+				new Attribute(BlackboardAttribute.Type.TSK_PATH_ID, 1002L));
+		List<Attribute> attrsC = Arrays.asList(
+				new Attribute(new BlackboardAttribute.Type(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_KEYWORD), "fileC"),
+				new Attribute(BlackboardAttribute.Type.TSK_PATH_ID, 1003L));
+
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
+				fileRequest("a.txt", rootFile, null, "/root.dir/", attrsA),
+				fileRequest("b.txt", rootFile, null, "/root.dir/", attrsB),
+				fileRequest("c.txt", rootFile, null, "/root.dir/", attrsC));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(3, result.size());
+		long idA = result.get(0).getId();
+		long idB = result.get(1).getId();
+		long idC = result.get(2).getId();
+
+		// Each file has exactly 2 attribute rows.
+		assertEquals(2, countRows("tsk_file_attributes", "obj_id = " + idA));
+		assertEquals(2, countRows("tsk_file_attributes", "obj_id = " + idB));
+		assertEquals(2, countRows("tsk_file_attributes", "obj_id = " + idC));
+
+		// Each file's STRING attribute carries the file-specific marker.
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + idA + " AND value_text = 'fileA'"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + idB + " AND value_text = 'fileB'"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + idC + " AND value_text = 'fileC'"));
+
+		// Each file's LONG attribute carries the file-specific marker.
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + idA + " AND value_int64 = 1001"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + idB + " AND value_int64 = 1002"));
+		assertEquals(1, countRows("tsk_file_attributes", "obj_id = " + idC + " AND value_int64 = 1003"));
+	}
+
+	/**
+	 * A request with a non-null {@code osAccount} produces a row in
+	 * tsk_os_account_instances of type ACCESSED.
+	 */
+	@Test
+	public void withOsAccount() throws TskCoreException {
+		SleuthkitCase.NewFileSystemFileRequest req = new SleuthkitCase.NewFileSystemFileRequest(
+				image.getId(), fs.getId(), "with-os.txt", 0, 0,
+				TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0,
+				TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 100,
+				0, 0, 0, 0,
+				null, null, null, null, true,
+				rootFile, null, "/root.dir/", null,
+				null, osAccount, TskData.CollectedStatus.UNKNOWN, Collections.<Attribute>emptyList());
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		List<FsContent> result;
+		try {
+			result = caseDB.addFileSystemFiles(Collections.singletonList(req), trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertEquals(1, result.size());
+		long fileId = result.get(0).getId();
+
+		// tsk_files row carries os_account_obj_id.
+		assertEquals(osAccount.getId(),
+				selectLong("os_account_obj_id", "tsk_files", "obj_id = " + fileId));
+
+		// tsk_os_account_instances row exists for this (os_account_obj_id, data_source_obj_id).
+		assertEquals("expected an ACCESSED os_account_instances row",
+				1, countRows("tsk_os_account_instances",
+						"os_account_obj_id = " + osAccount.getId()
+						+ " AND data_source_obj_id = " + image.getId()
+						+ " AND instance_type = " + OsAccountInstance.OsAccountInstanceType.ACCESSED.getId()));
+	}
+
+	/**
+	 * After a batch creating three children under {@code rootFile},
+	 * {@code hasChildren(rootFile)} reports true.
+	 */
+	@Test
+	public void hasChildrenPropagates() throws TskCoreException {
+		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
+				fileRequest("c1.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()),
+				fileRequest("c2.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()),
+				fileRequest("c3.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()));
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try {
+			caseDB.addFileSystemFiles(reqs, trans);
+			trans.commit();
+		} catch (TskCoreException ex) {
+			trans.rollback();
+			throw ex;
+		}
+
+		assertTrue("parent has-children bit not set", caseDB.getHasChildren(rootFile));
+	}
+}

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
@@ -74,8 +74,8 @@ public class BatchedFileSystemFileTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
+			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			// caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
@@ -74,8 +74,8 @@ public class BatchedFileSystemFileTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			 caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
+			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			// caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 
@@ -100,6 +100,7 @@ public class BatchedFileSystemFileTest {
 			System.out.println("BatchedFileSystemFileTest DB created at: " + dbPath);
 		} catch (TskCoreException | OsAccountManager.NotUserSIDException ex) {
 			LOGGER.log(Level.SEVERE, "Failed to set up BatchedFileSystemFileTest", ex);
+			fail("Failed to set up BatchedFileSystemFileTest: " + ex.getMessage());
 		}
 	}
 
@@ -181,25 +182,25 @@ public class BatchedFileSystemFileTest {
 
 	// ---------- DTO request builder (defaults for terseness) ----------
 
-	private static SleuthkitCase.NewFileSystemFileRequest dirRequest(String name, String normalizedFullPath, Content parent, String inBatchParentPath, String parentPath) {
+	private static SleuthkitCase.NewFileSystemFileRequest dirRequest(String name, String normalizedFullPath, Content parent, String inBatchParentPath) {
 		return new SleuthkitCase.NewFileSystemFileRequest(
 				image.getId(), fs.getId(), name, 0, 0,
 				TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0,
 				TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 0,
 				0, 0, 0, 0,
 				null, null, null, null, false,
-				parent, inBatchParentPath, parentPath, normalizedFullPath,
+				parent, inBatchParentPath, normalizedFullPath,
 				null, null, TskData.CollectedStatus.UNKNOWN, Collections.emptyList());
 	}
 
-	private static SleuthkitCase.NewFileSystemFileRequest fileRequest(String name, Content parent, String inBatchParentPath, String parentPath, List<Attribute> attrs) {
+	private static SleuthkitCase.NewFileSystemFileRequest fileRequest(String name, Content parent, String inBatchParentPath, List<Attribute> attrs) {
 		return new SleuthkitCase.NewFileSystemFileRequest(
 				image.getId(), fs.getId(), name, 0, 0,
 				TskData.TSK_FS_ATTR_TYPE_ENUM.TSK_FS_ATTR_TYPE_DEFAULT, 0,
 				TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 100,
 				0, 0, 0, 0,
 				null, null, null, null, true,
-				parent, inBatchParentPath, parentPath, null,
+				parent, inBatchParentPath, null,
 				null, null, TskData.CollectedStatus.UNKNOWN, attrs);
 	}
 
@@ -231,21 +232,21 @@ public class BatchedFileSystemFileTest {
 
 			// DTO constructor: both parent refs set → IAE.
 			try {
-				dirRequest("d", "/d/", rootFile, "/something/", "/");
+				dirRequest("d", "/d/", rootFile, "/something/");
 				fail("Expected IAE for both parent refs non-null");
 			} catch (IllegalArgumentException expected) {
 			}
 
 			// DTO constructor: neither parent ref set → IAE.
 			try {
-				dirRequest("d", "/d/", null, null, "/");
+				dirRequest("d", "/d/", null, null);
 				fail("Expected IAE for both parent refs null");
 			} catch (IllegalArgumentException expected) {
 			}
 
 			// DTO constructor: directory row without normalizedFullPath → IAE.
 			try {
-				dirRequest("d", null, rootFile, null, "/");
+				dirRequest("d", null, rootFile, null);
 				fail("Expected IAE for directory without normalizedFullPath");
 			} catch (IllegalArgumentException expected) {
 			}
@@ -258,7 +259,7 @@ public class BatchedFileSystemFileTest {
 						TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 100,
 						0, 0, 0, 0,
 						null, null, null, null, true,
-						rootFile, null, "/", null,
+						rootFile, null, null,
 						null, null, TskData.CollectedStatus.UNKNOWN, null);
 				fail("Expected IAE for null fileAttributes");
 			} catch (IllegalArgumentException expected) {
@@ -275,7 +276,7 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void singleFile() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Collections.singletonList(
-				fileRequest("solo.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()));
+				fileRequest("solo.txt", rootFile, null, Collections.<Attribute>emptyList()));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		List<FsContent> result;
@@ -297,7 +298,7 @@ public class BatchedFileSystemFileTest {
 		// tsk_files row with the right fields.
 		assertEquals(1, countRows("tsk_files", "obj_id = " + file.getId()));
 		assertEquals("solo.txt", selectString("name", "tsk_files", "obj_id = " + file.getId()));
-		assertEquals("/root.dir/", selectString("parent_path", "tsk_files", "obj_id = " + file.getId()));
+		assertEquals("/", selectString("parent_path", "tsk_files", "obj_id = " + file.getId()));
 		assertEquals(image.getId(), selectLong("data_source_obj_id", "tsk_files", "obj_id = " + file.getId()));
 		assertEquals(fs.getId(), selectLong("fs_obj_id", "tsk_files", "obj_id = " + file.getId()));
 		// meta_type = REG for files.
@@ -315,10 +316,10 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void mixedFilesAndDirs() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
-				dirRequest("etc", "/root.dir/etc/", rootFile, null, "/root.dir/"),
-				fileRequest("hosts", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()),
-				dirRequest("var", "/root.dir/var/", rootFile, null, "/root.dir/"),
-				fileRequest("README", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()));
+				dirRequest("etc", "/root.dir/etc/", rootFile, null),
+				fileRequest("hosts", rootFile, null, Collections.<Attribute>emptyList()),
+				dirRequest("var", "/root.dir/var/", rootFile, null),
+				fileRequest("README", rootFile, null, Collections.<Attribute>emptyList()));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		List<FsContent> result;
@@ -359,8 +360,8 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void inBatchParentResolves() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
-				dirRequest("subdir", "/root.dir/subdir/", rootFile, null, "/root.dir/"),
-				fileRequest("inside.txt", null, "/root.dir/subdir/", "/root.dir/subdir/", Collections.<Attribute>emptyList()));
+				dirRequest("subdir", "/root.dir/subdir/", rootFile, null),
+				fileRequest("inside.txt", null, "/root.dir/subdir/", Collections.<Attribute>emptyList()));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		List<FsContent> result;
@@ -388,7 +389,7 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void inBatchParentMissingThrows() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Collections.singletonList(
-				fileRequest("orphan.txt", null, "/never/declared/", "/never/declared/", Collections.<Attribute>emptyList()));
+				fileRequest("orphan.txt", null, "/never/declared/", Collections.<Attribute>emptyList()));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		try {
@@ -409,10 +410,10 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void deepChain() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
-				dirRequest("a", "/a/", rootFile, null, "/root.dir/"),
-				dirRequest("b", "/a/b/", null, "/a/", "/a/"),
-				dirRequest("c", "/a/b/c/", null, "/a/b/", "/a/b/"),
-				fileRequest("d.exe", null, "/a/b/c/", "/a/b/c/", Collections.<Attribute>emptyList()));
+				dirRequest("a", "/a/", rootFile, null),
+				dirRequest("b", "/a/b/", null, "/a/"),
+				dirRequest("c", "/a/b/c/", null, "/a/b/"),
+				fileRequest("d.exe", null, "/a/b/c/", Collections.<Attribute>emptyList()));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		List<FsContent> result;
@@ -443,8 +444,8 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void duplicateInBatchPathThrows() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
-				dirRequest("etc", "/root.dir/etc/", rootFile, null, "/root.dir/"),
-				dirRequest("etc-copy", "/root.dir/etc/", rootFile, null, "/root.dir/"));
+				dirRequest("etc", "/root.dir/etc/", rootFile, null),
+				dirRequest("etc-copy", "/root.dir/etc/", rootFile, null));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		try {
@@ -473,7 +474,7 @@ public class BatchedFileSystemFileTest {
 		attrs.add(new Attribute(new BlackboardAttribute.Type(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_DATETIME), 1700000000L));
 
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Collections.singletonList(
-				fileRequest("attrs.txt", rootFile, null, "/root.dir/", attrs));
+				fileRequest("attrs.txt", rootFile, null, attrs));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		List<FsContent> result;
@@ -523,9 +524,9 @@ public class BatchedFileSystemFileTest {
 				new Attribute(BlackboardAttribute.Type.TSK_PATH_ID, 1003L));
 
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
-				fileRequest("a.txt", rootFile, null, "/root.dir/", attrsA),
-				fileRequest("b.txt", rootFile, null, "/root.dir/", attrsB),
-				fileRequest("c.txt", rootFile, null, "/root.dir/", attrsC));
+				fileRequest("a.txt", rootFile, null, attrsA),
+				fileRequest("b.txt", rootFile, null, attrsB),
+				fileRequest("c.txt", rootFile, null, attrsC));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		List<FsContent> result;
@@ -570,7 +571,7 @@ public class BatchedFileSystemFileTest {
 				TskData.TSK_FS_NAME_FLAG_ENUM.ALLOC, (short) 0, 100,
 				0, 0, 0, 0,
 				null, null, null, null, true,
-				rootFile, null, "/root.dir/", null,
+				rootFile, null, null,
 				null, osAccount, TskData.CollectedStatus.UNKNOWN, Collections.<Attribute>emptyList());
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
@@ -605,9 +606,9 @@ public class BatchedFileSystemFileTest {
 	@Test
 	public void hasChildrenPropagates() throws TskCoreException {
 		List<SleuthkitCase.NewFileSystemFileRequest> reqs = Arrays.asList(
-				fileRequest("c1.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()),
-				fileRequest("c2.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()),
-				fileRequest("c3.txt", rootFile, null, "/root.dir/", Collections.<Attribute>emptyList()));
+				fileRequest("c1.txt", rootFile, null, Collections.<Attribute>emptyList()),
+				fileRequest("c2.txt", rootFile, null, Collections.<Attribute>emptyList()),
+				fileRequest("c3.txt", rootFile, null, Collections.<Attribute>emptyList()));
 
 		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 		try {

--- a/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/BatchedFileSystemFileTest.java
@@ -74,8 +74,8 @@ public class BatchedFileSystemFileTest {
 			caseDB = SleuthkitCase.newCase(dbPath);
 
 			// Uncomment to manually exercise the batched PostgreSQL path.
-			// CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
-			// caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
+			CaseDbConnectionInfo connectionInfo = new CaseDbConnectionInfo("localhost", "5432", "ct_user", "ct_user_abc", TskData.DbType.POSTGRESQL);
+			 caseDB = SleuthkitCase.newCase("TskBatchedFileSystemFileTest", connectionInfo, tempDirPath);
 
 			SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
 

--- a/bindings/java/test/org/sleuthkit/datamodel/CaseDbAccessManagerBatchTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CaseDbAccessManagerBatchTest.java
@@ -1,0 +1,215 @@
+/*
+ * Sleuth Kit Data Model
+ *
+ * Copyright 2026 Basis Technology Corp.
+ * Contact: carrier <at> sleuthkit <dot> org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.sleuthkit.datamodel;
+
+import java.nio.file.Paths;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for the batch-insert APIs on CaseDbAccessManager:
+ * addToBatch, insertBatch, and getMaxBatchSize.
+ */
+public class CaseDbAccessManagerBatchTest {
+
+	private static final Logger LOGGER = Logger.getLogger(CaseDbAccessManagerBatchTest.class.getName());
+
+	private static final String TEST_DB = "CaseDbAccessManagerBatchTest.db";
+	private static final String TEST_TABLE = "test_batch_insert";
+
+	private static SleuthkitCase caseDB;
+	private static String dbPath = null;
+
+	public CaseDbAccessManagerBatchTest() {
+	}
+
+	@BeforeClass
+	public static void setUpClass() {
+		String tempDirPath = System.getProperty("java.io.tmpdir");
+		try {
+			dbPath = Paths.get(tempDirPath, TEST_DB).toString();
+
+			java.io.File dbFile = new java.io.File(dbPath);
+			dbFile.delete();
+			if (dbFile.getParentFile() != null) {
+				dbFile.getParentFile().mkdirs();
+			}
+
+			caseDB = SleuthkitCase.newCase(dbPath);
+
+			caseDB.getCaseDbAccessManager().createTable(
+					TEST_TABLE,
+					"(id INTEGER PRIMARY KEY, name TEXT NOT NULL, value INTEGER)");
+
+			System.out.println("CaseDbAccessManagerBatchTest DB created at: " + dbPath);
+		} catch (TskCoreException ex) {
+			LOGGER.log(Level.SEVERE, "Failed to set up batch insert test", ex);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+	}
+
+	/**
+	 * Inserts a handful of rows via addToBatch + insertBatch, then reads them
+	 * back via select and verifies the contents.
+	 */
+	@Test
+	public void batchInsertHappyPath() throws Exception {
+		CaseDbAccessManager mgr = caseDB.getCaseDbAccessManager();
+
+		final int rowCount = 5;
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try (CaseDbAccessManager.CaseDbPreparedStatement stmt
+				= mgr.prepareInsert(TEST_TABLE, "(id, name, value) VALUES (?, ?, ?)", trans)) {
+
+			for (int i = 1; i <= rowCount; i++) {
+				stmt.setLong(1, i);
+				stmt.setString(2, "row-" + i);
+				stmt.setLong(3, i * 100L);
+				mgr.addToBatch(stmt);
+			}
+
+			int[] counts = mgr.insertBatch(stmt);
+			assertEquals(rowCount, counts.length);
+		}
+		trans.commit();
+
+		final List<Long> readBack = new ArrayList<>();
+		mgr.select(
+				"value FROM " + TEST_TABLE + " WHERE id BETWEEN 1 AND " + rowCount + " ORDER BY id",
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet resultSet) {
+						try {
+							while (resultSet.next()) {
+								readBack.add(resultSet.getLong("value"));
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException reading back rows: " + ex.getMessage());
+						}
+					}
+				});
+
+		assertEquals(rowCount, readBack.size());
+		for (int i = 0; i < rowCount; i++) {
+			assertEquals((i + 1) * 100L, (long) readBack.get(i));
+		}
+	}
+
+	/**
+	 * The same prepared statement must be reusable for a second batch after
+	 * insertBatch has been called.
+	 */
+	@Test
+	public void batchReuseAfterExecute() throws Exception {
+		CaseDbAccessManager mgr = caseDB.getCaseDbAccessManager();
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try (CaseDbAccessManager.CaseDbPreparedStatement stmt
+				= mgr.prepareInsert(TEST_TABLE, "(id, name, value) VALUES (?, ?, ?)", trans)) {
+
+			for (int i = 100; i < 103; i++) {
+				stmt.setLong(1, i);
+				stmt.setString(2, "reuse-a-" + i);
+				stmt.setLong(3, i);
+				mgr.addToBatch(stmt);
+			}
+			mgr.insertBatch(stmt);
+
+			for (int i = 200; i < 203; i++) {
+				stmt.setLong(1, i);
+				stmt.setString(2, "reuse-b-" + i);
+				stmt.setLong(3, i);
+				mgr.addToBatch(stmt);
+			}
+			mgr.insertBatch(stmt);
+		}
+		trans.commit();
+
+		final int[] count = new int[1];
+		mgr.select(
+				"COUNT(*) AS c FROM " + TEST_TABLE + " WHERE id >= 100 AND id < 300",
+				new CaseDbAccessManager.CaseDbAccessQueryCallback() {
+					@Override
+					public void process(ResultSet resultSet) {
+						try {
+							if (resultSet.next()) {
+								count[0] = resultSet.getInt("c");
+							}
+						} catch (SQLException ex) {
+							fail("Unexpected SQLException: " + ex.getMessage());
+						}
+					}
+				});
+		assertEquals(6, count[0]);
+	}
+
+	/**
+	 * getMaxBatchSize should return floor(65000 / paramsPerRow).
+	 */
+	@Test
+	public void getMaxBatchSizeReflectsColumnCount() throws Exception {
+		CaseDbAccessManager mgr = caseDB.getCaseDbAccessManager();
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try (CaseDbAccessManager.CaseDbPreparedStatement stmt
+				= mgr.prepareInsert(TEST_TABLE, "(id, name, value) VALUES (?, ?, ?)", trans)) {
+			assertEquals(65000 / 3, mgr.getMaxBatchSize(stmt));
+		}
+		trans.rollback();
+	}
+
+	/**
+	 * addToBatch and insertBatch must reject a SELECT prepared statement.
+	 */
+	@Test
+	public void batchRejectsNonInsertStatement() throws Exception {
+		CaseDbAccessManager mgr = caseDB.getCaseDbAccessManager();
+
+		SleuthkitCase.CaseDbTransaction trans = caseDB.beginTransaction();
+		try (CaseDbAccessManager.CaseDbPreparedStatement stmt
+				= mgr.prepareSelect("id FROM " + TEST_TABLE + " WHERE id = ?", trans)) {
+			try {
+				mgr.addToBatch(stmt);
+				fail("Expected TskCoreException for non-INSERT statement");
+			} catch (TskCoreException expected) {
+				assertTrue(expected.getMessage().toLowerCase().contains("incorrect type"));
+			}
+			try {
+				mgr.insertBatch(stmt);
+				fail("Expected TskCoreException for non-INSERT statement");
+			} catch (TskCoreException expected) {
+				assertTrue(expected.getMessage().toLowerCase().contains("incorrect type"));
+			}
+		}
+		trans.rollback();
+	}
+}

--- a/bindings/java/test/org/sleuthkit/datamodel/CaseDbAccessManagerBatchTest.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/CaseDbAccessManagerBatchTest.java
@@ -70,6 +70,7 @@ public class CaseDbAccessManagerBatchTest {
 			System.out.println("CaseDbAccessManagerBatchTest DB created at: " + dbPath);
 		} catch (TskCoreException ex) {
 			LOGGER.log(Level.SEVERE, "Failed to set up batch insert test", ex);
+			fail("Failed to set up batch insert test: " + ex.getMessage());
 		}
 	}
 

--- a/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
@@ -50,6 +50,7 @@ import org.junit.runners.Suite;
 	OsAccountTest.class,
 	TimelineEventTypesTest.class,
 	CaseDbAccessManagerBatchTest.class,
+	BatchedArtifactTest.class,
 	
 //  Note: these tests have dependencies on images being placed in the input folder: nps-2009-canon2-gen6, ntfs1-gen, and small2	
 //	org.sleuthkit.datamodel.TopDownTraversal.class, 

--- a/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
@@ -51,7 +51,8 @@ import org.junit.runners.Suite;
 	TimelineEventTypesTest.class,
 	CaseDbAccessManagerBatchTest.class,
 	BatchedArtifactTest.class,
-	
+	BatchedFileSystemFileTest.class,
+
 //  Note: these tests have dependencies on images being placed in the input folder: nps-2009-canon2-gen6, ntfs1-gen, and small2	
 //	org.sleuthkit.datamodel.TopDownTraversal.class, 
 //	org.sleuthkit.datamodel.SequentialTraversal.class, 

--- a/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
+++ b/bindings/java/test/org/sleuthkit/datamodel/DataModelTestSuite.java
@@ -42,13 +42,14 @@ import org.junit.runners.Suite;
  * default ant target sets properties for the various folders.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ 
-	CommunicationsManagerTest.class, 
+@Suite.SuiteClasses({
+	CommunicationsManagerTest.class,
 	CaseDbSchemaVersionNumberTest.class,
 	AttributeTest.class,
 	ArtifactTest.class,
 	OsAccountTest.class,
 	TimelineEventTypesTest.class,
+	CaseDbAccessManagerBatchTest.class,
 	
 //  Note: these tests have dependencies on images being placed in the input folder: nps-2009-canon2-gen6, ntfs1-gen, and small2	
 //	org.sleuthkit.datamodel.TopDownTraversal.class, 


### PR DESCRIPTION
The PG JDBC pool already has reWriteBatchedInserts=true, which fuses executeBatch into one multi-VALUES INSERT at the wire level — but TSK had no API
  surface that called addBatch/executeBatch. This PR adds that surface in three layered places, each scoped to one consumer pattern.

  Shared design choices (apply to all three commits)

  1. Sequence pre-allocation, not RETURN_GENERATED_KEYS. RGK defeats reWriteBatchedInserts. The two new code paths in Blackboard and SleuthkitCase reserve N
  ids in one round trip using nextval(pg_get_serial_sequence(...)) FROM generate_series(1, ?) AS ord ORDER BY ord, then issue batched INSERTs with explicit
  ids. pg_get_serial_sequence survives sequence renames; ORDER BY ord makes positional reads in Java deterministic.
  2. No acquireSingleUserCaseWriteLock. The single-row paths take this lock via addObject. The batched paths intentionally don't — the caller-owned
  CaseDbTransaction already serializes writes on its connection, and PG sequence atomicity handles cross-connection concurrency. Reintroducing the lock would
   serialize concurrent batched calls. Rationale lives in the javadoc on both batched-postgres helpers; do not "add it back for safety" without re-reading.
  3. Caller owns the transaction. No BEGIN/COMMIT logic in the new methods — they operate inside the caller's existing CaseDbTransaction. Failure semantics:
  BatchUpdateException is wrapped in TskCoreException; the chunk is all-or-nothing under reWriteBatchedInserts=true (caller rolls back).
  4. Chunking is internal; input list is unbounded. Each new method partitions the input internally (PG_CHUNK_SIZE=9000 for artifacts,
  PG_FILES_CHUNK_SIZE=2000 for files, PG_ATTR_CHUNK_SIZE=5000 / PG_FILE_ATTR_CHUNK_SIZE=5000 for attributes). Sizes are picked to keep each batch's
  bind-parameter count under PG's 65,535 hard ceiling with ≥15% margin given the column count per row.
  5. SQLite path is a per-row delegate. SQLite's in-process driver makes cross-row batching unprofitable; we loop the existing single-row method to keep
  semantics identical. Same test class can run against either backend.
  6. JDBC URL gate is additive and SSL-safe. SleuthkitCase appends reWriteBatchedInserts=true to the PG case-DB URL — & when an SSL param already opened the
  query string with ?, ? otherwise (SleuthkitCase.java:14660-14662).

  ---
  Commit 1 — Batching inserts in PG for performance improvements (CaseDbAccessManager)

  What changed:
  - CaseDbAccessManager.addToBatch(CaseDbPreparedStatement) — void, mirrors addBatch(). Same INSERT-type guard as insert(CaseDbPreparedStatement).
  - CaseDbAccessManager.insertBatch(CaseDbPreparedStatement) — returns int[] (per-row update counts from executeBatch).
  - SleuthkitCase.java:14660 — append reWriteBatchedInserts=true to the PG JDBC URL.
  - New test: CaseDbAccessManagerBatchTest.
Commit 2 — Batch insert data artifacts (Blackboard.newDataArtifacts)

  What changed in Blackboard.java:
  - Public method newDataArtifacts(List<NewDataArtifactRequest>, CaseDbTransaction) → List<DataArtifact>.
  - Public nested DTO NewDataArtifactRequest (fields mirror the 7-arg newDataArtifact overload, plus argument validation in the ctor).
  - Private newDataArtifactsBatchedPostgres — the actual PG path (steps 1-7 below).
  - Private addAttributesBatched — buckets attributes from all artifacts in the chunk by TSK_BLACKBOARD_ATTRIBUTE_VALUE_TYPE, then runs one executeBatch per
  non-empty bucket against the matching INSERT_*_ATTRIBUTE prepared statement, inner-chunked at PG_ATTR_CHUNK_SIZE.
  - Constants PG_CHUNK_SIZE = 9000, PG_ATTR_CHUNK_SIZE = 5000.
  - Blackboard.java:2462 — replace inline INSERT INTO tsk_data_artifacts string with the new INSERT_DATA_ARTIFACT enum entry (single-row path now shares the
  SQL with the batched path).

  What changed in SleuthkitCase.java:
  - 3 new PREPARED_STATEMENT entries: POSTGRESQL_RESERVE_ARTIFACT_IDS, POSTGRESQL_INSERT_OBJECT_WITH_ID, INSERT_DATA_ARTIFACT.
  - PREPARED_STATEMENT enum: private → package-private (javadoc'd to scope usage; see "risks" below).
  - setHasChildren(Long): private → package-private (called from the batched path).

  What changed in BlackboardArtifact.java:
  - New package-private markAttributesAdded(Collection<BlackboardAttribute>) — same observable cache mutation as the line 520 mutation inside addAttributes,
  but skips the per-attribute DB INSERT (the batched path has already persisted them).

  PG path, per chunk (≤9000 requests):
  1. Reserve N obj_ids + N artifact_ids in one executeQuery (sequence + generate_series).
  2. Batch INSERT into tsk_objects with explicit obj_ids.
  3. Batch INSERT into blackboard_artifacts (reuses the existing INSERT_ARTIFACT entry; BIGSERIAL accepts explicit values).
  4. Batch INSERT into tsk_data_artifacts for the subset with osAccountObjId != null.
  5. Per-row newOsAccountInstance only when osAccountInstanceType != null (no-op in CT's hot paths).
  6. setHasChildren(parentId) once per unique parent at end-of-chunk.
  7. Construct DataArtifact instances with isNew=true (sets loadedCacheFromDb=true), then addAttributesBatched for per-bucket attribute persistence + cache
  update.

  Projected gain: 372 µs/call → ~10-15 µs/call on windowsEvent (~25-35×).

  Risks captured in the design doc and preserved here:
  - Attribute order across artifacts within a value-type bucket is not preserved (blackboard_attributes row order is not API contract; per-artifact
  attrsCache ordering is preserved).
  - has-children bit propagates at end-of-chunk, not per-row — observable only by a concurrent reader of hasChildren(parentId) mid-batch.
  - The PREPARED_STATEMENT package-private widening is the most invasive single change. Javadoc'd to limit scope; alternative is narrow per-statement getters
   on SleuthkitCase.

  ---
  Commit 3 — Batched files insert (SleuthkitCase.addFileSystemFiles)

  Structurally the same shape as commit 2, but lives inside SleuthkitCase (so no cross-class visibility flips are needed) and adds in-batch parent resolution
   — a file's parent may itself be created earlier in the same batch.

  What changed in SleuthkitCase.java:
  - Public method addFileSystemFiles(List<NewFileSystemFileRequest>, CaseDbTransaction) → List<FsContent>.
  - Public nested DTO NewFileSystemFileRequest (mirrors the 25-arg single-row addFileSystemFile, with Content parent XOR String inBatchParentPath enforced in
   the ctor).
  - Private addFileSystemFilesBatchedPostgres — the PG path.
  - Private addFileAttributesBatched — sequence-reserves tsk_file_attributes.id, batches the INSERT, then writes the assigned ids back via Attribute.setId /
  setAttributeParentId (package-private; reused as-is).
  - 3 new PREPARED_STATEMENT entries: POSTGRESQL_RESERVE_FILE_IDS, POSTGRESQL_RESERVE_FILE_ATTRIBUTE_IDS, POSTGRESQL_INSERT_FILE_ATTRIBUTE_WITH_ID. Reuses
  the existing INSERT_FILE_SYSTEM_FILE and POSTGRESQL_INSERT_OBJECT_WITH_ID entries (the latter is the one introduced in commit 2; this commit takes the
  dependency).
  - Constants PG_FILES_CHUNK_SIZE = 2000, PG_FILE_ATTR_CHUNK_SIZE = 5000. Tighter file chunk because tsk_files has 28 columns vs blackboard_artifacts' 5.

  Parent ordering contract: each request specifies its parent via exactly one of:
  - parent: Content — for parents from a committed prior batch or case bootstrap (caller holds the Content directly; the batched code does not call
  getContentById because a separate pooled connection cannot see rows still in the caller's uncommitted transaction).
  - inBatchParentPath: String — lookup key into a per-call map keyed on normalizedFullPath; parent must appear earlier in the input list. The inBatchMap is
  built at the public-method level (outside the chunking loop) so in-batch parents can span chunk boundaries.

  Duplicate normalizedFullPath within one call, or an inBatchParentPath that doesn't resolve, throws TskCoreException.

  Side effects preserved from the single-row path:
  - setHasChildren once per unique parent at end-of-chunk.
  - Timeline event creation per row when timelineEventsDisabled.get() == false (no-op for CT). Not batched in this PR; a future timeline-batching PR will
  handle that.
  - osAccountManager.newOsAccountInstance(...) per row when osAccount != null, type ACCESSED — matches single-row line 7900. Server-side deduped.

  Skipped vs single-row path: isRootDirectory(parent, transaction) is not called; the caller supplies parentPath directly.

  Projected gain: ~3.5 RTs/file → ~3 RTs/chunk of ~2000 files. ~9 min/host of file-path wire latency → seconds.

  ---
  Tests

  Three new test classes follow the project convention (ArtifactTest.java pattern — SQLite by default, opt-in PG via uncommenting one block in setUpClass):

  - CaseDbAccessManagerBatchTest — addToBatch/insertBatch round-trip, empty batch, wrong-type rejection, failure propagation, statement reuse.
  - BatchedArtifactTest — null inputs, empty list, single request, mixed types, mixed OS-acct, all attribute value types, wrong category rejection,
  return-order, cache population. Opt-in PG: chunk boundary at 9000, outer chunking at 12000, attribute inner-chunk at 6000, rollback, concurrent batches,
  PG-vs-SQLite parity.
  - BatchedFileSystemFileTest — parallel coverage including the parent-ordering edge cases (Content parent, inBatchParentPath parent, parent spanning chunk
  boundary, duplicate path detection, unresolved path).

  Wired into DataModelTestSuite. Default CI run exercises the SQLite branch and the API contract; PG-path tests need the manual-uncomment block, same release
   convention as ArtifactTest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beta bulk APIs for creating data artifacts, analysis results, and filesystem entries (PostgreSQL-optimized batched paths; SQLite falls back to per-row). Bulk attribute persistence, aggregate-score recomputation, and batch analysis-result deletion included.
  * Batch insert APIs for DB access and improved score recompute helpers.

* **Tests**
  * New test suites covering batched artifacts/filesystem ingestion, batched analysis-result create/delete, batch DB behavior, validation, attribute persistence, and scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->