### PR TITLE
Added E01 Verification into img_stat and library

### DIFF
--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -162,7 +162,8 @@ main(int argc, char **argv1)
             exit(1);
         case TSK_IMG_VERIFY_UNSUPPORTED:
             tsk_printf("Verification: UNSUPPORTED\n");
-            break;
+            tsk_img_close(img);
+            exit(1);
         }
     }
 

--- a/tools/imgtools/img_stat.cpp
+++ b/tools/imgtools/img_stat.cpp
@@ -9,16 +9,32 @@
  * This software is distributed under the Common Public License 1.0
  */
 #include "tsk/tsk_tools_i.h"
+#include <stdio.h>
 
 static TSK_TCHAR *progname;
+
+static void
+verify_progress_cb(int a_percent, const char *a_msg, void *a_ctx)
+{
+    if (a_msg != NULL) {
+        /* Final call on FAIL/ERROR: clear progress line, capture message. */
+        tsk_printf("\r%-45s\r", "");   /* erase progress line */
+        if (a_ctx)
+            snprintf((char *) a_ctx, 100, "%s", a_msg);
+    } else {
+        tsk_printf("\rCalculating hash of image: %3d%%", a_percent);
+        fflush(stdout);
+    }
+}
 
 static void
 usage()
 {
     TFPRINTF(stderr,
         _TSK_T
-        ("usage: %" PRIttocTSK " [-tvV] [-i imgtype] [-b dev_sector_size] image\n"),
+        ("usage: %" PRIttocTSK " [-ctvV] [-i imgtype] [-b dev_sector_size] image\n"),
         progname);
+    tsk_fprintf(stderr, "\t-c: verify image integrity (MD5 check; EWF only)\n");
     tsk_fprintf(stderr, "\t-t: display type only\n");
     tsk_fprintf(stderr,
         "\t-i imgtype: The format of the image file (use '-i list' for list of supported types)\n");
@@ -38,6 +54,7 @@ main(int argc, char **argv1)
     TSK_IMG_TYPE_ENUM imgtype = TSK_IMG_TYPE_DETECT;
     int ch;
     uint8_t type = 0;
+    uint8_t do_check = 0;
     TSK_TCHAR **argv;
     unsigned int ssize = 0;
     TSK_TCHAR *cp;
@@ -55,7 +72,7 @@ main(int argc, char **argv1)
 
     progname = argv[0];
 
-    while ((ch = GETOPT(argc, argv, _TSK_T("b:i:tvV"))) > 0) {
+    while ((ch = GETOPT(argc, argv, _TSK_T("b:ci:tvV"))) > 0) {
         switch (ch) {
         case _TSK_T('?'):
         default:
@@ -84,6 +101,10 @@ main(int argc, char **argv1)
                     OPTARG);
                 usage();
             }
+            break;
+
+        case _TSK_T('c'):
+            do_check = 1;
             break;
 
         case _TSK_T('t'):
@@ -119,6 +140,30 @@ main(int argc, char **argv1)
     }
     else {
         img->imgstat(img, stdout);
+    }
+
+    if (do_check) {
+        char vdetail[100];
+        vdetail[0] = '\0';
+        TSK_IMG_VERIFY_RESULT vr = tsk_img_verify(img, verify_progress_cb, vdetail);
+        switch (vr) {
+        case TSK_IMG_VERIFY_PASS:
+            tsk_printf("\rVerification: PASS                    \n");
+            break;
+        case TSK_IMG_VERIFY_FAIL:
+            tsk_printf("Verification: FAIL\n");
+            if (vdetail[0]) tsk_printf("Details: %s\n", vdetail);
+            tsk_img_close(img);
+            exit(1);
+        case TSK_IMG_VERIFY_ERROR:
+            tsk_printf("Verification: ERROR\n");
+            if (vdetail[0]) tsk_printf("Details: %s\n", vdetail);
+            tsk_img_close(img);
+            exit(1);
+        case TSK_IMG_VERIFY_UNSUPPORTED:
+            tsk_printf("Verification: UNSUPPORTED\n");
+            break;
+        }
     }
 
     tsk_img_close(img);

--- a/tsk/fs/logical_fs.cpp
+++ b/tsk/fs/logical_fs.cpp
@@ -966,17 +966,6 @@ case_insensitive_compare(const std::wstring& a_a, const std::wstring& a_b) {
 		}
 	);
 }
-#else
-static bool
-case_insensitive_compare(const string& a_a, const string& a_b) {
-	return std::lexicographical_compare(
-		a_a.begin(), a_a.end(),
-		a_b.begin(), a_b.end(),
-		[](char a_a, char a_b) {
-			return std::tolower(a_a) < std::tolower(a_b);
-		}
-	);
-}
 #endif
 
 /*
@@ -2220,6 +2209,7 @@ typedef enum {
  *     entry point handles conversion)
  *   - Joins with base_path (which is always \\?\-prefixed) — no further conversion needed
  */
+#ifdef TSK_WIN32
 static LOGICAL_PATH_TYPE
 logical_fs_check_path(TSK_FS_INFO *a_fs, const TSK_TCHAR *a_path_wide) {
 	if (a_fs == NULL || a_path_wide == NULL || a_fs->ftype != TSK_FS_TYPE_LOGICAL) {
@@ -2232,7 +2222,6 @@ logical_fs_check_path(TSK_FS_INFO *a_fs, const TSK_TCHAR *a_path_wide) {
 		return LOGICAL_PATH_NOT_FOUND;
 	}
 
-#ifdef TSK_WIN32
 	LOGICALFS_INFO* logical_fs_info = (LOGICALFS_INFO*)a_fs;
 
 	// Build full host path: base_path + a_path_wide.
@@ -2255,10 +2244,8 @@ logical_fs_check_path(TSK_FS_INFO *a_fs, const TSK_TCHAR *a_path_wide) {
 		return LOGICAL_PATH_DIRECTORY;
 	}
 	return LOGICAL_PATH_FILE;
-#else
-	return LOGICAL_PATH_NOT_FOUND;
-#endif
 }
+#endif
 
 /*
  * Populate a TSK_FS_NAME from a resolved logical-FS leaf. Mirrors what the
@@ -2276,6 +2263,7 @@ logical_fs_check_path(TSK_FS_INFO *a_fs, const TSK_TCHAR *a_path_wide) {
  * Caller is responsible for having allocated a_fs_name->name and shrt_name
  * buffers. No-op if a_fs_name is NULL.
  */
+#ifdef TSK_WIN32
 static void
 populate_fs_name(TSK_FS_NAME *a_fs_name, TSK_INUM_T a_inum,
                  const wchar_t *a_leaf_wide, bool a_is_dir) {
@@ -2304,6 +2292,7 @@ populate_fs_name(TSK_FS_NAME *a_fs_name, TSK_INUM_T a_inum,
 	a_fs_name->type = a_is_dir ? TSK_FS_NAME_TYPE_DIR : TSK_FS_NAME_TYPE_REG;
 	a_fs_name->flags = TSK_FS_NAME_FLAG_ALLOC;
 }
+#endif  /* TSK_WIN32 */
 
 /*
  * Logical-FS path → inum resolver. Single entry point used by tsk_fs_path2inum's

--- a/tsk/fs/logical_fs.cpp
+++ b/tsk/fs/logical_fs.cpp
@@ -28,11 +28,11 @@
 
 #ifdef TSK_WIN32
 #include <windows.h>
+using std::wstring;
 #endif
 
 using std::vector;
 using std::string;
-using std::wstring;
 
 // Forward declaration: load_dir_and_file_lists_win uses this comparator when sorting
 // before caching, but the function bodies live further down. Keep these signatures in

--- a/tsk/fs/logical_fs.cpp
+++ b/tsk/fs/logical_fs.cpp
@@ -40,9 +40,6 @@ using std::wstring;
 #ifdef TSK_WIN32
 static bool
 case_insensitive_compare(const std::wstring& a_a, const std::wstring& a_b);
-#else
-static bool
-case_insensitive_compare(const std::string& a_a, const std::string& a_b);
 #endif
 
 static uint8_t

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -696,4 +696,88 @@ std::string ewf_get_details(IMG_EWF_INFO *ewf_info) {
     free(result);
     return collectionDetails;
 }
+
+/**
+ * Verify an EWF image by recomputing the MD5 hash of all logical bytes and
+ * comparing it to the hash stored in the image.
+ *
+ * @param img_info  Open EWF image
+ * @param cb        Optional callback invoked during computation.
+ *                  Called as cb(percent, NULL, ctx) for progress ticks (0-100).
+ *                  Called as cb(100, message, ctx) on FAIL or ERROR, where
+ *                  message describes the problem.  Pass NULL to disable.
+ * @param cb_ctx    Caller context pointer forwarded to cb.
+ * @returns TSK_IMG_VERIFY_RESULT
+ */
+TSK_IMG_VERIFY_RESULT
+ewf_image_verify(TSK_IMG_INFO * img_info,
+    TSK_IMG_VERIFY_CB cb, void *cb_ctx)
+{
+    IMG_EWF_INFO *ewf_info = (IMG_EWF_INFO *) img_info;
+
+    if (ewf_info->md5hash_isset != 1)
+        return TSK_IMG_VERIFY_UNSUPPORTED;
+
+    const size_t BUF_SIZE = 1 << 20;  /* 1 MB read buffer */
+    char *buf = (char *) tsk_malloc(BUF_SIZE);
+    if (buf == NULL) {
+        if (cb) cb(100, "out of memory allocating read buffer", cb_ctx);
+        return TSK_IMG_VERIFY_ERROR;
+    }
+
+    TSK_MD5_CTX ctx;
+    TSK_MD5_Init(&ctx);
+
+    int last_pct = -1;
+    TSK_OFF_T off = 0;
+    while (off < img_info->size) {
+        TSK_OFF_T remaining = img_info->size - off;
+        size_t want = (size_t) (remaining < (TSK_OFF_T) BUF_SIZE
+                                ? remaining : (TSK_OFF_T) BUF_SIZE);
+        ssize_t got = tsk_img_read(img_info, off, buf, want);
+        if (got <= 0) {
+            free(buf);
+            if (cb) {
+                char errmsg[80];
+                snprintf(errmsg, sizeof(errmsg),
+                         "read error at offset %" PRIdOFF, off);
+                cb(100, errmsg, cb_ctx);
+            }
+            return TSK_IMG_VERIFY_ERROR;
+        }
+        TSK_MD5_Update(&ctx, (unsigned char *) buf, (unsigned int) got);
+        off += got;
+
+        if (cb != NULL) {
+            int pct = (int) ((off * 100) / img_info->size);
+            if (pct != last_pct) {
+                cb(pct, NULL, cb_ctx);
+                last_pct = pct;
+            }
+        }
+    }
+    free(buf);
+
+    unsigned char raw[TSK_MD5_DIGEST_LENGTH];
+    TSK_MD5_Final(raw, &ctx);
+
+    /* Convert raw bytes to lowercase hex string */
+    char computed[33];
+    for (int i = 0; i < TSK_MD5_DIGEST_LENGTH; i++) {
+        snprintf(computed + i * 2, 3, "%02x", (unsigned int) raw[i]);
+    }
+
+    if (strcasecmp(ewf_info->md5hash, computed) == 0) {
+        if (cb) cb(100, NULL, cb_ctx);
+        return TSK_IMG_VERIFY_PASS;
+    }
+
+    if (cb) {
+        char errmsg[100];
+        snprintf(errmsg, sizeof(errmsg), "MD5 mismatch: stored=%s  computed=%s",
+                 ewf_info->md5hash, computed);
+        cb(100, errmsg, cb_ctx);
+    }
+    return TSK_IMG_VERIFY_FAIL;
+}
 #endif                          /* HAVE_LIBEWF */

--- a/tsk/img/ewf.cpp
+++ b/tsk/img/ewf.cpp
@@ -718,7 +718,7 @@ ewf_image_verify(TSK_IMG_INFO * img_info,
     if (ewf_info->md5hash_isset != 1)
         return TSK_IMG_VERIFY_UNSUPPORTED;
 
-    const size_t BUF_SIZE = 1 << 20;  /* 1 MB read buffer */
+    const size_t BUF_SIZE = 4 << 20;  /* 4 MB read buffer */
     char *buf = (char *) tsk_malloc(BUF_SIZE);
     if (buf == NULL) {
         if (cb) cb(100, "out of memory allocating read buffer", cb_ctx);

--- a/tsk/img/img_io.c
+++ b/tsk/img/img_io.c
@@ -248,3 +248,30 @@ tsk_img_read(TSK_IMG_INFO * a_img_info, TSK_OFF_T a_off,
     tsk_release_lock(&(a_img_info->cache_lock));
     return read_count;
 }
+
+/**
+ * \ingroup imglib
+ * Verifies the integrity of an open disk image by recomputing its hash and
+ * comparing it to the stored value.  Currently only EWF (E01) images with a
+ * stored MD5 hash are supported.
+ *
+ * @param a_img_info Disk image to verify
+ * @param cb     Optional callback (may be NULL). Called as cb(percent, NULL, ctx)
+ *               for progress ticks 0-100, and cb(100, message, ctx) on FAIL or ERROR.
+ * @param cb_ctx Opaque pointer forwarded to cb.
+ * @returns TSK_IMG_VERIFY_RESULT value
+ */
+TSK_IMG_VERIFY_RESULT
+tsk_img_verify(TSK_IMG_INFO * a_img_info,
+    TSK_IMG_VERIFY_CB cb, void *cb_ctx)
+{
+    if (a_img_info == NULL || a_img_info->tag != TSK_IMG_INFO_TAG)
+        return TSK_IMG_VERIFY_ERROR;
+
+#if HAVE_LIBEWF
+    if (TSK_IMG_TYPE_ISEWF(a_img_info->itype))
+        return ewf_image_verify(a_img_info, cb, cb_ctx);
+#endif
+
+    return TSK_IMG_VERIFY_UNSUPPORTED;
+}

--- a/tsk/img/tsk_img.h
+++ b/tsk/img/tsk_img.h
@@ -113,6 +113,26 @@ extern "C" {
         void (*imgstat) (TSK_IMG_INFO *, FILE *);       ///< Pointer to file type specific function
     };
 
+    /**
+     * Return value for tsk_img_verify().
+     */
+    typedef enum {
+        TSK_IMG_VERIFY_UNSUPPORTED = 0,  ///< Image type does not support verification
+        TSK_IMG_VERIFY_ERROR       = 1,  ///< Error during verification (e.g., read failure)
+        TSK_IMG_VERIFY_PASS        = 2,  ///< Hash matched
+        TSK_IMG_VERIFY_FAIL        = 3,  ///< Hash mismatch
+    } TSK_IMG_VERIFY_RESULT;
+
+    /**
+     * Optional callback for tsk_img_verify().
+     * Called periodically during hash computation and once on completion.
+     * @param a_percent  Completion percentage 0–100
+     * @param a_msg      NULL during progress ticks; on FAIL or ERROR, a
+     *                   human-readable description of the problem.
+     * @param a_context  Caller-supplied context pointer.
+     */
+    typedef void (*TSK_IMG_VERIFY_CB)(int a_percent, const char *a_msg, void *a_context);
+
     // open and close functions
     extern TSK_IMG_INFO *tsk_img_open_sing(const TSK_TCHAR * a_image,
         TSK_IMG_TYPE_ENUM type, unsigned int a_ssize);
@@ -134,6 +154,10 @@ extern "C" {
     // read functions
     extern ssize_t tsk_img_read(TSK_IMG_INFO * img, TSK_OFF_T off,
         char *buf, size_t len);
+
+    // verify functions
+    extern TSK_IMG_VERIFY_RESULT tsk_img_verify(TSK_IMG_INFO * img,
+        TSK_IMG_VERIFY_CB cb, void *cb_ctx);
 
     // type conversion functions
     extern TSK_IMG_TYPE_ENUM tsk_img_type_toid_utf8(const char *);

--- a/tsk/img/tsk_img_i.h
+++ b/tsk/img/tsk_img_i.h
@@ -40,6 +40,11 @@ extern void tsk_img_free(void *);
 extern TSK_TCHAR **tsk_img_findFiles(const TSK_TCHAR * a_startingName,
     int *a_numFound);
 
+#if HAVE_LIBEWF
+extern TSK_IMG_VERIFY_RESULT ewf_image_verify(TSK_IMG_INFO *img_info,
+    TSK_IMG_VERIFY_CB cb, void *cb_ctx);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a disk image integrity verification API that reports **PASS/FAIL/ERROR/UNSUPPORTED**, with optional callback-based **progress** and **details** messaging.
  * Enhanced the image statistics tool with a **`-c`** option to run verification and display results (including extra details when available).
  * Implemented verification for EWF images by recomputing and comparing the stored checksum, with progress updates.

* **Bug Fixes**
  * Improved Windows-specific string comparison and restricted certain Windows-only helpers to prevent unintended non-Windows compilation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->