### PR TITLE
Add System.loadLibrary fallback for native library loading

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/LibraryUtils.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/LibraryUtils.java
@@ -75,10 +75,17 @@ public class LibraryUtils {
 	public static boolean loadSleuthkitJNI() {
 		boolean loaded = LibraryUtils.loadNativeLibFromTskJar(Lib.TSK_JNI);
 		if (!loaded) {
-			System.out.println("SleuthkitJNI: failed to load " + Lib.TSK_JNI.getLibName()); //NON-NLS
-		} else {
-			// We want minimal console output for command line use case
-			//System.out.println("SleuthkitJNI: loaded " + Lib.TSK_JNI.getLibName()); //NON-NLS
+			// Fallback: try loading from system library path.
+			// This is needed when the class is loaded by a module classloader
+			// (e.g. NetBeans RCP) that doesn't expose jar resources via
+			// Class.getResource(), or when the native library is installed
+			// system-wide via sleuthkit-java package.
+			try {
+				System.loadLibrary(Lib.TSK_JNI.getUnixName());
+				loaded = true;
+			} catch (UnsatisfiedLinkError e) {
+				System.out.println("SleuthkitJNI: failed to load " + Lib.TSK_JNI.getLibName()); //NON-NLS
+			}
 		}
 		return loaded;
 	}


### PR DESCRIPTION
## Summary

Adds a `System.loadLibrary()` fallback in `LibraryUtils.loadSleuthkitJNI()` so the native library can be loaded from `java.library.path` when jar-based extraction fails.

## Problem

`loadNativeLibFromTskJar()` uses `SleuthkitJNI.class.getResource(path)` to locate `libtsk_jni.so` inside the jar. This fails under modular classloaders (e.g. NetBeans RCP used by Autopsy) because module classloaders don't expose jar-internal resources via `Class.getResource()`.

Without this fallback, Autopsy on Linux shows:
```
Library not found in jar (libtsk_jni)
SleuthkitJNI: failed to load libtsk_jni
```

## Fix

When jar extraction fails, try `System.loadLibrary("tsk_jni")` which loads from `java.library.path`. This works when `sleuthkit-java` is installed system-wide (providing `/usr/lib/x86_64-linux-gnu/libtsk_jni.so`).

The jar-based extraction remains the primary method for backwards compatibility.

## Testing

Verified on:
- Kali Linux (Debian-based)
- Java 21 (Eclipse Adoptium)
- Autopsy 4.23.1 with NetBeans module classloader

Fixes #3515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native library loading so the application can fall back to the system library path if bundled resources are unavailable.
  * Added more reliable handling when the JNI library is installed outside the application package, reducing startup/load failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->