### PR TITLE
apfs: prevent integer underflow reading corrupted APFS images

### DIFF
--- a/tsk/fs/decmpfs.c
+++ b/tsk/fs/decmpfs.c
@@ -303,6 +303,11 @@ decmpfs_read_lzvn_block_table(const TSK_FS_ATTR *rAttr, CMP_OFFSET_ENTRY** offse
     }
 
     tableDataSize = tsk_getu32(TSK_LIT_ENDIAN, fourBytes);
+    if (tableDataSize < 4) {
+        error_returned
+            (" %s: tableDataSize %u is too small", __func__, tableDataSize);
+        return 0;
+    }
 
     offsetTableData = tsk_malloc(tableDataSize);
     if (offsetTableData == NULL) {


### PR DESCRIPTION
Fixes a crash that happens when reading a corrupted APFS image.

It prevents `tableSize` to be evaluated as zero or negative integer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for compressed file table parsing by rejecting invalid table sizes earlier.
  * Prevents crashes or incorrect behavior when the computed table data is too small to be valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->