### PR TITLE
apfs: guard against null _child_it in APFSBtreeNodeIterator

### DIFF
--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -356,6 +356,11 @@ class APFSBtreeNodeIterator {
       return true;
     }
 
+    // Handle child iterator null safely
+    if (_child_it == nullptr || rhs._child_it == nullptr) {
+      return _child_it == rhs._child_it;   // equal only if both are null
+    }
+
     // Otherwise, let's compare the child iterators.
     return (*_child_it == *rhs._child_it);
   }


### PR DESCRIPTION
Fix this crash:

```
/usr/include/c++/15/bits/unique_ptr.h:455: typename std::add_lvalue_reference<_Tp>::type std::unique_ptr<_Tp, _Dp>::operator*() const [with _Tp = APFSBtreeNodeIterator<APFSJObjBtreeNode>; _Dp = std::default_delete<APFSBtreeNodeIterator<APFSJObjBtreeNode> >; typename std::add_lvalue_reference<_Tp>::type = APFSBtreeNodeIterator<APFSJObjBtreeNode>&]: Assertion 'get() != pointer()' failed.

Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=0) at ./nptl/pthread_kill.c:44
⚠ aviso: 44    ./nptl/pthread_kill.c: Arquivo ou diretório inexistente
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=0) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:89
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:100
#3  0x00007ffff6c45b7e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff6c288ec in __GI_abort () at ./stdlib/abort.c:77
#5  0x00007ffff7cae716 in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00005555555e87eb in std::unique_ptr<APFSBtreeNodeIterator<APFSJObjBtreeNode>, std::default_delete<APFSBtreeNodeIterator<APFSJObjBtreeNode> > >::operator* (this=0x7fffffffba80) at /usr/include/c++/15/bits/unique_ptr.h:455
#7  0x00005555555e6a71 in APFSBtreeNodeIterator<APFSJObjBtreeNode>::operator== (this=0x555555844b50, rhs=...) at ../fs/tsk_apfs.hpp:360
#8  0x00005555555e981f in APFSBtreeNodeIterator<APFSJObjBtreeNode>::operator!= (this=0x555555844b50, rhs=...) at ../fs/tsk_apfs.hpp:364
#9  0x00005555555eabd4 in APFSBtreeNodeIterator<APFSJObjBtreeNode>::operator++ (this=0x555555844ec0) at ../fs/tsk_apfs.hpp:314
#10 0x00005555555eab7e in APFSBtreeNodeIterator<APFSJObjBtreeNode>::operator++ (this=0x7fffffffbc60) at ../fs/tsk_apfs.hpp:312
#11 0x00005555555e9b88 in __find_if<APFSBtreeNodeIterator<APFSJObjBtreeNode>, __gnu_cxx::__ops::_Iter_pred<APFSJObjBtreeNode::find_range<long unsigned int, APFSJObjTree::jobjs(uint64_t) const::<lambda(const auto:3&, const auto:4&)> >(long unsigned int const&, APFSJObjTree::jobjs(uint64_t) const::<lambda(const auto:3&, const auto:4&)>) const::<lambda(const auto:2&)> > > (__first=..., __last=..., __pred=...) at /usr/include/c++/15/bits/stl_algobase.h:2096
#12 0x00005555555e857b in find_if<APFSBtreeNodeIterator<APFSJObjBtreeNode>, APFSJObjBtreeNode::find_range<long unsigned int, APFSJObjTree::jobjs(uint64_t) const::<lambda(const auto:3&, const auto:4&)> >(long unsigned int const&, APFSJObjTree::jobjs(uint64_t) const::<lambda(const auto:3&, const auto:4&)>) const::<lambda(const auto:2&)> > (__first=..., __last=..., __pred=...) at /usr/include/c++/15/bits/stl_algo.h:3922
#13 0x00005555555e6480 in APFSJObjBtreeNode::find_range<unsigned long, APFSJObjTree::jobjs(unsigned long) const::{lambda(auto:1 const&, auto:2 const&)#1}>(unsigned long const&, APFSJObjTree::jobjs(unsigned long) const::{lambda(auto:1 const&, auto:2 const&)#1}) const (
    this=0x55555575ec50, value=@0x7fffffffbec8: 12885817733, comp=...) at ../fs/tsk_apfs.hpp:710
#14 0x00005555555e52c3 in APFSJObjTree::jobjs (this=0x55555575dbe0, oid=12885817733) at ../fs/apfs_fs.hpp:124
#15 0x00005555555e539c in APFSJObjTree::obj (this=0x55555575dbe0, oid=12885817733) at /home/berenguel/git/sleuthkit-puro/tsk/fs/apfs_fs.hpp:136
#16 0x0000555555615271 in APFSFSCompat::file_add_meta (this=0x55555575dbe0, fs_file=0x55555589adc0, addr=12885817733) at apfs_compat.cpp:658
#17 0x000055555561291a in operator() (__closure=0x0, fs=0x55555575fc98, fs_file=0x55555589adc0, addr=12885817733) at apfs_compat.cpp:219
#18 0x000055555561294d in _FUN () at apfs_compat.cpp:220
#19 0x0000555555569079 in tsk_fs_dir_walk_recursive (a_fs=0x55555575fc98, a_dinfo=0x7fffffffc4e0, a_addr=12885817721, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, 
    macro_recursion_depth=5) at fs_dir.c:709
#20 0x000055555556963e in tsk_fs_dir_walk_recursive (a_fs=0x55555575fc98, a_dinfo=0x7fffffffc4e0, a_addr=12885816323, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, 
    macro_recursion_depth=4) at fs_dir.c:863
#21 0x000055555556963e in tsk_fs_dir_walk_recursive (a_fs=0x55555575fc98, a_dinfo=0x7fffffffc4e0, a_addr=12885815785, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, 
    macro_recursion_depth=3) at fs_dir.c:863
#22 0x000055555556963e in tsk_fs_dir_walk_recursive (a_fs=0x55555575fc98, a_dinfo=0x7fffffffc4e0, a_addr=12884931675, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, 
    macro_recursion_depth=2) at fs_dir.c:863
#23 0x000055555556963e in tsk_fs_dir_walk_recursive (a_fs=0x55555575fc98, a_dinfo=0x7fffffffc4e0, a_addr=12884923208, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, 
    macro_recursion_depth=1) at fs_dir.c:863
#24 0x000055555556963e in tsk_fs_dir_walk_recursive (a_fs=0x55555575fc98, a_dinfo=0x7fffffffc4e0, a_addr=2, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, 
    macro_recursion_depth=0) at fs_dir.c:863
#25 0x0000555555569a2a in tsk_fs_dir_walk_internal (a_fs=0x55555575fc98, a_addr=2, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990, macro_recursion_depth=0)
    at fs_dir.c:1001
#26 0x0000555555569aee in tsk_fs_dir_walk (a_fs=0x55555575fc98, a_addr=2, a_flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), a_action=0x555555567979 <print_dent_act>, a_ptr=0x7fffffffd990) at fs_dir.c:1043
#27 0x0000555555567db0 in tsk_fs_fls (fs=0x55555575fc98, lclflags=(TSK_FS_FLS_FILE | TSK_FS_FLS_DIR | TSK_FS_FLS_FULL | TSK_FS_FLS_MAC), inode=2, flags=(TSK_FS_DIR_WALK_FLAG_ALLOC | TSK_FS_DIR_WALK_FLAG_UNALLOC | TSK_FS_DIR_WALK_FLAG_RECURSE), tpre=0x7fffffffda10 "vol5/poolVol0/", 
    skew=0) at fls_lib.c:262
#28 0x00005555555651e0 in TskGetTimes::filterFs (this=0x7fffffffdcc0, fs_info=0x55555575fc98) at tsk_gettimes.cpp:114
#29 0x000055555556fb62 in TskAuto::findFilesInFsInt (this=0x7fffffffdcc0, a_fs_info=0x55555575fc98, a_inum=2) at auto.cpp:805
#30 0x000055555556f0fb in TskAuto::findFilesInPool (this=0x7fffffffdcc0, start=209735680, ptype=TSK_POOL_TYPE_DETECT) at auto.cpp:496
#31 0x000055555556eea8 in TskAuto::findFilesInPool (this=0x7fffffffdcc0, start=209735680) at auto.cpp:433
#32 0x000055555556eae2 in TskAuto::vsWalkCb (a_vs_part=0x55555595c700, a_ptr=0x7fffffffdcc0) at auto.cpp:301
#33 0x00005555555803c2 in tsk_vs_part_walk (a_vs=0x55555595c0e0, a_start=0, a_last=6, a_flags=3, a_action=0x55555556e9dc <TskAuto::vsWalkCb(TSK_VS_INFO*, TSK_VS_PART_INFO const*, void*)>, a_ptr=0x7fffffffdcc0) at mm_part.c:272
#34 0x000055555556ed5f in TskAuto::findFilesInVs (this=0x7fffffffdcc0, a_start=0, a_vtype=TSK_VS_TYPE_DETECT) at auto.cpp:375
#35 0x000055555556ede2 in TskAuto::findFilesInVs (this=0x7fffffffdcc0, a_start=0) at auto.cpp:396
#36 0x000055555556e9d8 in TskAuto::findFilesInImg (this=0x7fffffffdcc0) at auto.cpp:269
#37 0x000055555556575a in main (argc=4, argv1=0x7fffffffdf08) at tsk_gettimes.cpp:259
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iterator comparison stability when working with APFS tree nodes.
  * Prevented crashes or incorrect comparisons when child iterators are missing, making comparisons safer in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->