### PR TITLE
Added concept of alterantive OS account names for Entra / SAMNames

### DIFF
--- a/bindings/java/src/org/sleuthkit/datamodel/CaseDatabaseFactory.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/CaseDatabaseFactory.java
@@ -415,6 +415,7 @@ class CaseDatabaseFactory {
 			// For DC support 
 			stmt.execute("CREATE INDEX tsk_os_accounts_login_name_idx  ON tsk_os_accounts(login_name, db_status, realm_id)");
 			stmt.execute("CREATE INDEX tsk_os_accounts_addr_idx  ON tsk_os_accounts(addr, db_status, realm_id)");
+			stmt.execute("CREATE INDEX tsk_os_account_names_name_idx  ON tsk_os_account_names(name, host_id)");
 
 			stmt.execute("CREATE INDEX tsk_os_account_realms_realm_name_idx  ON tsk_os_account_realms(realm_name)");
 			stmt.execute("CREATE INDEX tsk_os_account_realms_realm_addr_idx  ON tsk_os_account_realms(realm_addr)");
@@ -551,7 +552,23 @@ class CaseDatabaseFactory {
 				+ "FOREIGN KEY(os_account_obj_id) REFERENCES tsk_objects(obj_id) ON DELETE CASCADE, "
 				+ "FOREIGN KEY(realm_id) REFERENCES tsk_os_account_realms(id) ON DELETE CASCADE,"
 				+ "FOREIGN KEY(merged_into) REFERENCES tsk_os_accounts(os_account_obj_id) ON DELETE CASCADE )");
-		
+
+		// References tsk_os_accounts, tsk_hosts
+		// Alternate/secondary names for an account, beyond the single login_name/addr on
+		// tsk_os_accounts, so an account can be resolved by another observed name form. host_id scopes
+		// a name to a host when the name is only unique within a host (e.g. the Entra down-level/SAM
+		// name - two hosts can each have a local "johndoe" for different accounts); host_id is
+		// null for names that are unique across the whole realm (e.g. a UPN). Search with a host to
+		// match host-scoped names, without one to match realm-wide names. Generic across operating
+		// systems. See OsAccount.OsAccountNameType.
+		stmt.execute("CREATE TABLE tsk_os_account_names (id " + dbQueryHelper.getPrimaryKey() + " PRIMARY KEY, "
+				+ "os_account_obj_id " + dbQueryHelper.getBigIntType() + " NOT NULL, "	// account the name belongs to
+				+ "host_id " + dbQueryHelper.getBigIntType() + ", "	// host the name is scoped to; null if unique across the realm
+				+ "name TEXT NOT NULL, "		// an alternate name for the account
+				+ "name_type INTEGER NOT NULL, "	// the kind of name (see OsAccount.OsAccountNameType)
+				+ "UNIQUE(os_account_obj_id, name, name_type, host_id), "
+				+ "FOREIGN KEY(os_account_obj_id) REFERENCES tsk_os_accounts(os_account_obj_id) ON DELETE CASCADE, "
+				+ "FOREIGN KEY(host_id) REFERENCES tsk_hosts(id) ON DELETE CASCADE )");
 	}
 	// Must be called after createAccountTables() and blackboard_attribute_types, blackboard_artifacts creation.
 	private void createAccountInstancesAndArtifacts(Statement stmt) throws SQLException {

--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccount.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccount.java
@@ -204,6 +204,80 @@ public final class OsAccount extends AbstractContent {
 	}
 
 	/**
+	 * The kind of an alternate/secondary name recorded for an account in
+	 * tsk_os_account_names (beyond the primary login_name/addr on tsk_os_accounts).
+	 * Generic across operating systems.
+	 */
+	public enum OsAccountNameType {
+		// Keep this minimal: only add a type when we are confident it is a distinct, needed
+		// name form. Unrecognized ids (e.g. written by a newer schema) resolve to OTHER.
+		//
+		// HOST_LOCAL_NAME is only unique within a host, so it MUST be matched together with a host
+		// (e.g. the Entra down-level/SAM name "briancarrier": two different hosts can each have a
+		// local "briancarrier" that belong to different accounts). Never match it on name alone.
+		HOST_LOCAL_NAME(0, "Host-local Name", true),	// a name unique only within a host; match with a host
+		OTHER(1, "Other", false);			// an unclassified alternate name / fallback for unknown ids
+
+		private final int id;
+		private final String name;
+		private final boolean hostSpecific;
+
+		OsAccountNameType(int id, String name, boolean hostSpecific) {
+			this.id = id;
+			this.name = name;
+			this.hostSpecific = hostSpecific;
+		}
+
+		/**
+		 * Get the name type id.
+		 *
+		 * @return The id.
+		 */
+		public int getId() {
+			return id;
+		}
+
+		/**
+		 * Get the name type display name.
+		 *
+		 * @return The display name.
+		 */
+		public String getName() {
+			return name;
+		}
+
+		/**
+		 * Whether this name type is only unique within a host (e.g. HOST_LOCAL_NAME), and so must
+		 * always be recorded/matched together with a host. Types that are not host-specific are
+		 * unique across the whole realm and are recorded/matched with a null host - see
+		 * tsk_os_account_names.host_id in the schema.
+		 *
+		 * @return True if this name type must be scoped to a host.
+		 */
+		public boolean isHostSpecific() {
+			return hostSpecific;
+		}
+
+		/**
+		 * Gets a name type from its id. Resilient to unknown ids (e.g. a name type
+		 * written by a newer schema version): never throws and never returns null -
+		 * any unrecognized id maps to {@link #OTHER}.
+		 *
+		 * @param typeId Id to look for.
+		 *
+		 * @return The matching name type, or OTHER if the id is not recognized.
+		 */
+		public static OsAccountNameType fromID(int typeId) {
+			for (OsAccountNameType nameType : OsAccountNameType.values()) {
+				if (nameType.id == typeId) {
+					return nameType;
+				}
+			}
+			return OTHER;
+		}
+	}
+
+	/**
 	 * Constructs an OsAccount with a realm/username and unique id, and
 	 * signature.
 	 *

--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -627,6 +627,126 @@ public final class OsAccountManager {
 	}
 
 	/**
+	 * Gets the OS account, if any, that has the given name recorded as an alternate
+	 * (secondary) name of the given type in tsk_os_account_names, in the given realm
+	 * - e.g. an Entra down-level/SAM name. This searches ONLY the alternate names; it
+	 * does not consider an account's primary login_name (use getOsAccountByLoginName
+	 * for that).
+	 *
+	 * A host-specific name type (nameType.isHostSpecific()) is only unique within a host, so
+	 * it is matched together with the host, which is then required. A name type that is not
+	 * host-specific is unique across the whole realm and is matched with no host (host_id is
+	 * null); host is ignored in that case.
+	 *
+	 * @param name     The alternate name to look for (matched case-insensitively).
+	 * @param nameType The kind of name - determines whether host is used to match.
+	 * @param host     The host the name is scoped to. Required if nameType.isHostSpecific().
+	 * @param realm    The realm to scope the search to.
+	 *
+	 * @return Optional with the matching account, empty if none.
+	 *
+	 * @throws TskCoreException If there is an error getting the account, or if a host is
+	 *                          required for nameType but not supplied.
+	 */
+	Optional<OsAccount> getOsAccountByAlternateName(String name, OsAccount.OsAccountNameType nameType, Host host, OsAccountRealm realm) throws TskCoreException {
+
+		if (nameType.isHostSpecific() && host == null) {
+			throw new TskCoreException("A host is required to look up a host-specific alternate name.");
+		}
+
+		String queryString = "SELECT accounts.* FROM tsk_os_accounts accounts "
+				+ "INNER JOIN tsk_os_account_names names ON names.os_account_obj_id = accounts.os_account_obj_id "
+				+ "WHERE names.name = '" + name.toLowerCase(Locale.ENGLISH) + "'"
+				+ " AND names.name_type = " + nameType.getId()
+				+ (nameType.isHostSpecific() ? " AND names.host_id = " + host.getHostId() : " AND names.host_id IS NULL")
+				+ " AND accounts.db_status = " + OsAccount.OsAccountDbStatus.ACTIVE.getId()
+				+ " AND accounts.realm_id = " + realm.getRealmId();
+
+		db.acquireSingleUserCaseReadLock();
+		try (CaseDbConnection connection = this.db.getConnection();
+				Statement s = connection.createStatement();
+				ResultSet rs = connection.executeQuery(s, queryString)) {
+
+			if (!rs.next()) {
+				return Optional.empty();	// no match found
+			} else {
+				return Optional.of(osAccountFromResultSet(rs));
+			}
+		} catch (SQLException ex) {
+			throw new TskCoreException(String.format("Error getting OS account for realm = %s and name = %s.", (realm != null) ? realm.getSignature() : "NULL", name), ex);
+		} finally {
+			db.releaseSingleUserCaseReadLock();
+		}
+	}
+
+	/**
+	 * Records an alternate (secondary) name for an account, in addition to its primary
+	 * login_name/addr, so the account can later be resolved by that name form via
+	 * getOsAccountByAlternateName. No-op if the name is blank or already recorded for
+	 * the account (on the same host, for a host-specific name type).
+	 *
+	 * A host-specific name type (nameType.isHostSpecific()) is only unique within a host, so
+	 * host is required and is stored/matched together with the name. A name type that is not
+	 * host-specific is unique across the whole realm and is stored with a null host; host is
+	 * ignored in that case.
+	 *
+	 * @param account  The account to add the alternate name to.
+	 * @param name     The alternate name (stored/matched case-insensitively).
+	 * @param nameType The kind of name - determines whether host is stored.
+	 * @param host     The host the name is scoped to. Required if nameType.isHostSpecific().
+	 *
+	 * @throws TskCoreException If there is an error adding the name, or if host is null
+	 *                          for a host-specific nameType.
+	 */
+	public void addAlternateOsAccountName(OsAccount account, String name, OsAccount.OsAccountNameType nameType, Host host) throws TskCoreException {
+
+		if (nameType.isHostSpecific() && host == null) {
+			throw new TskCoreException("A host is required to add a host-specific alternate name to an OS account.");
+		}
+		if (Strings.isNullOrEmpty(name)) {
+			return;
+		}
+		String normalizedName = name.toLowerCase(Locale.ENGLISH);
+		Long hostId = nameType.isHostSpecific() ? host.getHostId() : null;
+
+		synchronized (osAccountLockObj) {
+			db.acquireSingleUserCaseWriteLock();
+			try (CaseDbConnection connection = db.getConnection()) {
+
+				// Skip if this (name, name_type, host) is already recorded for the account.
+				String checkSQL = "SELECT id FROM tsk_os_account_names WHERE os_account_obj_id = " + account.getId()
+						+ " AND name = '" + normalizedName + "'"
+						+ " AND name_type = " + nameType.getId()
+						+ (hostId != null ? " AND host_id = " + hostId : " AND host_id IS NULL");
+				try (Statement s = connection.createStatement();
+						ResultSet rs = connection.executeQuery(s, checkSQL)) {
+					if (rs.next()) {
+						return;
+					}
+				}
+
+				String insertSQL = "INSERT INTO tsk_os_account_names(os_account_obj_id, host_id, name, name_type) VALUES (?, ?, ?, ?)"; // NON-NLS
+				PreparedStatement preparedStatement = connection.getPreparedStatement(insertSQL, Statement.NO_GENERATED_KEYS);
+				preparedStatement.clearParameters();
+				preparedStatement.setLong(1, account.getId());
+				if (hostId != null) {
+					preparedStatement.setLong(2, hostId);
+				} else {
+					preparedStatement.setNull(2, Types.BIGINT);
+				}
+				preparedStatement.setString(3, normalizedName);
+				preparedStatement.setInt(4, nameType.getId());
+				connection.executeUpdate(preparedStatement);
+
+			} catch (SQLException ex) {
+				throw new TskCoreException(String.format("Error adding name '%s' to OS account id = %d", name, account.getId()), ex);
+			} finally {
+				db.releaseSingleUserCaseWriteLock();
+			}
+		}
+	}
+
+	/**
 	 * Get the OS Account with the given object id.
 	 *
 	 * @param osAccountObjId Object id for the account.
@@ -1106,7 +1226,21 @@ public final class OsAccountManager {
 			query = makeOsAccountUpdateQuery("tsk_data_artifacts", sourceAccount, destAccount);
 			s.executeUpdate(query);
 
-			
+			// tsk_os_account_names has a unique constraint on (os_account_obj_id, name, name_type, host_id),
+			// so delete any source rows that would duplicate an existing dest row before re-pointing.
+			query = "DELETE FROM tsk_os_account_names "
+					+ "WHERE id IN ( "
+					+ "SELECT sourceName.id "
+					+ "FROM tsk_os_account_names destName "
+					+ "INNER JOIN tsk_os_account_names sourceName ON destName.name = sourceName.name AND destName.name_type = sourceName.name_type AND destName.host_id = sourceName.host_id "
+					+ "WHERE destName.os_account_obj_id = " + destAccount.getId()
+					+ " AND sourceName.os_account_obj_id = " + sourceAccount.getId() + ")";
+			s.executeUpdate(query);
+
+			query = makeOsAccountUpdateQuery("tsk_os_account_names", sourceAccount, destAccount);
+			s.executeUpdate(query);
+
+
 			// register the merged accounts with the transaction to fire off an event
 			trans.registerMergedOsAccount(sourceAccount.getId(), destAccount.getId());
 			
@@ -1152,7 +1286,8 @@ public final class OsAccountManager {
 			"tsk_os_account_attributes",
 			"tsk_os_account_instances",
 			"tsk_files",
-			"tsk_data_artifacts"
+			"tsk_data_artifacts",
+			"tsk_os_account_names"
 		))
 	);
 
@@ -1346,7 +1481,14 @@ public final class OsAccountManager {
 		// search by login name
 		if (!Strings.isNullOrEmpty(loginName)) {
 			String resolvedLoginName = WindowsAccountUtils.toWellknownEnglishLoginName(loginName);
-			return this.getOsAccountByLoginName(resolvedLoginName, realm.get());
+			Optional<OsAccount> account = this.getOsAccountByLoginName(resolvedLoginName, realm.get());
+			if (account.isPresent()) {
+				return account;
+			}
+			// Fall back to a host-local alternate name recorded for the account (e.g. an Entra
+			// down-level/SAM name), scoped to this host, so a name-only observation on this host
+			// still maps to the existing account.
+			return this.getOsAccountByAlternateName(resolvedLoginName, OsAccount.OsAccountNameType.HOST_LOCAL_NAME, referringHost, realm.get());
 		} else {
 			return Optional.empty();
 		}

--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -656,21 +656,23 @@ public final class OsAccountManager {
 
 		String queryString = "SELECT accounts.* FROM tsk_os_accounts accounts "
 				+ "INNER JOIN tsk_os_account_names names ON names.os_account_obj_id = accounts.os_account_obj_id "
-				+ "WHERE names.name = '" + name.toLowerCase(Locale.ENGLISH) + "'"
+				+ "WHERE names.name = ?"
 				+ " AND names.name_type = " + nameType.getId()
 				+ (nameType.isHostSpecific() ? " AND names.host_id = " + host.getHostId() : " AND names.host_id IS NULL")
 				+ " AND accounts.db_status = " + OsAccount.OsAccountDbStatus.ACTIVE.getId()
 				+ " AND accounts.realm_id = " + realm.getRealmId();
 
 		db.acquireSingleUserCaseReadLock();
-		try (CaseDbConnection connection = this.db.getConnection();
-				Statement s = connection.createStatement();
-				ResultSet rs = connection.executeQuery(s, queryString)) {
-
-			if (!rs.next()) {
-				return Optional.empty();	// no match found
-			} else {
-				return Optional.of(osAccountFromResultSet(rs));
+		try (CaseDbConnection connection = this.db.getConnection()) {
+			PreparedStatement preparedStatement = connection.getPreparedStatement(queryString, Statement.NO_GENERATED_KEYS);
+			preparedStatement.clearParameters();
+			preparedStatement.setString(1, name.toLowerCase(Locale.ENGLISH));
+			try (ResultSet rs = connection.executeQuery(preparedStatement)) {
+				if (!rs.next()) {
+					return Optional.empty();	// no match found
+				} else {
+					return Optional.of(osAccountFromResultSet(rs));
+				}
 			}
 		} catch (SQLException ex) {
 			throw new TskCoreException(String.format("Error getting OS account for realm = %s and name = %s.", (realm != null) ? realm.getSignature() : "NULL", name), ex);
@@ -713,19 +715,7 @@ public final class OsAccountManager {
 			db.acquireSingleUserCaseWriteLock();
 			try (CaseDbConnection connection = db.getConnection()) {
 
-				// Skip if this (name, name_type, host) is already recorded for the account.
-				String checkSQL = "SELECT id FROM tsk_os_account_names WHERE os_account_obj_id = " + account.getId()
-						+ " AND name = '" + normalizedName + "'"
-						+ " AND name_type = " + nameType.getId()
-						+ (hostId != null ? " AND host_id = " + hostId : " AND host_id IS NULL");
-				try (Statement s = connection.createStatement();
-						ResultSet rs = connection.executeQuery(s, checkSQL)) {
-					if (rs.next()) {
-						return;
-					}
-				}
-
-				String insertSQL = "INSERT INTO tsk_os_account_names(os_account_obj_id, host_id, name, name_type) VALUES (?, ?, ?, ?)"; // NON-NLS
+				String insertSQL = db.getInsertOrIgnoreSQL("INTO tsk_os_account_names(os_account_obj_id, host_id, name, name_type) VALUES (?, ?, ?, ?)"); // NON-NLS
 				PreparedStatement preparedStatement = connection.getPreparedStatement(insertSQL, Statement.NO_GENERATED_KEYS);
 				preparedStatement.clearParameters();
 				preparedStatement.setLong(1, account.getId());
@@ -770,9 +760,15 @@ public final class OsAccountManager {
 			throw new TskCoreException("A host is required to get host-specific alternate names for an OS account.");
 		}
 
+		String hostIdClause;
+		if (nameType.isHostSpecific()) {
+			hostIdClause = " AND host_id = " + host.getHostId();
+		} else {
+			hostIdClause = " AND host_id IS NULL";
+		}
 		String queryString = "SELECT name FROM tsk_os_account_names WHERE os_account_obj_id = " + account.getId()
 				+ " AND name_type = " + nameType.getId()
-				+ (nameType.isHostSpecific() ? " AND host_id = " + host.getHostId() : " AND host_id IS NULL");
+				+ hostIdClause;
 
 		List<String> names = new ArrayList<>();
 		db.acquireSingleUserCaseReadLock();
@@ -1277,7 +1273,7 @@ public final class OsAccountManager {
 					+ "WHERE id IN ( "
 					+ "SELECT sourceName.id "
 					+ "FROM tsk_os_account_names destName "
-					+ "INNER JOIN tsk_os_account_names sourceName ON destName.name = sourceName.name AND destName.name_type = sourceName.name_type AND destName.host_id = sourceName.host_id "
+					+ "INNER JOIN tsk_os_account_names sourceName ON destName.name = sourceName.name AND destName.name_type = sourceName.name_type AND (destName.host_id = sourceName.host_id OR (destName.host_id IS NULL AND sourceName.host_id IS NULL)) "
 					+ "WHERE destName.os_account_obj_id = " + destAccount.getId()
 					+ " AND sourceName.os_account_obj_id = " + sourceAccount.getId() + ")";
 			s.executeUpdate(query);

--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -650,12 +650,11 @@ public final class OsAccountManager {
 	 */
 	Optional<OsAccount> getOsAccountByAlternateName(String name, OsAccount.OsAccountNameType nameType, Host host, OsAccountRealm realm) throws TskCoreException {
 
-		if (nameType.isHostSpecific() && host == null) {
-			throw new TskCoreException("A host is required to look up a host-specific alternate name.");
-		}
-
 		String hostIdClause;
 		if (nameType.isHostSpecific()) {
+			if (host == null) {
+				throw new TskCoreException("A host is required to look up a host-specific alternate name.");
+			}
 			hostIdClause = " AND names.host_id = " + host.getHostId();
 		} else {
 			hostIdClause = " AND names.host_id IS NULL";
@@ -708,14 +707,19 @@ public final class OsAccountManager {
 	 */
 	public void addAlternateOsAccountName(OsAccount account, String name, OsAccount.OsAccountNameType nameType, Host host) throws TskCoreException {
 
-		if (nameType.isHostSpecific() && host == null) {
-			throw new TskCoreException("A host is required to add a host-specific alternate name to an OS account.");
-		}
 		if (Strings.isNullOrEmpty(name)) {
 			return;
 		}
 		String normalizedName = name.toLowerCase(Locale.ENGLISH);
-		Long hostId = nameType.isHostSpecific() ? host.getHostId() : null;
+		Long hostId;
+		if (nameType.isHostSpecific()) {
+			if (host == null) {
+				throw new TskCoreException("A host is required to add a host-specific alternate name to an OS account.");
+			}
+			hostId = host.getHostId();
+		} else {
+			hostId = null;
+		}
 
 		synchronized (osAccountLockObj) {
 			db.acquireSingleUserCaseWriteLock();
@@ -762,12 +766,11 @@ public final class OsAccountManager {
 	 */
 	public List<String> getOsAccountAlternateNames(OsAccount account, OsAccount.OsAccountNameType nameType, Host host) throws TskCoreException {
 
-		if (nameType.isHostSpecific() && host == null) {
-			throw new TskCoreException("A host is required to get host-specific alternate names for an OS account.");
-		}
-
 		String hostIdClause;
 		if (nameType.isHostSpecific()) {
+			if (host == null) {
+				throw new TskCoreException("A host is required to get host-specific alternate names for an OS account.");
+			}
 			hostIdClause = " AND host_id = " + host.getHostId();
 		} else {
 			hostIdClause = " AND host_id IS NULL";

--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -654,11 +654,17 @@ public final class OsAccountManager {
 			throw new TskCoreException("A host is required to look up a host-specific alternate name.");
 		}
 
+		String hostIdClause;
+		if (nameType.isHostSpecific()) {
+			hostIdClause = " AND names.host_id = " + host.getHostId();
+		} else {
+			hostIdClause = " AND names.host_id IS NULL";
+		}
 		String queryString = "SELECT accounts.* FROM tsk_os_accounts accounts "
 				+ "INNER JOIN tsk_os_account_names names ON names.os_account_obj_id = accounts.os_account_obj_id "
 				+ "WHERE names.name = ?"
 				+ " AND names.name_type = " + nameType.getId()
-				+ (nameType.isHostSpecific() ? " AND names.host_id = " + host.getHostId() : " AND names.host_id IS NULL")
+				+ hostIdClause
 				+ " AND accounts.db_status = " + OsAccount.OsAccountDbStatus.ACTIVE.getId()
 				+ " AND accounts.realm_id = " + realm.getRealmId();
 

--- a/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/OsAccountManager.java
@@ -747,6 +747,51 @@ public final class OsAccountManager {
 	}
 
 	/**
+	 * Gets the alternate (secondary) names of the given type recorded for the given account
+	 * in tsk_os_account_names - e.g. an Entra down-level/SAM name.
+	 *
+	 * A host-specific name type (nameType.isHostSpecific()) is only unique within a host, so
+	 * it is matched together with the host, which is then required. A name type that is not
+	 * host-specific is unique across the whole realm and is matched with no host (host_id is
+	 * null); host is ignored in that case.
+	 *
+	 * @param account  The account to get alternate names for.
+	 * @param nameType The kind of name - determines whether host is used to match.
+	 * @param host     The host to scope host-specific names to. Required if nameType.isHostSpecific().
+	 *
+	 * @return The alternate names recorded for the account (empty if none).
+	 *
+	 * @throws TskCoreException If there is an error getting the names, or if a host is
+	 *                          required for nameType but not supplied.
+	 */
+	public List<String> getOsAccountAlternateNames(OsAccount account, OsAccount.OsAccountNameType nameType, Host host) throws TskCoreException {
+
+		if (nameType.isHostSpecific() && host == null) {
+			throw new TskCoreException("A host is required to get host-specific alternate names for an OS account.");
+		}
+
+		String queryString = "SELECT name FROM tsk_os_account_names WHERE os_account_obj_id = " + account.getId()
+				+ " AND name_type = " + nameType.getId()
+				+ (nameType.isHostSpecific() ? " AND host_id = " + host.getHostId() : " AND host_id IS NULL");
+
+		List<String> names = new ArrayList<>();
+		db.acquireSingleUserCaseReadLock();
+		try (CaseDbConnection connection = this.db.getConnection();
+				Statement s = connection.createStatement();
+				ResultSet rs = connection.executeQuery(s, queryString)) {
+
+			while (rs.next()) {
+				names.add(rs.getString("name"));
+			}
+			return names;
+		} catch (SQLException ex) {
+			throw new TskCoreException(String.format("Error getting alternate names for OS account id = %d", account.getId()), ex);
+		} finally {
+			db.releaseSingleUserCaseReadLock();
+		}
+	}
+
+	/**
 	 * Get the OS Account with the given object id.
 	 *
 	 * @param osAccountObjId Object id for the account.

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -113,7 +113,7 @@ public class SleuthkitCase {
 	private static final int MAX_DB_NAME_LEN_BEFORE_TIMESTAMP = 47;
 
 	static final CaseDbSchemaVersionNumber CURRENT_DB_SCHEMA_VERSION
-			= new CaseDbSchemaVersionNumber(9, 7);
+			= new CaseDbSchemaVersionNumber(9, 8);
 
 	private static final long BASE_ARTIFACT_ID = Long.MIN_VALUE; // Artifact ids will start at the lowest negative value
 	private static final Logger logger = Logger.getLogger(SleuthkitCase.class.getName());
@@ -1182,6 +1182,7 @@ public class SleuthkitCase {
 				dbSchemaVersion = updateFromSchema9dot4toSchema9dot5(dbSchemaVersion, connection);
 				dbSchemaVersion = updateFromSchema9dot5toSchema9dot6(dbSchemaVersion, connection);
 				dbSchemaVersion = updateFromSchema9dot6toSchema9dot7(dbSchemaVersion, connection);
+				dbSchemaVersion = updateFromSchema9dot7toSchema9dot8(dbSchemaVersion, connection);
 
 
 				statement = connection.createStatement();
@@ -3075,6 +3076,46 @@ public class SleuthkitCase {
 
 			return new CaseDbSchemaVersionNumber(9, 7);
 
+		} finally {
+			closeStatement(statement);
+			releaseSingleUserCaseWriteLock();
+		}
+	}
+
+	private CaseDbSchemaVersionNumber updateFromSchema9dot7toSchema9dot8(CaseDbSchemaVersionNumber schemaVersion, CaseDbConnection connection) throws SQLException, TskCoreException {
+		if (schemaVersion.getMajor() != 9) {
+			return schemaVersion;
+		}
+
+		if (schemaVersion.getMinor() != 7) {
+			return schemaVersion;
+		}
+
+		String bigIntDataType = "BIGINT";
+		String primaryKeyType = "BIGSERIAL";
+		if (this.dbType.equals(DbType.SQLITE)) {
+			bigIntDataType = "INTEGER";
+			primaryKeyType = "INTEGER";
+		}
+
+		Statement statement = connection.createStatement();
+		acquireSingleUserCaseWriteLock();
+		try {
+			// Alternate/secondary names for an OS account (UPN, down-level SAM name, object id, ...),
+			// beyond the single login_name/addr on tsk_os_accounts, so an account can be resolved by any
+			// observed name form. See OsAccount.OsAccountNameType.
+			statement.execute("CREATE TABLE tsk_os_account_names (id " + primaryKeyType + " PRIMARY KEY, "
+					+ "os_account_obj_id " + bigIntDataType + " NOT NULL, "
+					+ "host_id " + bigIntDataType + ", "
+					+ "name TEXT NOT NULL, "
+					+ "name_type INTEGER NOT NULL, "
+					+ "UNIQUE(os_account_obj_id, name, name_type, host_id), "
+					+ "FOREIGN KEY(os_account_obj_id) REFERENCES tsk_os_accounts(os_account_obj_id) ON DELETE CASCADE, "
+					+ "FOREIGN KEY(host_id) REFERENCES tsk_hosts(id) ON DELETE CASCADE )");
+
+			statement.execute("CREATE INDEX tsk_os_account_names_name_idx ON tsk_os_account_names(name, host_id)");
+
+			return new CaseDbSchemaVersionNumber(9, 8);
 		} finally {
 			closeStatement(statement);
 			releaseSingleUserCaseWriteLock();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for alternate OS account names, including host-specific variants.
  * Added capabilities to add and retrieve alternate account names.
  * Windows account lookup now falls back to host-local alternate names.
  * Alternate names are preserved and reconciled during account merges.
* **Chores**
  * Updated the case database schema to version 9.8 with automatic migration support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->