### PR TITLE
Multi bitlocker passwords

### DIFF
--- a/bindings/java/jni/auto_db_java.cpp
+++ b/bindings/java/jni/auto_db_java.cpp
@@ -1737,7 +1737,7 @@ TSK_RETVAL_ENUM TskAutoDbJava::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo)
     }
 
     //open the fs we have from database
-    TSK_FS_INFO* fsInfo = tsk_fs_open_img_decrypt(m_img_info, dbFsInfo.imgOffset, dbFsInfo.fType, getFileSystemPassword().data());
+    TSK_FS_INFO* fsInfo = openFsDecryptWithPasswords(dbFsInfo.imgOffset, dbFsInfo.fType);
     if (fsInfo == NULL) {
         tsk_error_set_errstr2("TskAutoDbJava::addFsInfoUnalloc: error opening fs at offset %" PRIdOFF, dbFsInfo.imgOffset);
         registerError();

--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -785,6 +785,37 @@ JNIEXPORT jobject JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_hashDbLookup
 }
 
 /*
+ * Convert a Java String array to a vector of strings. Null entries are skipped.
+ *
+ * @param env Pointer to java environment.
+ * @param arrayJ The Java array of strings (may be null).
+ *
+ * @return Vector containing a copy of the non-null strings in the array.
+ */
+static std::vector<std::string> convertJavaStringArray(JNIEnv * env, jobjectArray arrayJ) {
+    std::vector<std::string> result;
+    if (arrayJ == NULL) {
+        return result;
+    }
+
+    jsize len = env->GetArrayLength(arrayJ);
+    for (jsize i = 0; i < len; i++) {
+        jstring strJ = (jstring)env->GetObjectArrayElement(arrayJ, i);
+        if (strJ == NULL) {
+            continue;
+        }
+        jboolean isCopy;
+        const char *str = (const char*)env->GetStringUTFChars(strJ, &isCopy);
+        if (str != NULL) {
+            result.push_back(std::string(str));
+            env->ReleaseStringUTFChars(strJ, str);
+        }
+        env->DeleteLocalRef(strJ);
+    }
+    return result;
+}
+
+/*
  * Initialize a process for adding an image to a case database.
  *
  * @param env Pointer to java environment.
@@ -920,6 +951,36 @@ Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgPasswordNat(JNIEnv * e
     }
 
     return (jlong)tskAutoJava;
+}
+
+/*
+ * Initialize a process for adding an image to a case database, with a list of
+ * candidate passwords that will each be tried when opening encrypted file systems.
+ *
+ * @param env Pointer to java environment.
+ * @param obj Pointer the Java class object.
+ * @param timeZone The time zone for the image.
+ * @param addFileSystems Pass true to attempt to add file systems within the image to the case database.
+ * @param addUnallocSpace Pass true to create virtual files for unallocated space. Ignored if addFileSystems is false.
+ * @param skipFatFsOrphans Pass true to skip processing of orphan files for FAT file systems. Ignored if addFileSystems is false.
+ * @param passwordsJ Array of candidate passwords for the file systems or null for no passwords.
+ *
+ * @return A pointer to the process (TskAutoDbJava object) or NULL on error.
+ */
+JNIEXPORT jlong JNICALL
+Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgCandidatesNat(JNIEnv * env, jclass obj,
+    jobject callbackObj, jstring timeZone, jboolean addFileSystems, jboolean addUnallocSpace, jboolean skipFatFsOrphans, jobjectArray passwordsJ) {
+
+    jlong autoDbPtr = Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgPasswordNat(env, obj,
+        callbackObj, timeZone, addFileSystems, addUnallocSpace, skipFatFsOrphans, NULL);
+    if (autoDbPtr == 0) {
+        // exception already set
+        return 0;
+    }
+
+    TskAutoDbJava *tskAutoJava = (TskAutoDbJava *)autoDbPtr;
+    tskAutoJava->setCandidatePasswords(convertJavaStringArray(env, passwordsJ));
+    return autoDbPtr;
 }
 
 /*
@@ -2412,6 +2473,46 @@ JNIEXPORT jstring JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_isImageSuppo
         tskIsImage.setFileSystemPassword(string(password));
         env->ReleaseStringUTFChars(passwordJ, (const char*)password);
     }
+
+    jstring resultStr = env->NewStringUTF(""); // This will stay empty if we can open the image/file system
+
+    // It seems like passing &imagePathT should work instead of making this new array,
+    // but it generated an EXCEPTION_ACCESS_VIOLATION during testing.
+    TSK_TCHAR ** imagePaths = (TSK_TCHAR**)tsk_malloc((1) * sizeof(TSK_TCHAR*));
+    imagePaths[0] = imagePathT;
+    if (tskIsImage.openImage(1, imagePaths, TSK_IMG_TYPE_DETECT, 0)) {
+        resultStr = env->NewStringUTF("Error opening image");
+    } else {
+        tskIsImage.findFilesInImg();
+        resultStr = env->NewStringUTF(tskIsImage.getMessageForIsImageSupportedNat().c_str());
+    }
+
+    // Cleanup
+    tskIsImage.closeImage();
+    free(imagePaths);
+
+    return resultStr;
+}
+
+/*
+ * Test whether an image is supported, trying each of the given candidate
+ * passwords when opening encrypted file systems.
+ * @param env pointer to java environment this was called from
+ * @param obj the java object this was called from
+ * @param imagePathJ the image path
+ * @param passwordsJ  array of candidate passwords to try for any file systems found (may be null)
+ * @return empty string if the image can be processed, error message otherwise.
+ *         If multiple volumes could not be opened due to BitLocker errors, the
+ *         message will contain one line per locked volume.
+ */
+JNIEXPORT jstring JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_isImageSupportedListNat
+  (JNIEnv * env, jclass obj, jstring imagePathJ, jobjectArray passwordsJ) {
+
+    TskIsImageSupported tskIsImage;
+    TSK_TCHAR imagePathT[1024];
+    toTCHAR(env, imagePathT, 1024, imagePathJ);
+
+    tskIsImage.setCandidatePasswords(convertJavaStringArray(env, passwordsJ));
 
     jstring resultStr = env->NewStringUTF(""); // This will stay empty if we can open the image/file system
 

--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -1556,7 +1556,9 @@ JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_openFsDecryptN
     fs_info =
         tsk_fs_open_img_decrypt(img_info, (TSK_OFF_T) fs_offset,
         TSK_FS_TYPE_DETECT, password);
-    env->ReleaseStringUTFChars(passwordJ, (const char*)password);
+    if (passwordJ != NULL) {
+        env->ReleaseStringUTFChars(passwordJ, (const char*)password);
+    }
 
     if (fs_info == NULL) {
         setThrowTskCoreError(env, tsk_error_get());

--- a/bindings/java/jni/dataModel_SleuthkitJNI.h
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.h
@@ -185,6 +185,14 @@ JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddI
 
 /*
  * Class:     org_sleuthkit_datamodel_SleuthkitJNI
+ * Method:    initializeAddImgCandidatesNat
+ * Signature: (Lorg/sleuthkit/datamodel/TskCaseDbBridge;Ljava/lang/String;ZZZ[Ljava/lang/String;)J
+ */
+JNIEXPORT jlong JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgCandidatesNat
+  (JNIEnv *, jclass, jobject, jstring, jboolean, jboolean, jboolean, jobjectArray);
+
+/*
+ * Class:     org_sleuthkit_datamodel_SleuthkitJNI
  * Method:    initAddImgNat
  * Signature: (Lorg/sleuthkit/datamodel/TskCaseDbBridge;Ljava/lang/String;ZZ)J
  */
@@ -478,6 +486,14 @@ JNIEXPORT jboolean JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_isImageSupp
  */
 JNIEXPORT jstring JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_isImageSupportedStringNat
 (JNIEnv*, jclass, jstring, jstring);
+
+/*
+ * Class:     org_sleuthkit_datamodel_SleuthkitJNI
+ * Method:    isImageSupportedListNat
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_org_sleuthkit_datamodel_SleuthkitJNI_isImageSupportedListNat
+(JNIEnv*, jclass, jstring, jobjectArray);
 
 /*
  * Class:     org_sleuthkit_datamodel_SleuthkitJNI

--- a/bindings/java/src/org/sleuthkit/datamodel/FileSystem.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/FileSystem.java
@@ -18,6 +18,7 @@
  */
 package org.sleuthkit.datamodel;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
@@ -25,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import static org.sleuthkit.datamodel.SleuthkitCase.IMAGE_PASSWORD_KEY;
+import static org.sleuthkit.datamodel.SleuthkitCase.IMAGE_PASSWORDS_KEY;
 
 /**
  * Represents a file system object stored in tsk_fs_info table FileSystem has a
@@ -120,36 +122,65 @@ public class FileSystem extends AbstractContent {
 						}
 						filesystemHandle = SleuthkitJNI.openFsPool(image.getImageHandle(), imgOffset, pool.getPoolHandle(), poolVolume.getStart(), getSleuthkitCase());
 					} else {
-						String password = getImagePasswordFromSettings(image.getAcquisitionToolSettings());
-						filesystemHandle = SleuthkitJNI.openFs(image.getImageHandle(), imgOffset, password, getSleuthkitCase());
+						List<String> passwords = getImagePasswordsFromSettings(image.getAcquisitionToolSettings());
+						TskCoreException lastException = null;
+						for (String password : passwords) {
+							try {
+								filesystemHandle = SleuthkitJNI.openFs(image.getImageHandle(), imgOffset, password, getSleuthkitCase());
+								lastException = null;
+								break;
+							} catch (TskCoreException ex) {
+								lastException = ex;
+							}
+						}
+						if (lastException != null) {
+							throw lastException;
+						}
 					}
 				}
 			}
 		}
 		return this.filesystemHandle;
 	}
-	
+
 	/**
-	 * Attempt to read the image password from the settings string 
-	 * 
+	 * Attempt to read the candidate image passwords from the settings string.
+	 * Reads the password list if present, otherwise falls back to the legacy
+	 * single-password key.
+	 *
 	 * @param settingsStr
-	 * 
-	 * @return the password if found, empty string otherwise
+	 *
+	 * @return the candidate passwords if found, a list containing only the
+	 *         empty string otherwise
 	 */
 	@SuppressWarnings("unchecked")
-	private String getImagePasswordFromSettings(String settingsStr) {
-		
+	private List<String> getImagePasswordsFromSettings(String settingsStr) {
+
+		List<String> passwords = new ArrayList<>();
 		if(StringUtils.isBlank(settingsStr)){
-			return "";
+			passwords.add("");
+			return passwords;
 		}
 
 		try {
 			Map<String, Object> settingsMap = (new Gson()).fromJson(settingsStr, Map.class);
-			return (String)settingsMap.getOrDefault(IMAGE_PASSWORD_KEY, "");
+			Object passwordsObj = settingsMap.get(IMAGE_PASSWORDS_KEY);
+			if (passwordsObj instanceof List) {
+				for (Object passwordObj : (List<?>) passwordsObj) {
+					if (passwordObj instanceof String) {
+						passwords.add((String) passwordObj);
+					}
+				}
+			}
+			if (passwords.isEmpty()) {
+				passwords.add((String)settingsMap.getOrDefault(IMAGE_PASSWORD_KEY, ""));
+			}
 		} catch (JsonSyntaxException ex) {
 			// There's no guarantee that acquisition settings will contain a valid JSON string
-			return "";
+			passwords.clear();
+			passwords.add("");
 		}
+		return passwords;
 	}
 
 	public Directory getRootDirectory() throws TskCoreException {

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitCase.java
@@ -196,6 +196,7 @@ public class SleuthkitCase {
 	
 	// key in acquisition tool settings; the password for decrypting an image
 	static final String IMAGE_PASSWORD_KEY = "imagePassword";
+	static final String IMAGE_PASSWORDS_KEY = "imagePasswords";
 
 	/**
 	 * Maximum number of files per PostgreSQL batch chunk inside
@@ -3763,7 +3764,7 @@ public class SleuthkitCase {
 	 *         SleuthKit native code layer.
 	 */
 	public AddImageProcess makeAddImageProcess(String timeZone, boolean addUnallocSpace, boolean noFatFsOrphans, String imageCopyPath) {
-		return makeAddImageProcess(timeZone, addUnallocSpace, noFatFsOrphans, imageCopyPath, null);
+		return makeAddImageProcess(timeZone, addUnallocSpace, noFatFsOrphans, imageCopyPath, (String) null);
 	}
 
 	/**
@@ -3788,6 +3789,31 @@ public class SleuthkitCase {
 	@Beta
 	public AddImageProcess makeAddImageProcess(String timeZone, boolean addUnallocSpace, boolean noFatFsOrphans, String imageCopyPath, String password) {
 		return this.caseHandle.initAddImageProcess(timeZone, addUnallocSpace, noFatFsOrphans, imageCopyPath, password, this);
+	}
+
+	/**
+	 * Starts the multi-step process of adding an image data source to the case
+	 * by creating an object that can be used to control the process and get
+	 * progress messages from it. Each of the candidate passwords will be
+	 * tried, in order, when opening encrypted file systems in the image.
+	 *
+	 * @param timeZone        The time zone of the image.
+	 * @param addUnallocSpace Set to true to create virtual files for
+	 *                        unallocated space in the image.
+	 * @param noFatFsOrphans  Set to true to skip processing orphan files of FAT
+	 *                        file systems.
+	 * @param imageCopyPath   Path to which a copy of the image should be
+	 *                        written. Use the empty string to disable image
+	 *                        writing.
+	 * @param passwords       The candidate passwords for decrypting the image
+	 *                        (may be null or empty).
+	 *
+	 * @return An object that encapsulates control of adding an image via the
+	 *         SleuthKit native code layer.
+	 */
+	@Beta
+	public AddImageProcess makeAddImageProcess(String timeZone, boolean addUnallocSpace, boolean noFatFsOrphans, String imageCopyPath, List<String> passwords) {
+		return this.caseHandle.initAddImageProcess(timeZone, addUnallocSpace, noFatFsOrphans, imageCopyPath, passwords, this);
 	}
 	
 	/**
@@ -7423,7 +7449,7 @@ public class SleuthkitCase {
 			String deviceId, Host host,
 			CaseDbTransaction transaction) throws TskCoreException {
 
-		return addImage(type, sectorSize, size, displayName, imagePaths, timezone, md5, sha1, sha256, deviceId, host, null, transaction);
+		return addImage(type, sectorSize, size, displayName, imagePaths, timezone, md5, sha1, sha256, deviceId, host, (String) null, transaction);
 	}
 
 	/**
@@ -7451,6 +7477,69 @@ public class SleuthkitCase {
 	public Image addImage(TskData.TSK_IMG_TYPE_ENUM type, long sectorSize, long size, String displayName, List<String> imagePaths,
 			String timezone, String md5, String sha1, String sha256,
 			String deviceId, Host host, String password,
+			CaseDbTransaction transaction) throws TskCoreException {
+		return addImageInternal(type, sectorSize, size, displayName, imagePaths, timezone, md5, sha1, sha256, deviceId, host, password, null, transaction);
+	}
+
+	/**
+	 * Add an image to the database. Each of the candidate passwords will be
+	 * tried, in order, when opening encrypted file systems in the image.
+	 *
+	 * @param type        Type of image
+	 * @param sectorSize  Sector size
+	 * @param size        Image size
+	 * @param displayName Display name for the image
+	 * @param imagePaths  Image path(s)
+	 * @param timezone    Time zone
+	 * @param md5         MD5 hash
+	 * @param sha1        SHA1 hash
+	 * @param sha256      SHA256 hash
+	 * @param deviceId    Device ID
+	 * @param host        Host
+	 * @param passwords   The candidate passwords to decrypt the image (may be
+	 *                    null or empty).
+	 * @param transaction Case DB transaction
+	 *
+	 * @return the newly added Image
+	 *
+	 * @throws TskCoreException
+	 */
+	@Beta
+	public Image addImage(TskData.TSK_IMG_TYPE_ENUM type, long sectorSize, long size, String displayName, List<String> imagePaths,
+			String timezone, String md5, String sha1, String sha256,
+			String deviceId, Host host, List<String> passwords,
+			CaseDbTransaction transaction) throws TskCoreException {
+		return addImageInternal(type, sectorSize, size, displayName, imagePaths, timezone, md5, sha1, sha256, deviceId, host, null, passwords, transaction);
+	}
+
+	/**
+	 * Add an image to the database. If a candidate password list is given it
+	 * is persisted (and takes precedence over the single password); otherwise
+	 * the single password is persisted if not null.
+	 *
+	 * @param type        Type of image
+	 * @param sectorSize  Sector size
+	 * @param size        Image size
+	 * @param displayName Display name for the image
+	 * @param imagePaths  Image path(s)
+	 * @param timezone    Time zone
+	 * @param md5         MD5 hash
+	 * @param sha1        SHA1 hash
+	 * @param sha256      SHA256 hash
+	 * @param deviceId    Device ID
+	 * @param host        Host
+	 * @param password    The password to decrypt the image or null.
+	 * @param passwords   The candidate passwords to decrypt the image (may be
+	 *                    null or empty).
+	 * @param transaction Case DB transaction
+	 *
+	 * @return the newly added Image
+	 *
+	 * @throws TskCoreException
+	 */
+	private Image addImageInternal(TskData.TSK_IMG_TYPE_ENUM type, long sectorSize, long size, String displayName, List<String> imagePaths,
+			String timezone, String md5, String sha1, String sha256,
+			String deviceId, Host host, String password, List<String> passwords,
 			CaseDbTransaction transaction) throws TskCoreException {
 		Statement statement = null;
 		try {
@@ -7506,7 +7595,14 @@ public class SleuthkitCase {
 			}
 
 			Map<String, Object> acquisitionToolMap = new HashMap<>();
-			if (password != null) {
+			if (passwords != null && !passwords.isEmpty()) {
+				acquisitionToolMap.put(IMAGE_PASSWORDS_KEY, passwords);
+				if (passwords.size() == 1) {
+					// Also write the legacy single-password key so older code
+					// can still find the password.
+					acquisitionToolMap.put(IMAGE_PASSWORD_KEY, passwords.get(0));
+				}
+			} else if (password != null) {
 				acquisitionToolMap.put(IMAGE_PASSWORD_KEY, password);
 			}
 			String acquisitionToolJson = (new Gson()).toJson(acquisitionToolMap);
@@ -16393,7 +16489,7 @@ public class SleuthkitCase {
 	 */
 	@Deprecated
 	public AddImageProcess makeAddImageProcess(String timezone, boolean addUnallocSpace, boolean noFatFsOrphans) {
-		return this.caseHandle.initAddImageProcess(timezone, addUnallocSpace, noFatFsOrphans, "", null, this);
+		return this.caseHandle.initAddImageProcess(timezone, addUnallocSpace, noFatFsOrphans, "", (String) null, this);
 	}
 
 	/**

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -88,9 +88,11 @@ public class SleuthkitJNI {
 
 		/*
 		 * A SleuthKit file system handles cache implemented as a mapping of
-		 * image handles to image offset and file system handle pairs.
+		 * image handles to cache key (image offset and password for regular
+		 * file systems, pool block for file systems in pools) and file system
+		 * handle pairs.
 		 */
-		private final Map<Long, Map<Long, Long>> fsHandleCache = new HashMap<>();
+		private final Map<Long, Map<String, Long>> fsHandleCache = new HashMap<>();
 
 		/*
 		 * The collection of open file handles. We will only allow requests
@@ -306,7 +308,7 @@ public class SleuthkitJNI {
 				/*
 				 * Close any cached file system handles.
 				 */
-				for (Map<Long, Long> imageToFsMap : getCaseHandles(caseIdentifier).fsHandleCache.values()) {
+				for (Map<String, Long> imageToFsMap : getCaseHandles(caseIdentifier).fsHandleCache.values()) {
 					for (Long fsHandle : imageToFsMap.values()) {						
 						// First close all open file handles for the file system.
 						if (getCaseHandles(caseIdentifier).fileSystemToFileHandles.containsKey(fsHandle)) {
@@ -1185,17 +1187,20 @@ public class SleuthkitJNI {
 				} else {
 					caseIdentifier = skCase.getCaseHandleIdentifier();
 				}
-				final Map<Long, Long> imgOffSetToFsHandle = HandleCache.getCaseHandles(caseIdentifier).fsHandleCache.get(imgHandle);
+				final Map<String, Long> imgOffSetToFsHandle = HandleCache.getCaseHandles(caseIdentifier).fsHandleCache.get(imgHandle);
 				if (imgOffSetToFsHandle == null) {
 					throw new TskCoreException("Missing image offset to file system handle cache for image handle " + imgHandle);
 				}
-				if (imgOffSetToFsHandle.containsKey(fsOffset)) {
+				// The password is part of the cache key so that a retry with a
+				// different password does not return a stale handle.
+				final String fsKey = fsOffset + ":" + ((password == null) ? "" : password);
+				if (imgOffSetToFsHandle.containsKey(fsKey)) {
 					//return cached
-					fsHandle = imgOffSetToFsHandle.get(fsOffset);
+					fsHandle = imgOffSetToFsHandle.get(fsKey);
 				} else {
 					fsHandle = openFsDecryptNat(imgHandle, fsOffset, password);
 					//cache it
-					imgOffSetToFsHandle.put(fsOffset, fsHandle);
+					imgOffSetToFsHandle.put(fsKey, fsHandle);
 				}
 			}
 			return fsHandle;
@@ -1236,20 +1241,21 @@ public class SleuthkitJNI {
 				} else {
 					caseIdentifier = skCase.getCaseHandleIdentifier();
 				}
-				final Map<Long, Long> imgOffSetToFsHandle = HandleCache.getCaseHandles(caseIdentifier).fsHandleCache.get(imgHandle);
+				final Map<String, Long> imgOffSetToFsHandle = HandleCache.getCaseHandles(caseIdentifier).fsHandleCache.get(imgHandle);
 				if (imgOffSetToFsHandle == null) {
 					throw new TskCoreException("Missing image offset to file system handle cache for image handle " + imgHandle);
 				}
-				
-				if (imgOffSetToFsHandle.containsKey(poolBlock)) {
+
+				final String poolKey = String.valueOf(poolBlock);
+				if (imgOffSetToFsHandle.containsKey(poolKey)) {
 					//return cached
-					fsHandle = imgOffSetToFsHandle.get(poolBlock);
+					fsHandle = imgOffSetToFsHandle.get(poolKey);
 				} else {
 					long poolImgHandle = getImgInfoForPoolNat(poolHandle, poolBlock);
 					HandleCache.getCaseHandles(caseIdentifier).poolImgCache.add(poolImgHandle);
 					fsHandle = openFsNat(poolImgHandle, fsOffset);
 					//cache it
-					imgOffSetToFsHandle.put(poolBlock, fsHandle);
+					imgOffSetToFsHandle.put(poolKey, fsHandle);
 					HandleCache.getCaseHandles(caseIdentifier).poolFsList.add(fsHandle);
 				}
 			}

--- a/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
+++ b/bindings/java/src/org/sleuthkit/datamodel/SleuthkitJNI.java
@@ -484,6 +484,30 @@ public class SleuthkitJNI {
 		}
 
 		/**
+		 * Initializes a multi-step process for adding an image to the case
+		 * database, trying each of the given candidate passwords when opening
+		 * encrypted file systems.
+		 *
+		 * @param timeZone         The time zone of the image.
+		 * @param addUnallocSpace  Pass true to create virtual files for
+		 *                         unallocated space.
+		 * @param skipFatFsOrphans Pass true to skip processing of orphan files
+		 *                         for FAT file systems.
+		 * @param imageCopyPath    Path to which a copy of the image should be
+		 *                         written. Use the empty string to disable
+		 *                         image writing.
+		 * @param passwords        The candidate passwords for decrypting the
+		 *                         image (may be null or empty).
+		 * @param skCase           The Sleuth Kit case.
+		 *
+		 * @return An object that can be used to exercise fine-grained control
+		 *         of the process of adding the image to the case database.
+		 */
+		AddImageProcess initAddImageProcess(String timeZone, boolean addUnallocSpace, boolean skipFatFsOrphans, String imageCopyPath, List<String> passwords, SleuthkitCase skCase) {
+			return new AddImageProcess(timeZone, addUnallocSpace, skipFatFsOrphans, imageCopyPath, passwords, skCase);
+		}
+
+		/**
 		 * Encapsulates a multi-step process to add an image to the case
 		 * database.
 		 */
@@ -499,6 +523,7 @@ public class SleuthkitJNI {
 			private final SleuthkitCase skCase;
 			private TskCaseDbBridge dbHelper;
 			private final String password;
+			private final List<String> passwords;
 
 			/**
 			 * Constructs an object that encapsulates a multi-step process to
@@ -524,7 +549,36 @@ public class SleuthkitJNI {
 				this.isCanceled = false;
 				this.skCase = skCase;
 				this.password = password;
-				
+				this.passwords = null;
+			}
+
+			/**
+			 * Constructs an object that encapsulates a multi-step process to
+			 * add an image to the case database, trying each of the given
+			 * candidate passwords when opening encrypted file systems.
+			 *
+			 * @param timeZone         The time zone of the image.
+			 * @param addUnallocSpace  Pass true to create virtual files for
+			 *                         unallocated space.
+			 * @param skipFatFsOrphans Pass true to skip processing of orphan
+			 *                         files for FAT file systems.
+			 * @param imageWriterPath  Path that a copy of the image should be
+			 *                         written to. Use empty string to disable
+			 *                         image writing
+			 * @param passwords        The candidate passwords for decrypting
+			 *                         the image (may be null or empty).
+			 * @param skCase           The Sleuth Kit case.
+			 */
+			private AddImageProcess(String timeZone, boolean addUnallocSpace, boolean skipFatFsOrphans, String imageWriterPath, List<String> passwords, SleuthkitCase skCase) {
+				this.timeZone = timeZone;
+				this.addUnallocSpace = addUnallocSpace;
+				this.skipFatFsOrphans = skipFatFsOrphans;
+				this.imageWriterPath = imageWriterPath;
+				tskAutoDbPointer = 0;
+				this.isCanceled = false;
+				this.skCase = skCase;
+				this.password = null;
+				this.passwords = passwords;
 			}
 
 			/**
@@ -544,7 +598,12 @@ public class SleuthkitJNI {
 			 *                          the process)
 			 */
 			public void run(String deviceId, String[] imageFilePaths, int sectorSize) throws TskCoreException, TskDataException {
-				Image img = addImageToDatabase(skCase, imageFilePaths, sectorSize, "", "", "", "", deviceId, password, null);
+				Image img;
+				if (passwords != null) {
+					img = addImageToDatabase(skCase, imageFilePaths, sectorSize, "", "", "", "", deviceId, passwords, null);
+				} else {
+					img = addImageToDatabase(skCase, imageFilePaths, sectorSize, "", "", "", "", deviceId, password, null);
+				}
 				run(deviceId, img, sectorSize, new DefaultAddDataSourceCallbacks());
 			}
 			
@@ -578,7 +637,11 @@ public class SleuthkitJNI {
 						}
 						if (!isCanceled) { //with isCanceled being guarded by this it will have the same value everywhere in this synchronized block
 							imageHandle = image.getImageHandle();
-							tskAutoDbPointer = initAddImgNatPassword(dbHelper, timezoneLongToShort(timeZone), addUnallocSpace, skipFatFsOrphans, password);
+							if (passwords != null) {
+								tskAutoDbPointer = initializeAddImgCandidatesNat(dbHelper, timezoneLongToShort(timeZone), true, addUnallocSpace, skipFatFsOrphans, passwords.toArray(new String[0]));
+							} else {
+								tskAutoDbPointer = initAddImgNatPassword(dbHelper, timezoneLongToShort(timeZone), addUnallocSpace, skipFatFsOrphans, password);
+							}
 						}
 						if (0 == tskAutoDbPointer) {
 							throw new TskCoreException("initAddImgNat returned a NULL TskAutoDb pointer");
@@ -979,7 +1042,7 @@ public class SleuthkitJNI {
 	public static Image addImageToDatabase(SleuthkitCase skCase, String[] imagePaths, int sectorSize,
 		String timeZone, String md5fromSettings, String sha1fromSettings, String sha256fromSettings, String deviceId, Host host) throws TskCoreException {
 		
-		return addImageToDatabase(skCase, imagePaths, sectorSize, timeZone, md5fromSettings, sha1fromSettings, sha256fromSettings, deviceId, null, host);
+		return addImageToDatabase(skCase, imagePaths, sectorSize, timeZone, md5fromSettings, sha1fromSettings, sha256fromSettings, deviceId, (String) null, host);
 	}
 	
 	/**
@@ -1048,8 +1111,77 @@ public class SleuthkitJNI {
 			throw(ex);
 		}
 	}
-	
-	
+
+	/**
+	 * Add an image to the database and return the open image. Each of the
+	 * candidate passwords will be tried, in order, when opening encrypted
+	 * file systems in the image.
+	 *
+	 * @param skCase     The current case.
+	 * @param imagePaths The path(s) to the image (will just be the first for .e01, .001, etc).
+	 * @param sectorSize The sector size (0 for auto-detect).
+	 * @param timeZone   The time zone.
+	 * @param md5fromSettings        MD5 hash (if known).
+	 * @param sha1fromSettings       SHA1 hash (if known).
+	 * @param sha256fromSettings     SHA256 hash (if known).
+	 * @param deviceId   Device ID.
+	 * @param passwords  The candidate passwords to use to decrypt the image (may be null or empty).
+	 * @param host       Host.
+	 *
+	 * @return The Image object.
+	 *
+	 * @throws TskCoreException
+	 */
+	@Beta
+	public static Image addImageToDatabase(SleuthkitCase skCase, String[] imagePaths, int sectorSize,
+		String timeZone, String md5fromSettings, String sha1fromSettings, String sha256fromSettings, String deviceId, List<String> passwords, Host host) throws TskCoreException {
+
+		// Open the image
+		long imageHandle = openImgNat(imagePaths, 1, sectorSize);
+
+		// Get the fields stored in the native code
+		List<String> computedPaths = Arrays.asList(getPathsForImageNat(imageHandle));
+		long size = getSizeForImageNat(imageHandle);
+		long type = getTypeForImageNat(imageHandle);
+		long computedSectorSize = getSectorSizeForImageNat(imageHandle);
+		String md5 = md5fromSettings;
+		if (StringUtils.isEmpty(md5)) {
+			md5 = getMD5HashForImageNat(imageHandle);
+		}
+		String sha1 = sha1fromSettings;
+		if (StringUtils.isEmpty(sha1)) {
+			sha1 = getSha1HashForImageNat(imageHandle);
+		}
+		// Sleuthkit does not currently generate any SHA256 hashes. Set to empty
+		// string for consistency.
+		String sha256 = sha256fromSettings;
+		if (sha256 == null) {
+			sha256 = "";
+		}
+		String collectionDetails = getCollectionDetailsForImageNat(imageHandle);
+
+		//  Now save to database
+		CaseDbTransaction transaction = skCase.beginTransaction();
+		try {
+			Image img = skCase.addImage(TskData.TSK_IMG_TYPE_ENUM.valueOf(type), computedSectorSize,
+				size, null, computedPaths,
+				timeZone, md5, sha1, sha256,
+				deviceId, host, passwords, transaction);
+			if (!StringUtils.isEmpty(collectionDetails)) {
+				skCase.setAcquisitionDetails(img, collectionDetails);
+			}
+			transaction.commit();
+
+		    img.setImageHandle(imageHandle);
+			cacheImageHandle(skCase, computedPaths, imageHandle);
+			return img;
+		} catch (TskCoreException ex) {
+			transaction.rollback();
+			throw(ex);
+		}
+	}
+
+
 
 	/**
 	 * Get volume system Handle
@@ -2026,6 +2158,26 @@ public class SleuthkitJNI {
 		}
 		return new TestOpenImageResult(false, resultStr);
 	}
+
+	/**
+	 * Tries opening the image, trying each of the given candidate passwords
+	 * when opening encrypted volumes.
+	 *
+	 * @param imagePath  Path to the image (will just be the first for .e01, .001, etc).
+	 * @param passwords  Candidate passwords to use when trying to decrypt the volumes (may be null or empty).
+	 *
+	 * @return TestOpenImageResult that will contain whether we were able to open a file system and a user-friendly
+	 *         message. If multiple volumes could not be opened due to BitLocker errors, the message will contain
+	 *         one line per locked volume.
+	 */
+	@Beta
+	public static TestOpenImageResult testOpenImage(String imagePath, List<String> passwords) {
+		String resultStr = isImageSupportedListNat(imagePath, (passwords == null) ? null : passwords.toArray(new String[0]));
+		if (resultStr.isBlank()) {
+			return new TestOpenImageResult(true, "Image opened successfully");
+		}
+		return new TestOpenImageResult(false, resultStr);
+	}
 	
 	/** Get the version of the Sleuthkit code in number form.
 	 * Upper byte is A, next is B, and next byte is C in version A.B.C.
@@ -2232,6 +2384,8 @@ public class SleuthkitJNI {
 
 	private static native long initializeAddImgPasswordNat(TskCaseDbBridge dbHelperObj, String timezone, boolean addFileSystems, boolean addUnallocSpace, boolean skipFatFsOrphans, String password) throws TskCoreException;
 
+	private static native long initializeAddImgCandidatesNat(TskCaseDbBridge dbHelperObj, String timezone, boolean addFileSystems, boolean addUnallocSpace, boolean skipFatFsOrphans, String[] passwords) throws TskCoreException;
+
 	private static native void runOpenAndAddImgNat(long process, String deviceId, String[] imgPath, int splits, String timezone) throws TskCoreException, TskDataException;
 
 	private static native void runAddImgNat(long process, String deviceId, long a_img_info, long image_id, String timeZone, String imageWriterPath) throws TskCoreException, TskDataException;
@@ -2299,6 +2453,8 @@ public class SleuthkitJNI {
 	private static native String getCurDirNat(long process);
 
 	private static native String isImageSupportedStringNat(String imagePath, String password);
+
+	private static native String isImageSupportedListNat(String imagePath, String[] passwords);
 	
 	private static native long getSleuthkitVersionNat();
 

--- a/tsk/auto/auto.cpp
+++ b/tsk/auto/auto.cpp
@@ -541,10 +541,64 @@ TskAuto::findFilesInPool(TSK_OFF_T start, TSK_POOL_TYPE_ENUM ptype)
 
 
 /**
+ * Opens the file system at the given offset, trying each candidate password
+ * set with setCandidatePasswords(). If no candidate list was set, the single
+ * password from setFileSystemPassword() is used (empty by default), making a
+ * single attempt as before. Stops early if an attempt fails with anything
+ * other than a BitLocker error, since a different password cannot change that
+ * outcome. If all attempts fail, the last BitLocker error (which contains the
+ * recovery key identifier) is restored so it reaches the caller.
+ *
+ * @param a_start Byte offset of the file system.
+ * @param a_ftype File system type.
+ * @returns Open file system, or NULL if all attempts failed (error state will be set).
+ */
+TSK_FS_INFO *
+    TskAuto::openFsDecryptWithPasswords(TSK_OFF_T a_start, TSK_FS_TYPE_ENUM a_ftype)
+{
+    std::vector<std::string> candidates = m_candidatePasswords;
+    if (candidates.empty()) {
+        candidates.push_back(m_fileSystemPassword);
+    }
+
+    int haveBitlockerError = 0;
+    uint32_t bitlockerErrno = 0;
+    std::string bitlockerErrstr;
+
+    for (size_t i = 0; i < candidates.size(); i++) {
+        tsk_error_reset();
+        TSK_FS_INFO *fs_info = tsk_fs_open_img_decrypt(m_img_info, a_start,
+            a_ftype, candidates[i].c_str());
+        if (fs_info != NULL) {
+            tsk_error_reset();
+            return fs_info;
+        }
+
+        if (tsk_error_get_errno() == TSK_ERR_FS_BITLOCKER_ERROR) {
+            haveBitlockerError = 1;
+            bitlockerErrno = tsk_error_get_errno();
+            bitlockerErrstr = tsk_error_get_errstr();
+        }
+        else {
+            // Only a BitLocker failure can be fixed by another password
+            break;
+        }
+    }
+
+    if (haveBitlockerError
+        && tsk_error_get_errno() != TSK_ERR_FS_BITLOCKER_ERROR) {
+        tsk_error_reset();
+        tsk_error_set_errno(bitlockerErrno);
+        tsk_error_set_errstr("%s", bitlockerErrstr.c_str());
+    }
+    return NULL;
+}
+
+/**
  * Starts in a specified byte offset of the opened disk images and looks for a
  * file system. Will call processFile() on each file
  * that is found.  Same as findFilesInFs, but gives more detailed return values.
- * @param a_start Byte offset to start analyzing from. 
+ * @param a_start Byte offset to start analyzing from.
  * @param a_ftype File system type.
  * @returns Error (messages will have been registered), OK, or STOP.
  */
@@ -572,7 +626,7 @@ TSK_RETVAL_ENUM
 	}
 
     TSK_FS_INFO *fs_info;
-    if ((fs_info = tsk_fs_open_img_decrypt(m_img_info, a_start, a_ftype, m_fileSystemPassword.c_str())) == NULL) {
+    if ((fs_info = openFsDecryptWithPasswords(a_start, a_ftype)) == NULL) {
         if (isCurVsValid() == false) {
             tsk_error_set_errstr2 ("Sector offset: %" PRIdOFF, a_start/512);
             registerError();
@@ -671,7 +725,7 @@ uint8_t
 	}
 
     TSK_FS_INFO *fs_info;
-    if ((fs_info = tsk_fs_open_img_decrypt(m_img_info, a_start, a_ftype, m_fileSystemPassword.c_str())) == NULL) {
+    if ((fs_info = openFsDecryptWithPasswords(a_start, a_ftype)) == NULL) {
         if (isCurVsValid() == false) {
             tsk_error_set_errstr2 ("Sector offset: %" PRIdOFF, a_start/512);
             registerError();

--- a/tsk/auto/auto_db.cpp
+++ b/tsk/auto/auto_db.cpp
@@ -1124,7 +1124,7 @@ TSK_RETVAL_ENUM TskAutoDb::addFsInfoUnalloc(const TSK_DB_FS_INFO & dbFsInfo) {
     }
 
     //open the fs we have from database
-    TSK_FS_INFO * fsInfo = tsk_fs_open_img_decrypt(m_img_info, dbFsInfo.imgOffset, dbFsInfo.fType, getFileSystemPassword().data());
+    TSK_FS_INFO * fsInfo = openFsDecryptWithPasswords(dbFsInfo.imgOffset, dbFsInfo.fType);
     if (fsInfo == NULL) {
         tsk_error_set_errstr2("TskAutoDb::addFsInfoUnalloc: error opening fs at offset %" PRIdOFF, dbFsInfo.imgOffset);
         registerError();

--- a/tsk/auto/is_image_supported.cpp
+++ b/tsk/auto/is_image_supported.cpp
@@ -36,6 +36,7 @@ TskIsImageSupported::TskIsImageSupported()
     m_possibleEncryptionDesc[0] = '\0';
     m_unsupportedDesc[0] = '\0';
     m_bitlockerDesc[0] = '\0';
+    m_curVolOffset = 0;
 }
 
 bool TskIsImageSupported::isImageSupported()
@@ -161,6 +162,13 @@ uint8_t TskIsImageSupported::handleError()
             // %.*s limits the errstr field width so prefix + errstr fits in the buffer.
             snprintf(m_bitlockerDesc, sizeof(m_bitlockerDesc), "BitLocker status - %.*s",
                 (int)(sizeof(m_bitlockerDesc) - sizeof("BitLocker status - ")), lastError->errstr);
+
+            // Also record the failure with the volume offset so that an image
+            // with multiple locked volumes can report every one of them.
+            BitlockerFailure failure;
+            failure.offset = m_curVolOffset;
+            failure.desc = lastError->errstr;
+            m_bitlockerFailures.push_back(failure);
         }
         else if (errCode == TSK_ERR_FS_POSSIBLY_ENCRYPTED) {
             snprintf(m_possibleEncryptionDesc, sizeof(m_possibleEncryptionDesc), "%s", lastError->errstr);
@@ -204,7 +212,23 @@ std::string TskIsImageSupported::getMessageForIsImageSupportedNat() {
     // - Otherwise return the error string
 
     if (m_bitlockerError) {
-        return getSingleLineErrorMessage();
+        // With a single locked volume, keep the original message format.
+        if (m_bitlockerFailures.size() <= 1) {
+            return getSingleLineErrorMessage();
+        }
+
+        // Multiple volumes failed to open because of BitLocker. Report one
+        // per line, keeping the single-volume format and appending the volume
+        // offset so the user can tell which volume each message applies to.
+        std::stringstream ss;
+        for (size_t i = 0; i < m_bitlockerFailures.size(); i++) {
+            if (i > 0) {
+                ss << "\n";
+            }
+            ss << "BitLocker status - " << m_bitlockerFailures[i].desc
+                << " (Volume offset: " << m_bitlockerFailures[i].offset << ")";
+        }
+        return ss.str();
     }
 
     if (isImageSupported()) {
@@ -278,8 +302,12 @@ TskIsImageSupported::filterPoolVol(const TSK_POOL_VOLUME_INFO * pool_vol)
 }
 
 TSK_FILTER_ENUM
-TskIsImageSupported::filterVol(const TSK_VS_PART_INFO * /*vs_part*/)
+TskIsImageSupported::filterVol(const TSK_VS_PART_INFO * vs_part)
 {
     m_wasDataFound = true;
+    // Track the byte offset of the volume about to be processed (matches the
+    // offset used to open the file system in vsWalkCb) so that errors can be
+    // tied back to the volume they occurred in.
+    m_curVolOffset = vs_part->start * vs_part->vs->block_size;
     return TSK_FILTER_CONT;
 }

--- a/tsk/auto/tsk_auto.h
+++ b/tsk/auto/tsk_auto.h
@@ -113,6 +113,18 @@ class TskAuto {
     std::string getFileSystemPassword() const { return m_fileSystemPassword; }
 
     /**
+    * Set a list of candidate passwords that will each be tried, in order, when
+    * trying to open an encrypted file system. A non-empty list takes precedence
+    * over the single password set with setFileSystemPassword().
+    */
+    void setCandidatePasswords(const std::vector<std::string>& candidatePasswords) { m_candidatePasswords = candidatePasswords; }
+
+    /**
+     * @returns The list of candidate passwords that will be tried when opening each encrypted file system.
+     */
+    std::vector<std::string> getCandidatePasswords() const { return m_candidatePasswords; }
+
+    /**
      * TskAuto calls this method before it processes the volume system that is found in an 
      * image. You can use this to learn about the volume system before it is processed
      * and you can force TskAuto to skip this volume system. 
@@ -252,6 +264,7 @@ class TskAuto {
     TSK_VS_PART_FLAG_ENUM m_volFilterFlags;
     TSK_FS_DIR_WALK_FLAG_ENUM m_fileFilterFlags;
     std::string m_fileSystemPassword;
+    std::vector<std::string> m_candidatePasswords;
     
     std::vector<error_record> m_errors;
 
@@ -293,6 +306,9 @@ class TskAuto {
     TSK_TCHAR * m_imageWriterPath;
 
     
+    TSK_FS_INFO * openFsDecryptWithPasswords(TSK_OFF_T a_start,
+        TSK_FS_TYPE_ENUM a_ftype);
+
     TSK_RETVAL_ENUM processAttributes(TSK_FS_FILE * fs_file,
         const char *path);
 

--- a/tsk/auto/tsk_is_image_supported.h
+++ b/tsk/auto/tsk_is_image_supported.h
@@ -42,6 +42,12 @@ public:
     void printResults();
     
 private:
+    // One entry per volume that could not be opened because of a BitLocker error
+    struct BitlockerFailure {
+        TSK_OFF_T offset;   ///< Byte offset of the volume
+        std::string desc;   ///< The BitLocker error message for the volume
+    };
+
     bool m_wasDataFound;
     bool m_wasEncryptionFound;
     bool m_wasPossibleEncryptionFound;
@@ -52,4 +58,6 @@ private:
     char m_possibleEncryptionDesc[TSK_ERROR_STRING_MAX_LENGTH + 1];
     char m_unsupportedDesc[TSK_ERROR_STRING_MAX_LENGTH + 1];
     char m_bitlockerDesc[TSK_ERROR_STRING_MAX_LENGTH + 1];
+    TSK_OFF_T m_curVolOffset;
+    std::vector<BitlockerFailure> m_bitlockerFailures;
 };


### PR DESCRIPTION
# Support multiple candidate BitLocker passwords per image

## Problem

Autopsy can only pass ONE password for a whole disk image. An image with
two BitLocker partitions protected by different keys can only ever unlock one of them,
because `TskAuto` holds a single `m_fileSystemPassword` that is applied to every
partition. In addition, `TskIsImageSupported` overwrote its BitLocker error buffer on
each failure, so only the last locked volume was ever reported to the user.

## Changes

**Core (`tsk/auto`)**
- New `TskAuto::setCandidatePasswords(std::vector<std::string>)` plus a protected
  helper `openFsDecryptWithPasswords()` used by `findFilesInFsRet()`, `findFilesInFs()`,
  `TskAutoDb::addFsInfoUnalloc()` and `TskAutoDbJava::addFsInfoUnalloc()`. Each
  candidate is tried in order; the loop stops early on non-BitLocker errors (another
  password cannot fix those) and preserves the last BitLocker error (with the recovery
  key GUID) when all attempts fail. When no list is set, the single password from
  `setFileSystemPassword()` is used exactly as before.
- `TskIsImageSupported` now accumulates one entry per locked volume (byte offset +
  message). `getMessageForIsImageSupportedNat()` is byte-identical for a single locked
  volume; with several it returns one line per volume in the existing
  `BitLocker status - ...` format with `(Volume offset: N)` appended.

**Java bindings (additive only, new methods `@Beta`)**
- `SleuthkitJNI.testOpenImage(String, List<String>)` via new `isImageSupportedListNat`
  (message may be multi-line, one locked volume per line).
- `SleuthkitJNI.addImageToDatabase(..., List<String>, Host)` and
  `SleuthkitCase.makeAddImageProcess(..., List<String>)` via new
  `initializeAddImgCandidatesNat`.
- `SleuthkitCase.addImage(..., List<String>, ...)` persists the list as a JSON array
  under a new `"imagePasswords"` acquisition-settings key; when exactly one candidate
  is given the legacy `"imagePassword"` key is also written for backward compatibility.
- `FileSystem.getFileSystemHandle()` reads `"imagePasswords"` (falling back to
  `"imagePassword"`) and tries each candidate, so case re-open works for multiple
  encrypted volumes.
- Note: binary compatibility is unaffected, but source passing a bare `null`
  literal in the password position of the overloaded methods must cast to
  `(String) null` to disambiguate (four internal call sites updated accordingly).

**Bug fixes (found while in the area)**
- `openFsDecryptNat` called `ReleaseStringUTFChars` even when the password jstring was
  null (undefined behavior).
- The FS handle cache in `SleuthkitJNI` was keyed only on (image handle, offset), so a
  retry with a different password could return a stale handle; the password is now part
  of the cache key.

## Design notes

- Candidate passwords are a flat list, NOT a map keyed by recovery-key GUID:
  `getRecoveryKeyIdStr()` returns "" for volumes without a RECOVERY_PASSWORD protector,
  so GUID keying would break user-password volumes. Cost is acceptable: the expensive
  step is the 0x100000-round SHA-256 stretch per (candidate, salt), and it only runs
  for BitLocker volumes.
- No parser or FS-opener signature changes; `BitlockerParser` is already per-volume.

## Testing

- Windows x64 Release build (VS2022/v143, mbedTLS via NuGet): clean.
- Win32 Release_NoLibs build (no `HAVE_LIBMBEDTLS`): clean — the new code only uses
  unconditional APIs, so the Linux/macOS autotools path is unaffected.
- `ant dist` produces `sleuthkit-4.15.0.jar` (natives included); `case-uco` builds.
- Functional testing against an E01 image with **two BitLocker partitions using
  different recovery keys** (plus a mixed encrypted/unencrypted image and an
  unencrypted baseline): 12/12 checks pass —
  - `testOpenImage` with both keys succeeds; with one key it fails and names the
    other volume's recovery-key GUID; with no keys it returns one line per locked
    volume with both GUIDs and volume offsets.
  - Ingest via `makeAddImageProcess(List)` adds both file systems; with only one key
    it completes (no abort) with one file system and the locked volume's GUID in the
    error list.
  - Case re-open reads file content from both encrypted volumes (verifies the
    `imagePasswords` persistence + `FileSystem.getFileSystemHandle()` loop).
  - Legacy single-password CLI (`fls -k`, `icat -k`) and String APIs behave as before.

A companion Autopsy PR (multi-key UI) will follow.

Powered by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for trying multiple candidate passwords when opening encrypted file systems and images.
  * Added image ingestion and image-support checks using password lists.
  * Preserved compatibility with existing single-password workflows.
* **Bug Fixes**
  * Improved encrypted file-system handle separation for different passwords.
  * Enhanced BitLocker failure reporting with affected volume offsets.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->