### PR TITLE
Fix OOM in hfs_load_extended_attrs (OSSFuzz #471519955 / GH #3425)

### DIFF
--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -3943,6 +3943,18 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
         return 1;
     }
 
+    /* HFS+ B-tree node sizes must be a power-of-2 between 512 and 32768.
+     * An out-of-range value from a corrupt image would cause malloc() to
+     * allocate gigabytes of memory (OOM).  Reject anything above 32768. */
+    if (attrFile.nodeSize > 32768) {
+        error_detected(TSK_ERR_FS_CORRUPT,
+            "hfs_load_extended_attrs: node size %" PRIu32
+            " exceeds maximum valid HFS+ B-tree node size (32768)",
+            (uint32_t) attrFile.nodeSize);
+        close_attr_file(&attrFile);
+        return 1;
+    }
+
     // A place to hold one node worth of data
     nodeData = (uint8_t *) malloc(attrFile.nodeSize);
     if (nodeData == NULL) {

--- a/tsk/fs/hfs.c
+++ b/tsk/fs/hfs.c
@@ -3936,20 +3936,15 @@ hfs_load_extended_attrs(TSK_FS_FILE * fs_file,
         return 0;
     }
 
-    if (attrFile.nodeSize < sizeof(hfs_btree_node)) {
-        error_returned
-            ("hfs_load_extended_attrs: node size too small");
-        close_attr_file(&attrFile);
-        return 1;
-    }
-
-    /* HFS+ B-tree node sizes must be a power-of-2 between 512 and 32768.
-     * An out-of-range value from a corrupt image would cause malloc() to
-     * allocate gigabytes of memory (OOM).  Reject anything above 32768. */
-    if (attrFile.nodeSize > 32768) {
+    /* HFS+ B-tree node sizes must be a power-of-two in the range [512, 32768].
+     * An out-of-range or non-power-of-two value from a corrupt image would
+     * cause malloc() to allocate an invalid amount of memory.  Reject anything
+     * that does not satisfy the spec. */
+    if (attrFile.nodeSize < 512 || attrFile.nodeSize > 32768 ||
+            (attrFile.nodeSize & (attrFile.nodeSize - 1)) != 0) {
         error_detected(TSK_ERR_FS_CORRUPT,
             "hfs_load_extended_attrs: node size %" PRIu32
-            " exceeds maximum valid HFS+ B-tree node size (32768)",
+            " is not a valid HFS+ B-tree node size (must be a power of two between 512 and 32768)",
             (uint32_t) attrFile.nodeSize);
         close_attr_file(&attrFile);
         return 1;


### PR DESCRIPTION
hfs_load_extended_attrs calls malloc(attrFile.nodeSize) to allocate a single B-tree node buffer.  The node size is read from the Attributes file header on disk.  Only a lower bound (>= sizeof(hfs_btree_node)) was checked; a corrupt image can set nodeSize to an arbitrarily large value (up to 0xFFFFFFFF), causing malloc(4294967295) and an OOM crash.

HFS+ B-tree node sizes are required to be a power of 2 between 512 and 32768 bytes (per the HFS+ spec, section 1.4.3).  Add an upper bound check of 32768 and return an error for any larger value.

Fixes: OSSFuzz issue 471519955
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted HFS+ file systems by rejecting oversized Attributes-file B-tree nodes.
  * Reports a file-system corruption error and safely stops processing before allocating excessive memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->