### PR TITLE
Fix UBSAN undefined-shift in ntfs_uncompress_compunit (OSSFuzz #47155…

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1047,9 +1047,7 @@ ntfs_uncompress_compunit(NTFS_COMP_INFO * comp)
                         }
 
                         pheader =
-                            ((((comp->comp_buf[cl_index +
-                                            1]) << 8) & 0xFF00) |
-                            (comp->comp_buf[cl_index] & 0xFF));
+                            tsk_getu16(TSK_LIT_ENDIAN, comp->comp_buf + cl_index);
                         cl_index += 2;
 
 


### PR DESCRIPTION
…3935 / GH #3428)

comp_buf is declared as char*, so comp_buf[i] can be a negative signed value on platforms where char is signed.  Shifting a negative value left (e.g. -110 << 8) is undefined behavior under the C standard.

The phrase-token header was read as two bytes manually assembled with a left-shift.  Replacing it with tsk_getu16(TSK_LIT_ENDIAN, ...) is equivalent (NTFS compression data is little-endian), avoids the signed char intermediate, and matches the identical pattern used for sb_header a few lines earlier in the same function.

Fixes: OSSFuzz issue 471553935
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when decompressing NTFS compressed data while preserving little-endian decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->