### PR TITLE
Fix OOM in iso9660_dir_open_meta (OSSFuzz #471568853 / GH #3429)

### DIFF
--- a/tsk/fs/iso9660_dent.c
+++ b/tsk/fs/iso9660_dent.c
@@ -280,6 +280,19 @@ iso9660_dir_open_meta(TSK_FS_INFO * a_fs, TSK_FS_DIR ** a_fs_dir,
 
     /* read directory extent into memory */
     length = (size_t) fs_dir->fs_file->meta->size;
+
+    /* Sanity check: ISO9660 directories are read in their entirety.
+     * A directory claiming to be larger than the image itself (or
+     * unreasonably large relative to a real disc) indicates corrupt data.
+     * Cap at 128 MB to prevent OOM from fuzz/corrupted images. */
+    if (length == 0 || length > (128UL * 1024 * 1024)) {
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
+        tsk_error_set_errstr("iso9660_dir_open_meta: directory size %" PRIuOFF
+            " is unreasonably large", fs_dir->fs_file->meta->size);
+        return TSK_COR;
+    }
+
     if ((buf = tsk_malloc(length)) == NULL)
         return TSK_ERR;
 

--- a/tsk/fs/iso9660_dent.c
+++ b/tsk/fs/iso9660_dent.c
@@ -288,8 +288,8 @@ iso9660_dir_open_meta(TSK_FS_INFO * a_fs, TSK_FS_DIR ** a_fs_dir,
     if (length == 0 || length > (128UL * 1024 * 1024)) {
         tsk_error_reset();
         tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
-        tsk_error_set_errstr("iso9660_dir_open_meta: directory size %" PRIuOFF
-            " is unreasonably large", fs_dir->fs_file->meta->size);
+        tsk_error_set_errstr("iso9660_dir_open_meta: directory size %" PRIdOFF
+            " is invalid (must be between 1 and 128 MB)", fs_dir->fs_file->meta->size);
         return TSK_COR;
     }
 


### PR DESCRIPTION
iso9660_dir_open_meta reads the entire directory into a heap buffer using meta->size (a TSK_OFF_T from the directory record on disk) as the allocation size.  A corrupted or fuzz-generated ISO9660 image can set this field to an enormous value (e.g. 2,727,817,048 bytes), causing an OOM crash even though the actual image is much smaller.

Fix: reject directory sizes of 0 or greater than 128 MB before calling tsk_malloc().  Real ISO9660 directories are far smaller; the cap prevents allocation of multi-GB buffers while still accommodating the largest realistic directories.

Fixes: OSSFuzz issue 471568853
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid filesystem directory entries.
  * Zero-length or excessively large directory extents are now rejected safely, preventing unnecessary memory allocation or reads.
  * Valid directory contents continue to open normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->