### PR TITLE
Fix APFS btree traversal timeout from corrupt key_count (OSSFuzz #471…

### DIFF
--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -501,6 +501,15 @@ class APFSBtreeNode : public APFSObject, public APFSOmap::node_tag {
     const auto vec = [&] {
       std::vector<typename iterator::value_type> v{};
 
+      // Sanity check: key_count is read directly from the on-disk node header
+      // and can be corrupted.  A node cannot hold more entries than its total
+      // storage in bytes (minimum 1 byte per key + 1 byte per value + TOC).
+      // Iterating over a bogus key_count (e.g. 2^32-1) would spin for hours.
+      if (key_count() > _storage.size()) {
+        throw std::runtime_error(
+            "APFSBtreeNode: key_count exceeds node storage size");
+      }
+
       std::for_each(begin(), end(), [&v](const auto e) { v.push_back(e); });
 
       return v;


### PR DESCRIPTION
…605916 / GH #3432)

APFSBtreeNode::entries() iterates from begin() to end(), where end() is determined by key_count() read directly from the on-disk btree node header. A corrupt image can set key_count to a very large value (e.g. 2^32-1), causing entries() to spin iterating billions of non-existent entries and triggering a 60-second fuzzer timeout.

The iteration also recursively calls operator++() through every level of a deep btree (18+ stack frames observed), multiplying the work per entry.

Fix: in entries(), check that key_count() does not exceed _storage.size() before iterating.  A node cannot hold more entries than its total storage in bytes (minimum 2 bytes per entry plus TOC overhead), so this check reliably detects corrupt key_count values while being safe for all valid APFS btree nodes.

Fixes: OSSFuzz issue 471605916
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when reading damaged or malformed APFS data.
  * Prevented invalid entry counts from causing unsafe processing or crashes during storage inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->