### PR TITLE
Fix timeout in ntfs_proc_attrlist from oversized attr list (OSSFuzz #…

### DIFF
--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -2615,6 +2615,22 @@ ntfs_proc_attrlist(NTFS_INFO * ntfs,
     /* Clear the contents of the todo buffer */
     memset(mftToDo, 0, sizeof(mftToDo));
 
+    /* Sanity-check attribute list size before allocating.  The $ATTR_LIST
+     * stream holds a list of attribute locator entries (~26+ bytes each).
+     * Even a heavily fragmented file would never need more than a few MB.
+     * A corrupt value above 100 MB would cause OOM or a very long run-list
+     * walk (timeout). */
+    if (fs_attr_attrlist->size > (100ULL * 1024 * 1024)) {
+        tsk_error_reset();
+        tsk_error_set_errno(TSK_ERR_FS_INODE_COR);
+        tsk_error_set_errstr("ntfs_proc_attrlist: attribute list size %"
+            PRIdOFF " is unreasonably large for inode %" PRIuINUM,
+            fs_attr_attrlist->size, fs_file->meta->addr);
+        free(mft);
+        free(map);
+        return TSK_COR;
+    }
+
     /* Get a copy of the attribute list stream using the above action */
     load_file.left = load_file.total = (size_t) fs_attr_attrlist->size;
     load_file.base = load_file.cur = buf =


### PR DESCRIPTION
…471587334 / GH #3433)

ntfs_proc_attrlist reads the entire $ATTR_LIST attribute into a heap buffer, then walks every attribute locator entry to process extension MFT records.  The size of the attribute is read from on-disk metadata without an upper bound check.

A corrupt NTFS image can set the non-resident attribute's allocated/init size to a very large value (e.g. several GB), causing either:
  - OOM from tsk_malloc(), or
  - a very long walk of fake run-list entries in tsk_fs_attr_walk_nonres(), exceeding the 60-second fuzzer timeout.

Fix: reject attribute list streams larger than 100 MB.  Real $ATTR_LIST attributes for even pathologically fragmented files are at most a few MB; the 100 MB cap is generous while still preventing runaway processing.

Fixes: OSSFuzz issue 471587334
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3433