### PR TITLE
Fix APFS null iterator dereference (OSSFuzz #471593728 / GH #3430, OS…

### DIFF
--- a/tsk/fs/apfs.cpp
+++ b/tsk/fs/apfs.cpp
@@ -242,7 +242,9 @@ const std::vector<apfs_block_num> APFSSuperblock::volume_blocks() const {
   const auto root = omap().root<APFSObjectBtreeNode>();
 
   for (const auto& e : root.entries()) {
-    vec.emplace_back(e.value->paddr);
+    if (e.value != nullptr) {
+      vec.emplace_back(e.value->paddr);
+    }
   }
 
   return vec;

--- a/tsk/fs/tsk_apfs.hpp
+++ b/tsk/fs/tsk_apfs.hpp
@@ -291,6 +291,9 @@ class APFSBtreeNodeIterator {
     }
 
     // Non-Leaf nodes return the pointer
+    if (_child_it == nullptr) {
+      return nullptr;
+    }
     return _child_it->operator->();
   }
 
@@ -354,6 +357,11 @@ class APFSBtreeNodeIterator {
     // If we're leaves then we're good.
     if (_node->is_leaf()) {
       return true;
+    }
+
+    // Guard against a null child iterator (can occur with corrupt on-disk data).
+    if (_child_it == nullptr || rhs._child_it == nullptr) {
+      return (_child_it == nullptr && rhs._child_it == nullptr);
     }
 
     // Otherwise, let's compare the child iterators.


### PR DESCRIPTION
…SFuzz #471517907 / GH #3416)

Two related APFS btree iterator bugs triggered by corrupted disk images:

1. APFSBtreeNodeIterator::operator==() (tsk_apfs.hpp:360) For non-leaf nodes, the method unconditionally dereferenced *_child_it via unique_ptr::operator*().  If _child_it is null (which can occur when corrupt block data causes init_value() to be skipped or throw), this is undefined behavior (UBSAN: reference binding to null pointer). Fix: check _child_it and rhs._child_it for null before comparing.

2. APFSBtreeNodeIterator::operator->() (tsk_apfs.hpp:294) Similarly dereferenced _child_it without a null guard, returning a null pointer that callers like volume_blocks() dereferred. Fix: return nullptr explicitly when _child_it is null.

3. APFSSuperblock::volume_blocks() (apfs.cpp:245) Assumed e.value was always non-null; e.value->paddr caused SEGV (access at offset 8 from null = address 0x8). Fix: skip entries where operator->() returned null.

Fixes: OSSFuzz issue 471593728
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3430
Fixes: OSSFuzz issue 471517907
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3416