### PR TITLE
Fix UBSAN invalid-enum-value in ntfs_proc_attrseq (OSSFuzz #542853444…

### DIFF
--- a/ossfuzz/status.md
+++ b/ossfuzz/status.md
@@ -1,8 +1,0 @@
-# OSSFuzz Issue Status
-
-This file tracks the status of every OSSFuzz issue we have triaged.
-
-| OSSFuzz ID | GitHub ID | Branch | Status | Notes |
-|------------|-----------|--------|--------|-------|
-| 542909776 | 3530 | 20260817-gh3530-ossfuzz542909776-fatxxfs-name-leak | FIXED | Direct-leak: fs_name leaked on two early-return paths in fatxxfs_dent_parse_buf |
-| 542853444 | 3529 | 20260817-gh3529-ossfuzz542853444-ntfs-invalid-enum | FIXED | UBSAN invalid-enum-value: NTFS attribute type read from disk not validated; values >0x100 are invalid |

--- a/ossfuzz/status.md
+++ b/ossfuzz/status.md
@@ -1,0 +1,8 @@
+# OSSFuzz Issue Status
+
+This file tracks the status of every OSSFuzz issue we have triaged.
+
+| OSSFuzz ID | GitHub ID | Branch | Status | Notes |
+|------------|-----------|--------|--------|-------|
+| 542909776 | 3530 | 20260817-gh3530-ossfuzz542909776-fatxxfs-name-leak | FIXED | Direct-leak: fs_name leaked on two early-return paths in fatxxfs_dent_parse_buf |
+| 542853444 | 3529 | 20260817-gh3529-ossfuzz542853444-ntfs-invalid-enum | FIXED | UBSAN invalid-enum-value: NTFS attribute type read from disk not validated; values >0x100 are invalid |

--- a/tsk/fs/ntfs.c
+++ b/tsk/fs/ntfs.c
@@ -1910,6 +1910,19 @@ ntfs_proc_attrseq(NTFS_INFO * ntfs,
         id = tsk_getu16(fs->endian, attr->id);
         id_new = id;
 
+        /* Validate attribute type: NTFS types are multiples of 0x10 up to
+         * 0x100 (TSK_FS_ATTR_TYPE_NTFS_LOG). Values outside this range are
+         * not valid NTFS attribute types and cannot be stored safely in a
+         * TSK_FS_ATTR_TYPE_ENUM (UBSAN: invalid-enum-value). Skip them. */
+        if (type > 0x100) {
+            if (tsk_verbose)
+                tsk_fprintf(stderr,
+                    "ntfs_proc_attrseq: Skipping attribute with invalid type 0x%"
+                    PRIx32 " at inode %" PRIuINUM "\n", type,
+                    fs_file->meta->addr);
+            continue;
+        }
+
         /* If the map was supplied, search through it to see if this
          * entry is in there.  Use that ID instead so that we always have
          * unique IDs for each attribute -- even if it spans multiple MFT entries. */


### PR DESCRIPTION
… / GH #3529)

ntfs_proc_attrseq reads a 32-bit attribute type directly from the MFT record on disk and passes it to tsk_fs_attr_set_run / tsk_fs_attr_set_str, both of which store the value in a TSK_FS_ATTR_TYPE_ENUM field.

UBSAN caught that the value 0xE000003F is not a valid enumerator for TSK_FS_ATTR_TYPE_ENUM.  The highest defined NTFS attribute type is 0x100 (TSK_FS_ATTR_TYPE_NTFS_LOG / $Logged_Utility_Stream).  Any value above 0x100 from a disk image is either corrupted or a vendor extension not recognized by TSK.

Fix: after reading the type from disk, skip (continue) attributes whose type exceeds 0x100 rather than propagating an invalid enum value into the TSK_FS_ATTR structure.

Fixes: OSSFuzz issue 542853444
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3529