### PR TITLE
Fix fs_name leak in fatxxfs_dent_parse_buf (OSSFuzz #542909776 / GH #…

### DIFF
--- a/ossfuzz/status.md
+++ b/ossfuzz/status.md
@@ -1,7 +1,0 @@
-# OSSFuzz Issue Status
-
-This file tracks the status of every OSSFuzz issue we have triaged.
-
-| OSSFuzz ID | GitHub ID | Branch | Status | Notes |
-|------------|-----------|--------|--------|-------|
-| 542909776 | 3530 | 20260817-gh3530-ossfuzz542909776-fatxxfs-name-leak | FIXED | Direct-leak: fs_name leaked on two early-return paths in fatxxfs_dent_parse_buf |

--- a/ossfuzz/status.md
+++ b/ossfuzz/status.md
@@ -1,0 +1,7 @@
+# OSSFuzz Issue Status
+
+This file tracks the status of every OSSFuzz issue we have triaged.
+
+| OSSFuzz ID | GitHub ID | Branch | Status | Notes |
+|------------|-----------|--------|--------|-------|
+| 542909776 | 3530 | 20260817-gh3530-ossfuzz542909776-fatxxfs-name-leak | FIXED | Direct-leak: fs_name leaked on two early-return paths in fatxxfs_dent_parse_buf |

--- a/tsk/fs/fatxxfs_dent.c
+++ b/tsk/fs/fatxxfs_dent.c
@@ -377,6 +377,7 @@ fatxxfs_dent_parse_buf(FATFS_INFO *fatfs, TSK_FS_DIR *a_fs_dir, char *buf,
                             TSK_FS_DIR_WALK_FLAG_RECURSE),
                             fatfs_find_parent_act,
                             (void *) &a_fs_dir->fs_file->meta->addr, recursion_depth)) {
+                                tsk_fs_name_free(fs_name);
                                 return TSK_OK;
                         }
 
@@ -401,8 +402,10 @@ fatxxfs_dent_parse_buf(FATFS_INFO *fatfs, TSK_FS_DIR *a_fs_dir, char *buf,
                 * info for '..' entries */
                 if (fs_name->type == TSK_FS_NAME_TYPE_DIR) {
                     if (fatfs_dir_buf_add(fatfs,
-                        a_fs_dir->fs_file->meta->addr, fs_name->meta_addr))
+                        a_fs_dir->fs_file->meta->addr, fs_name->meta_addr)) {
+                        tsk_fs_name_free(fs_name);
                         return TSK_ERR;
+                    }
                 }
             }
 


### PR DESCRIPTION
…3530)

fatxxfs_dent_parse_buf allocates an fs_name object at function entry but two early-return paths did not free it before returning:

1. Line 380: when tsk_fs_dir_walk_internal fails while searching for a parent directory, the function returned TSK_OK without freeing fs_name.

2. Line 405: when fatfs_dir_buf_add fails, the function returned TSK_ERR without freeing fs_name.

Both paths now call tsk_fs_name_free(fs_name) before returning. The existing path at line 429 (normal exit) was already correct.

Fixes: OSSFuzz issue 542909776
Fixes: https://github.com/sleuthkit/sleuthkit/issues/3530