### PR TITLE
Replace putenv() with setenv() to prevent crash

### DIFF
--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -868,7 +868,22 @@ Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgPasswordNat(JNIEnv * e
             return 0;
         }
 
-        if (0 != setenv("TZ", tzstr, 1)) {
+        TSK_TCHAR timezone[65];
+#ifdef TSK_WIN32
+        UTF16 *timezonePtr = (UTF16 *) timezone;
+        const UTF8 *tzstrPtr = (const UTF8 *) tzstr;
+        if (tsk_UTF8toUTF16(&tzstrPtr, &tzstrPtr[strlen(tzstr)],
+                &timezonePtr, (UTF16 *) &timezone[65], TSKlenientConversion) != TSKconversionOK) {
+            env->ReleaseStringUTFChars(timeZone, tzstr);
+            setThrowTskCoreError(env, "Error converting timezone to UTF-16");
+            return 0;
+        }
+        *timezonePtr = '\0';
+#else
+        snprintf(timezone, sizeof(timezone), "%s", tzstr);
+#endif
+
+        if (0 != TSETENV(_TSK_T("TZ"), timezone)) {
             env->ReleaseStringUTFChars(timeZone, tzstr);
 
             stringstream ss;

--- a/bindings/java/jni/dataModel_SleuthkitJNI.cpp
+++ b/bindings/java/jni/dataModel_SleuthkitJNI.cpp
@@ -868,17 +868,16 @@ Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgPasswordNat(JNIEnv * e
             return 0;
         }
 
-        char envstr[70];
-        snprintf(envstr, 70, "TZ=%s", tzstr);
-        env->ReleaseStringUTFChars(timeZone, tzstr);
+        if (0 != setenv("TZ", tzstr, 1)) {
+            env->ReleaseStringUTFChars(timeZone, tzstr);
 
-        if (0 != putenv(envstr)) {
             stringstream ss;
-            ss << "Error setting timezone environment, using: ";
-            ss << envstr;
+            ss << "Error setting timezone environment";
             setThrowTskCoreError(env, ss.str().c_str());
             return 0;
         }
+
+        env->ReleaseStringUTFChars(timeZone, tzstr);
 
         /* we should be checking this somehow */
         TZSET();

--- a/tools/autotools/tsk_gettimes.cpp
+++ b/tools/autotools/tsk_gettimes.cpp
@@ -226,9 +226,7 @@ main(int argc, char **argv1)
                 
         case 'z':
             {
-                TSK_TCHAR envstr[32];
-                TSNPRINTF(envstr, 32, _TSK_T("TZ=%s"), OPTARG);
-                if (0 != TPUTENV(envstr)) {
+                if (0 != TSETENV(_TSK_T("TZ"), OPTARG)) {
                     tsk_fprintf(stderr, "error setting environment");
                     exit(1);
                 }

--- a/tools/autotools/tsk_loaddb.cpp
+++ b/tools/autotools/tsk_loaddb.cpp
@@ -126,9 +126,7 @@ main(int argc, char **argv1)
             exit(0);
 
         case _TSK_T('z'):
-            TSK_TCHAR envstr[32];
-            TSNPRINTF(envstr, 32, _TSK_T("TZ=%s"), OPTARG);
-            if (0 != TPUTENV(envstr)) {
+            if (0 != TSETENV(_TSK_T("TZ"), OPTARG)) {
                 tsk_fprintf(stderr, "error setting environment");
                 exit(1);
             }

--- a/tools/fstools/fls.cpp
+++ b/tools/fstools/fls.cpp
@@ -237,9 +237,7 @@ main(int argc, char **argv1)
             exit(0);
         case 'z':
             {
-                TSK_TCHAR envstr[32];
-                TSNPRINTF(envstr, 32, _TSK_T("TZ=%s"), OPTARG);
-                if (0 != TPUTENV(envstr)) {
+                if (0 != TSETENV(_TSK_T("TZ"), OPTARG)) {
                     tsk_fprintf(stderr, "error setting environment");
                     exit(1);
                 }

--- a/tools/fstools/ifind.cpp
+++ b/tools/fstools/ifind.cpp
@@ -224,9 +224,7 @@ main(int argc, char **argv1)
             exit(0);
         case 'z':
             {
-                TSK_TCHAR envstr[32];
-                TSNPRINTF(envstr, 32, _TSK_T("TZ=%s"), OPTARG);
-                if (0 != TPUTENV(envstr)) {
+                if (0 != TSETENV(_TSK_T("TZ"), OPTARG)) {
                     tsk_fprintf(stderr, "error setting environment");
                     exit(1);
                 }

--- a/tools/fstools/istat.cpp
+++ b/tools/fstools/istat.cpp
@@ -199,9 +199,7 @@ main(int argc, char **argv1)
             exit(0);
         case _TSK_T('z'):
             {
-                TSK_TCHAR envstr[32];
-                TSNPRINTF(envstr, 32, _TSK_T("TZ=%s"), OPTARG);
-                if (0 != TPUTENV(envstr)) {
+                if (0 != TSETENV(_TSK_T("TZ"), OPTARG)) {
                     tsk_fprintf(stderr, "error setting environment");
                     exit(1);
                 }

--- a/tsk/base/tsk_os.h
+++ b/tsk/base/tsk_os.h
@@ -149,7 +149,7 @@ typedef WCHAR TSK_TCHAR;        ///< Character data type that is UTF-16 (wchar_t
 #define TATOI	_wtoi
 #define TFPRINTF fwprintf
 #define TSNPRINTF _snwprintf
-#define TPUTENV	_wputenv
+#define TSETENV(name, value) _wputenv_s(name, value)
 #define TZSET	_tzset
 #define TZNAME _tzname
 #if defined(_MSC_VER)
@@ -200,7 +200,7 @@ typedef char TSK_TCHAR;         ///< Character data type that is UTF-16 (wchar_t
 #define TATOI	atoi
 #define TFPRINTF fprintf
 #define TSNPRINTF snprintf
-#define TPUTENV	putenv
+#define TSETENV(name, value) setenv(name, value, 1)
 #define TZSET	tzset
 #define TZNAME	tzname
 


### PR DESCRIPTION
This PR replaces the use of `putenv()` with `setenv()` when setting the `TZ` environment variable in `SleuthkitJNI_initializeAddImgPasswordNat()`.

The previous implementation constructed a `TZ=...` string in a local stack buffer and passed that buffer to `putenv()`. On POSIX systems, `putenv()` may retain the supplied pointer rather than copying the string. Once the JNI function returned, the process environment could therefore contain a pointer to invalid stack memory.

This caused reproducible crashes on macOS when adding a disk image through Autopsy. The eventual crash occurred when unrelated macOS frameworks subsequently accessed the process environment:

```text
SIGSEGV
libsystem_c.dylib`__findenv_locked
```

Using LLDB showed the environment mutation originated here:

```text
libsystem_c.dylib`putenv
libtsk_jni.dylib`Java_org_sleuthkit_datamodel_SleuthkitJNI_initializeAddImgPasswordNat
dataModel_SleuthkitJNI.cpp
```

with the argument, for example:

```text
TZ=AED-10AES
```

The previous code effectively did:

```cpp
char envstr[70];
snprintf(envstr, 70, "TZ=%s", tzstr);
putenv(envstr);
```

`envstr` has automatic storage duration. Because `putenv()` is permitted to use the supplied string directly as part of the process environment, the environment may retain a pointer to `envstr` after it is no longer valid.

A later call to `getenv()`, `localtime_r()`, LaunchServices, AppKit, or another library can then dereference the stale environment entry and crash.

This PR fixes the issue by using `setenv()` instead:

```cpp
setenv("TZ", tzstr, 1);
```

`setenv()` copies the variable name and value into the environment, so the lifetime of the JNI string or local stack storage is no longer relevant.

The JNI UTF string is released after the `setenv()` call.

## Testing

Tested with:

- Sleuth Kit 4.15.0
- Autopsy 4.23.1
- macOS 26.6.2
- Apple Silicon (`arm64`)
- OpenJDK/Liberica 23

Before the change, adding a disk image reliably resulted in a native crash in `__findenv_locked`.

After rebuilding `libtsk_jni` with this change, the disk image can be added successfully without the environment corruption/crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone configuration for more reliable date and time handling across platforms.
  * Ensured timezone resources are properly released, including when setup fails.
  * Simplified error reporting by removing sensitive timezone details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->