### PR TITLE
Add Apple Silicon build to Sleuth Kit JNI library

### DIFF
--- a/bindings/java/build-unix.xml
+++ b/bindings/java/build-unix.xml
@@ -26,11 +26,64 @@
 
 	<target name="check-native-build" depends="check-native-build-mac,check-native-build-unix"/>
 
-	<target name="check-native-build-mac" depends="testTSKLibs" if="tsk_dylib.present">
-		<condition property="native-up-to-date">
+	<target name="detect-mac-architectures" depends="testTSKLibs" if="tsk_dylib.present">
+		<exec executable="/usr/bin/lipo" outputproperty="mac.architectures" failonerror="true">
+			<arg file="${jni.build.dir}/.libs/libtsk_jni.dylib"/>
+			<arg value="-archs"/>
+		</exec>
+		<condition property="mac.arm64.present">
+			<matches string="${mac.architectures}" pattern="(^| )arm64( |$)"/>
+		</condition>
+		<condition property="mac.x86_64.present">
+			<matches string="${mac.architectures}" pattern="(^| )x86_64( |$)"/>
+		</condition>
+		<condition property="mac.arm64.missing">
+			<not><isset property="mac.arm64.present"/></not>
+		</condition>
+		<condition property="mac.x86_64.missing">
+			<not><isset property="mac.x86_64.present"/></not>
+		</condition>
+		<fail message="The JNI library contains neither an arm64 nor an x86_64 Mach-O slice.">
+			<condition>
+				<and>
+					<isset property="mac.arm64.missing"/>
+					<isset property="mac.x86_64.missing"/>
+				</and>
+			</condition>
+		</fail>
+	</target>
+
+	<target name="check-native-build-mac-arm64" depends="detect-mac-architectures" if="mac.arm64.present">
+		<uptodate property="mac.arm64.up-to-date" srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${aarch64}/mac/libtsk_jni.jnilib"/>
+	</target>
+	<target name="check-native-build-mac-arm64-missing" depends="detect-mac-architectures" if="mac.arm64.missing">
+		<condition property="mac.arm64.up-to-date">
+			<not><available file="${aarch64}/mac/libtsk_jni.jnilib"/></not>
+		</condition>
+	</target>
+
+	<target name="check-native-build-mac-x86_64" depends="detect-mac-architectures" if="mac.x86_64.present">
+		<condition property="mac.x86_64.up-to-date">
 			<and>
 				<uptodate srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${amd64}/mac/libtsk_jni.jnilib"/>
-				<uptodate srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${aarch64}/mac/libtsk_jni.jnilib"/>
+				<uptodate srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${x86_64}/mac/libtsk_jni.jnilib"/>
+			</and>
+		</condition>
+	</target>
+	<target name="check-native-build-mac-x86_64-missing" depends="detect-mac-architectures" if="mac.x86_64.missing">
+		<condition property="mac.x86_64.up-to-date">
+			<and>
+				<not><available file="${amd64}/mac/libtsk_jni.jnilib"/></not>
+				<not><available file="${x86_64}/mac/libtsk_jni.jnilib"/></not>
+			</and>
+		</condition>
+	</target>
+
+	<target name="check-native-build-mac" depends="detect-mac-architectures,check-native-build-mac-arm64,check-native-build-mac-arm64-missing,check-native-build-mac-x86_64,check-native-build-mac-x86_64-missing" if="tsk_dylib.present">
+		<condition property="native-up-to-date">
+			<and>
+				<isset property="mac.arm64.up-to-date"/>
+				<isset property="mac.x86_64.up-to-date"/>
 			</and>
 		</condition>
 	</target>
@@ -67,17 +120,29 @@
 		<copy file="${jni.build.dir}/.libs/libtsk_jni.dylib" tofile="./libtsk_jni.jnilib" overwrite="true"/>
 	</target>
 
-	<target name="copyMacLibs" depends="testTSKLibs" if="tsk_dylib.present">
-		<property environment="env"/>
+	<target name="removeMacArm64Lib" depends="detect-mac-architectures" if="mac.arm64.missing">
+		<delete file="${aarch64}/mac/libtsk_jni.jnilib"/>
+	</target>
+
+	<target name="removeMacX86_64Libs" depends="detect-mac-architectures" if="mac.x86_64.missing">
+		<delete file="${x86_64}/mac/libtsk_jni.jnilib"/>
+		<delete file="${amd64}/mac/libtsk_jni.jnilib"/>
+	</target>
+
+	<target name="copyMacArm64Lib" depends="detect-mac-architectures" if="mac.arm64.present">
 		<property name="jni.dylib" location="${jni.build.dir}/.libs/libtsk_jni.dylib"/>
 		<property name="jni.jnilib" value="libtsk_jni.jnilib"/>
-		<!-- x86_64 -->
-		<copy file="${jni.dylib}" tofile="${x86_64}/mac/${jni.jnilib}" overwrite="true"/>
-		<!-- amd64 -->
-		<copy file="${jni.dylib}" tofile="${amd64}/mac/${jni.jnilib}" overwrite="true"/>
-		<!-- aarch64 -->
 		<copy file="${jni.dylib}" tofile="${aarch64}/mac/${jni.jnilib}" overwrite="true"/>
 	</target>
+
+	<target name="copyMacX86_64Libs" depends="detect-mac-architectures" if="mac.x86_64.present">
+		<property name="jni.dylib" location="${jni.build.dir}/.libs/libtsk_jni.dylib"/>
+		<property name="jni.jnilib" value="libtsk_jni.jnilib"/>
+		<copy file="${jni.dylib}" tofile="${x86_64}/mac/${jni.jnilib}" overwrite="true"/>
+		<copy file="${jni.dylib}" tofile="${amd64}/mac/${jni.jnilib}" overwrite="true"/>
+	</target>
+
+	<target name="copyMacLibs" depends="removeMacArm64Lib,removeMacX86_64Libs,copyMacArm64Lib,copyMacX86_64Libs"/>
 
 	<!-- Non-OS X -->
 	<target name="copyTskLibs_so" depends="testTSKLibs" if="tsk_so.present">

--- a/bindings/java/build-unix.xml
+++ b/bindings/java/build-unix.xml
@@ -27,7 +27,12 @@
 	<target name="check-native-build" depends="check-native-build-mac,check-native-build-unix"/>
 
 	<target name="check-native-build-mac" depends="testTSKLibs" if="tsk_dylib.present">
-		<uptodate property="native-up-to-date" srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${amd64}/mac/libtsk_jni.jnilib"/>
+		<condition property="native-up-to-date">
+			<and>
+				<uptodate srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${amd64}/mac/libtsk_jni.jnilib"/>
+				<uptodate srcfile="${jni.build.dir}/.libs/libtsk_jni.dylib" targetfile="${aarch64}/mac/libtsk_jni.jnilib"/>
+			</and>
+		</condition>
 	</target>
 
 	<target name="check-native-build-unix" depends="testTSKLibs" if="tsk_so.present">
@@ -70,6 +75,8 @@
 		<copy file="${jni.dylib}" tofile="${x86_64}/mac/${jni.jnilib}" overwrite="true"/>
 		<!-- amd64 -->
 		<copy file="${jni.dylib}" tofile="${amd64}/mac/${jni.jnilib}" overwrite="true"/>
+		<!-- aarch64 -->
+		<copy file="${jni.dylib}" tofile="${aarch64}/mac/${jni.jnilib}" overwrite="true"/>
 	</target>
 
 	<!-- Non-OS X -->

--- a/bindings/java/build.xml
+++ b/bindings/java/build.xml
@@ -30,6 +30,7 @@
 	<property name="amd64" location="${build}/NATIVELIBS/amd64"/>
 	<property name="x86" location="${build}/NATIVELIBS/x86"/>
 	<property name="x86_64" location="${build}/NATIVELIBS/x86_64"/>
+	<property name="aarch64" location="${build}/NATIVELIBS/aarch64"/>
 	<property name="i386" location="${build}/NATIVELIBS/i386"/>
 	<property name="i586" location="${build}/NATIVELIBS/i586"/>
 	<property name="i686" location="${build}/NATIVELIBS/i686"/>
@@ -54,6 +55,8 @@
 		<mkdir dir="${x86_64}/win"/>
 		<mkdir dir="${x86_64}/mac"/>
 		<mkdir dir="${x86_64}/linux"/>
+		<mkdir dir="${aarch64}"/>
+		<mkdir dir="${aarch64}/mac"/>
 		<mkdir dir="${i386}"/>
 		<mkdir dir="${i386}/win"/>
 		<mkdir dir="${i386}/linux"/>


### PR DESCRIPTION
Add Apple Silicon support to the Sleuth Kit Java build by packaging the macOS JNI library under the `aarch64` architecture path.

On Apple Silicon, Java reports:

```text
os.arch=aarch64
```

`LibraryUtils` consequently searches for:

```text
NATIVELIBS/aarch64/mac/libtsk_jni.jnilib
```

The build previously packaged the macOS JNI library only under `amd64` and `x86_64`, causing `LibraryUtils.loadSleuthkitJNI()` to report that `libtsk_jni` could not be found.

## Changes

- Add the `NATIVELIBS/aarch64/mac` build directory.
- Copy the macOS JNI library into the aarch64 and/or amd64 path depending on the architectures present in the binary.

## Testing

Tested on Apple Silicon macOS with an ARM64 JDK:

- `ant dist` completed successfully.
- The generated JAR contains:

  ```text
  NATIVELIBS/aarch64/mac/libtsk_jni.jnilib
  ```

- The AArch64 entry was verified as an ARM64 Mach-O library.
- `LibraryUtils.loadSleuthkitJNI()` returned `true` with `os.arch=aarch64`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS native library builds to detect and validate available amd64 and aarch64 architecture slices.
  * Ensured architecture-specific libraries are copied to the correct destinations, including amd64 compatibility output.
  * Prevented stale libraries from remaining when an architecture is unavailable.

* **Build Improvements**
  * Added build configuration and directory support for aarch64 native libraries and macOS outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->